### PR TITLE
This commit makes the Dockerfile smaller in size.

### DIFF
--- a/terra-jupyter-r/Dockerfile
+++ b/terra-jupyter-r/Dockerfile
@@ -9,35 +9,39 @@ RUN apt-get update \
     && apt update \
 #     && apt-get -y build-dep libcurl4-gnutls-dev \
     && apt install -yq --no-install-recommends \
-        apt-utils \
-        curl \
-        libssh2-1-dev \
-        libssl-dev \
-        libcurl4-gnutls-dev \
-        libgit2-dev \
-        libxml2-dev \
-        # libcurl4-gnutls-dev \
-        r-base \
-        r-base-dev \
-        r-base-core \
-        r-recommended
+	apt-utils \
+	curl \
+	libssh2-1-dev \
+	libssl-dev \
+	libcurl4-gnutls-dev \
+	libgit2-dev \
+	libxml2-dev \
+	# libcurl4-gnutls-dev \
+	r-base \
+	r-base-dev \
+	r-base-core \
+	r-recommended \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN R -e 'install.packages(c( \
+    "remotes", \
+    "BiocManager"))' \
+ && R -e 'BiocManager::install(c( \
+    # Jupyter notebook essentials 
     "IRdisplay",  \
-    "evaluate",  \
-    "pbdZMQ",  \
-    "devtools",  \
-    "uuid",  \
-    "reshape2",  \
+    "DataBiosphere/Ronaldo", \
+    "IRkernel/IRkernel", \
+    # GCP essentials 
     "bigrquery",  \
     "googleCloudStorageR", \
-    "tidyverse"), \
-    repos="http://cran.mtu.edu")' \
- && R -e 'devtools::install_github("DataBiosphere/Ronaldo")' \
- && R -e 'devtools::install_github("IRkernel/IRkernel")' \
+    # User oriented packages 
+    "tidyverse", \
+    "pbdZMQ", \
+    "uuid"))' \
  && R -e 'IRkernel::installspec(user=FALSE)' \
  && chown -R $USER:users /home/jupyter-user/.local  \
- && R -e 'devtools::install_github("apache/spark@v2.2.3", subdir="R/pkg")' \
+ && R -e 'BiocManager::install("apache/spark@v2.2.3", subdir="R/pkg")' \
  && mkdir -p /home/jupyter-user/.rpackages \
  && echo "R_LIBS=/home/jupyter-user/.rpackages" > /home/jupyter-user/.Renviron \
  && chown -R $USER:users /home/jupyter-user/.rpackages


### PR DESCRIPTION
Hi @Qi77Qi 

A few points,

1. The image can be made smaller if the apt cache is cleaned.

```
+	&& apt-get clean \
+	&& rm -rf /var/lib/apt/lists/*
```

Testing on my local machine shows a 200MB decrease in size, ( tag name v2 is the updated one.)

```
terra-jupyter-r                                             base2               0902cb75ca17        21 minutes ago      2.92GB
terra-jupyter-r                                             base                6ecb0f95ccaf        20 hours ago        3.13GB
```

2.  `tidyverse` has many dependencies which are not needed like `read
    excel spreadsheets` for example. What are the criteria for choosing
    the R packages?

```
> db = available.packages(repos = BiocManager::repositories())
> sort(tools::package_dependencies(db = db, packages = "tidyverse", recursive=TRUE)[[1]])
 [1] "askpass"      "assertthat"   "backports"    "base64enc"    "BH"
 [6] "broom"        "callr"        "cellranger"   "cli"          "clipr"
[11] "colorspace"   "crayon"       "curl"         "DBI"          "dbplyr"
[16] "digest"       "dplyr"        "ellipsis"     "evaluate"     "fansi"
[21] "forcats"      "fs"           "generics"     "ggplot2"      "glue"
[26] "graphics"     "grDevices"    "grid"         "gtable"       "haven"
[31] "highr"        "hms"          "htmltools"    "httr"         "jsonlite"
[36] "knitr"        "labeling"     "lattice"      "lazyeval"     "lubridate"
[41] "magrittr"     "markdown"     "MASS"         "Matrix"       "methods"
[46] "mgcv"         "mime"         "modelr"       "munsell"      "nlme"
[51] "openssl"      "pillar"       "pkgconfig"    "plogr"        "plyr"
[56] "prettyunits"  "processx"     "progress"     "ps"           "purrr"
[61] "R6"           "RColorBrewer" "Rcpp"         "readr"        "readxl"
[66] "rematch"      "reprex"       "reshape2"     "rlang"        "rmarkdown"
[71] "rstudioapi"   "rvest"        "scales"       "selectr"      "splines"
[76] "stats"        "stringi"      "stringr"      "sys"          "tibble"
[81] "tidyr"        "tidyselect"   "tinytex"      "tools"        "utf8"
[86] "utils"        "vctrs"        "viridisLite"  "whisker"      "withr"
[91] "xfun"         "xml2"         "yaml"         "zeallot"
```

3. The package 'BiocManager' should be included in the list of
   packages.

The pull request addresses some of these,

1. The package installation is delegated to `BiocManager()`.

2. Pacakges `evaluate` and `reshape2` are already in the `tidyverse` so they don't need to be explicitly installed again.

3. I organized the R packages so that they are grouped based on function.