### PR TITLE
Remove cache tjp

### DIFF
--- a/terra-jupyter-python/Dockerfile
+++ b/terra-jupyter-python/Dockerfile
@@ -16,7 +16,9 @@ RUN apt-get update &&  apt-get upgrade -y && \
   make \
   liblzo2-dev \
   zlib1g-dev \ 
-  libz-dev 
+  libz-dev \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
 
 RUN pip3 -V \
  && pip3 install --upgrade pip \


### PR DESCRIPTION
Remove apt cache to reduce size of image.

The removal of cache reduces the image size by 240MB.

```
terra-jupyter-python:v2     5GB
terra-jupyter-python:v1     5.24GB
```

where, v1 is the original docker image, and v2 includes the removal of
the cache.