### PR TITLE
[IA-1417] Jc update jenkinsfile

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,7 +3,7 @@
 # Example: ./build.sh terra-jupyter-base
 set -e -x
 
-PYTHON_IMAGES="terra-jupyter-hail terra-jupyter-python terra-jupyter-base terra-jupyter-bioconductor terra-jupyter-gatk"
+PYTHON_IMAGES="terra-jupyter-hail terra-jupyter-python terra-jupyter-base terra-jupyter-bioconductor"
 R_IMAGES="terra-jupyter-r terra-jupyter-bioconductor terra-jupyter-gatk"
 
 IMAGE_DIR=$1

--- a/build.sh
+++ b/build.sh
@@ -13,10 +13,10 @@ TAG_NAME=$(git log --pretty=format:'%h' -n 1)
 REPO="us.gcr.io/broad-dsp-gcr-public"
 DOCUMENTATION_BUCKET="gs://terra-docker-image-documentation"
 
-IMAGE_EXISTS=$(gcloud container images list-tags $REPO/$IMAGE_DIR | grep $VERSION)
+#for some reason, this command fails if the script is in strict mode because grep not finding something exits with 1
+IMAGE_EXISTS=$(gcloud container images list-tags $REPO/$IMAGE_DIR | grep $VERSION) | true
 
-if [ -z "$IMAGE_EXISTS" ]
-then
+if [ -z "$IMAGE_EXISTS" ]; then
     echo "An image for this version does not exist. Proceeding with build"
 else
     echo "An image for the version you are trying to build already exists. Ensure you have updated the VERSION file."

--- a/hub/Dockerfile
+++ b/hub/Dockerfile
@@ -1,0 +1,24 @@
+FROM ubuntu:14.04
+
+RUN apt-get -y update 
+
+RUN apt-get -y install software-properties-common
+
+RUN add-apt-repository -y ppa:cpick/hub
+
+RUN apt-get -y update
+
+RUN apt-get -y install hub
+
+RUN git config --system core.logallrefupdates false
+
+RUN mkdir -p /app/leo
+WORKDIR /app/leo
+
+RUN useradd -m dsde-jenkins
+USER dsde-jenkins
+
+RUN mkdir /home/dsde-jenkins/.config
+
+CMD ["/bin/bash"]
+

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -1,3 +1,10 @@
+//Builds the images in the terra-docker repo.
+
+// Currently, this is referenced in a jenkins job with the following configuration:
+// Create a 'New Item' that is a Pipeline in Jenkins
+// Specify Pipeline script from SCM with the scm for terra-docker and the appropriate branch
+// Script Path should be the location of this file relative to the repo root
+
 import hudson.model.*
 import hudson.FilePath
 import jenkins.model.Jenkins

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -34,7 +34,7 @@ def ArrayList<String> getChangedImages() {
 def Boolean hasImageChanged(dir) {
   def String output = sh (
     //TODO revert
-        script: "git diff HEAD..HEAD~40 $dir",
+        script: "git diff HEAD..HEAD~10 $dir",
         returnStdout: true
   ).trim()
 

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -5,8 +5,12 @@ import jenkins.model.Jenkins
 //branch name we will create in leo. Will be appended with the build number.
 def branchName = "automated-leonardo-hash-update-"
 
+def prBody = "Automated terra-docker image hash update [jenkins-generated-message]"
+
 //used to exit early if no changes are detected
 def shouldAbortBuild = false
+
+def prLink = ""
 
 //declared in outer scope so it persists between steps
 //omitting the 'def' is what makes it global
@@ -29,7 +33,8 @@ def ArrayList<String> getChangedImages() {
 
 def Boolean hasImageChanged(dir) {
   def String output = sh (
-        script: "git diff HEAD..HEAD~1 $dir",
+    //TODO revert
+        script: "git diff HEAD..HEAD~40 $dir",
         returnStdout: true
   ).trim()
 
@@ -142,7 +147,6 @@ def FilePath createFilePath(String path) {
 def abortBuild() {
   currentBuild.setResult('ABORTED')
   currentBuild.setDescription("No image changes detected. Aborting the build.")
-  shouldAbortBuild = true
   sh "exit 0"
 }
 
@@ -189,9 +193,11 @@ pipeline {
 
           if (changedImageDirs.isEmpty()) {
             abortBuild()
+            shouldAbortBuild = true
           }
-
-          buildAll(changedImageDirs)
+          
+          //TODO REVERT
+          // buildAll(changedImageDirs)
           //this is maintained as state between stages
           versionMap = getVersionMap(changedImageDirs)
         }
@@ -213,10 +219,6 @@ pipeline {
       when { expression { !shouldAbortBuild } }
 
       steps {
-        sh """
-          git submodule init && git submodule update
-        """
-
         script {
           //even thought versionMap is global, we must pass it to the function here for some reason
           updateConfigHashes(versionMap)
@@ -228,17 +230,51 @@ pipeline {
 
           //needed, because if a VERSION is not updated for all imageDirs with changes, the below git actions will cause the build to fail
           if (changesMade.isEmpty()) {
-            abortBuild() 
+            abortBuild()
+            shouldAbortBuild = true 
           }
         }
 
         sshagent(['jenkins-ssh-github']) {
           sh """
+            git config --global user.name "Jenkins Role account"
+            git config --global user.email jenkins@dsp-fc-jenkins-slave-prod210.c.broad-dsp-techops.internal
+
             git checkout -b $branchName${BUILD_NUMBER}
             git commit -m "automated config hash updates"
             git push origin $branchName${BUILD_NUMBER}
           """
         }
+         
+      }
+    }
+
+    stage('Create PR') {
+       when { expression { !shouldAbortBuild } }
+
+      steps {
+         withCredentials([file(credentialsId: 'hub-token', variable: 'token')]) {
+          sh """
+            docker pull us.gcr.io/broad-dsp-gcr-public/hub:1
+            docker rm -f hub-runtime | true
+
+            docker run -itd --name=hub-runtime -u root -v ${WORKSPACE}:/app/leo us.gcr.io/broad-dsp-gcr-public/hub:1 
+            docker cp \$token hub-runtime:/home/dsde-jenkins/.config/hub
+            docker exec hub-runtime sudo chmod 777 /home/dsde-jenkins/.config/hub
+          """
+        }
+
+        script {
+             prLink = sh(
+              script: "docker exec --user dsde-jenkins hub-runtime hub pull-request -m \"$prBody\"",
+              returnStdout: true
+            ).trim()
+        }
+
+        sh """
+          docker stop hub-runtime
+          docker rm -f hub-runtime | true
+        """
       }
     }
 
@@ -248,8 +284,9 @@ pipeline {
       when { expression { !shouldAbortBuild } }
 
       steps {
-        slackSend(channel: '#dsp-callisto-internal', message: "Jenkins has successfully created a branch with the updated terra-docker hashes.\n" + 
-         "https://github.com/DataBiosphere/leonardo/pull/new/$branchName${BUILD_NUMBER}")
+        //TODO revert dsp-callisto-internal
+        slackSend(channel: '#newrelictest', message: "Jenkins has successfully built images and created a PR with the updated terra-docker hashes.\n" + 
+         "\nIf you would like to check the status of the PR, click: $prLink")
       }
     }
      

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -25,32 +25,10 @@ def prLink = ""
 //omitting the 'def' is what makes it global
 LinkedHashMap<String, String> versionMap = [:]
 
-  //the thing sorted is assumed to be a set here
-
-
-//we must sort using this unconventional approach until this issue is resolved: https://issues.jenkins-ci.org/browse/JENKINS-44924
-def LinkedHashSet<String> getSortedSet(Collection<String> imageSet) {
-  def sortedSet = new LinkedHashSet<String>();
-  def ArrayList<String> priorityOrder = ["terra-jupyter-base", "terra-jupyter-python", "terra-jupyter-r"]
-  
-  for (String priorityImage in priorityOrder) {
-    if (imageSet.contains(priorityImage)) {
-      sortedSet.add(priorityImage)
-      imageSet.remove(priorityImage)
-    }
-  }
-
-  sortedSet.addAll(imageSet)
-
-  return sortedSet;
-}
 
 def LinkedHashSet<String> getSortedChangedImages() {
   def String[] images = readFile("jenkins/imageDirs.txt").trim().split("\n")
 
-  //Ensures the base images which may be used to build other images are built first.
-  //The order they will be sorted is terra-jupyter-base -> terra-jupyter-python -> terra-jupyter-r -> [...tail]
-  //If any of those images aren't present, the other will move up in the order
   def LinkedHashSet<String> filteredImages = new LinkedHashSet<String>();
   //we must use a c-style loop due to jenkins serialization, aka https://www.devopscat.tech/2018/10/what-is-noncps-in-jenkins-pipeline/
   for (String currImage in images) {
@@ -74,6 +52,26 @@ def Boolean hasImageChanged(String dir) {
   return !output.isEmpty()
 }
 
+//we must sort using this unconventional approach until this issue is resolved: https://issues.jenkins-ci.org/browse/JENKINS-44924
+  //Ensures the base images which may be used to build other images are built first.
+  //The order they will be sorted is terra-jupyter-base -> terra-jupyter-python -> terra-jupyter-r -> [...tail]
+  //If any of those images aren't present, the other will move up in the order
+def LinkedHashSet<String> getSortedSet(Collection<String> imageSet) {
+  def sortedSet = new LinkedHashSet<String>();
+  def ArrayList<String> priorityOrder = ["terra-jupyter-base", "terra-jupyter-python", "terra-jupyter-r"]
+  
+  for (String priorityImage in priorityOrder) {
+    if (imageSet.contains(priorityImage)) {
+      sortedSet.add(priorityImage)
+      imageSet.remove(priorityImage)
+    }
+  }
+
+  sortedSet.addAll(imageSet)
+
+  return sortedSet;
+}
+
 def void buildAll(LinkedHashSet<String> imageDirs) {
   for (String imageDir in imageDirs) {
     buildImage(imageDir)
@@ -84,7 +82,6 @@ def void buildImage(String imageDir) {
   def workingDir = pwd()
   sh "echo 'building the following image: $imageDir'"
   def exitCode = sh(
-    //; echo \"the build code was: \$?\""
     script: "$workingDir/build.sh $imageDir 2>&1",
     returnStatus: true
   )

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -168,7 +168,9 @@ pipeline {
      
     stage('Terra Docker Git') {
       steps {
-        git credentialsId: 'jenkins-ssh-github', url: 'git@github.com:DataBiosphere/terra-docker.git', branch: 'master'
+
+        //TODO revert
+        git credentialsId: 'jenkins-ssh-github', url: 'git@github.com:DataBiosphere/terra-docker.git', branch: 'jc-update-jenkinsfile'
       }
     }
 

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -5,7 +5,7 @@ import jenkins.model.Jenkins
 //branch name we will create in leo. Will be appended with the build number.
 def branchName = "automated-leonardo-hash-update-"
 
-def prBody = "Automated terra-docker image hash update [jenkins-generated-message]"
+def prBody = "[jenkins-generated-pr] Automated terra-docker image hash update"
 
 //used to exit early if no changes are detected
 def shouldAbortBuild = false

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -67,8 +67,7 @@ def LinkedHashSet<String> getSortedChangedImages() {
 
 def Boolean hasImageChanged(String dir) {
   def String output = sh (
-    //TODO revert
-        script: "git diff HEAD..HEAD~10 $dir",
+        script: "git diff HEAD..HEAD~1 $dir",
         returnStdout: true
   ).trim()
 
@@ -345,8 +344,7 @@ pipeline {
       when { expression { !shouldAbortBuild } }
 
       steps {
-        //TODO revert dsp-callisto-internal
-        slackSend(channel: '#newrelictest', message: "Jenkins has successfully built images and created a PR with the updated terra-docker hashes.\n" + 
+        slackSend(channel: '#dsp-callisto-internal', message: "Jenkins has successfully built images and created a PR with the updated terra-docker hashes.\n" + 
          "\nIf you would like to check the status of the PR, click: $prLink")
       }
     }

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -10,38 +10,65 @@ def prBody = "[jenkins-generated-pr] Automated terra-docker image hash update"
 //used to exit early if no changes are detected
 def shouldAbortBuild = false
 
+def LinkedHashSet<String> imagesToBuild = new LinkedHashSet<String>()
+
 def prLink = ""
 
 //declared in outer scope so it persists between steps
 //omitting the 'def' is what makes it global
 LinkedHashMap<String, String> versionMap = [:]
 
-def ArrayList<String> getChangedImages() {
+  //the thing sorted is assumed to be a set here
+
+
+//we must sort using this unconventional approach until this issue is resolved: https://issues.jenkins-ci.org/browse/JENKINS-44924
+def LinkedHashSet<String> getSortedSet(Collection<String> imageSet) {
+  def sortedSet = new LinkedHashSet<String>();
+  def ArrayList<String> priorityOrder = ["terra-jupyter-base", "terra-jupyter-python", "terra-jupyter-r"]
+  
+  for (String priorityImage in priorityOrder) {
+    if (imageSet.contains(priorityImage)) {
+      sortedSet.add(priorityImage)
+      imageSet.remove(priorityImage)
+    }
+  }
+
+  sortedSet.addAll(imageSet)
+
+  return sortedSet;
+}
+
+def LinkedHashSet<String> getSortedChangedImages() {
   def String[] images = readFile("jenkins/imageDirs.txt").trim().split("\n")
 
-  def filteredImages = []
+  //Ensures the base images which may be used to build other images are built first.
+  //The order they will be sorted is terra-jupyter-base -> terra-jupyter-python -> terra-jupyter-r -> [...tail]
+  //If any of those images aren't present, the other will move up in the order
+  def LinkedHashSet<String> filteredImages = new LinkedHashSet<String>();
   //we must use a c-style loop due to jenkins serialization, aka https://www.devopscat.tech/2018/10/what-is-noncps-in-jenkins-pipeline/
   for (String currImage in images) {
     if (hasImageChanged(currImage)) {
       println("detected change for $currImage")
-      filteredImages.add(currImage) 
+      filteredImages.add(currImage); 
     }
   }
 
-  return filteredImages
+  println("Filtered images: " + filteredImages.toString());
+
+  return getSortedSet(filteredImages);
 }
 
-def Boolean hasImageChanged(dir) {
+def Boolean hasImageChanged(String dir) {
   def String output = sh (
     //TODO revert
         script: "git diff HEAD..HEAD~10 $dir",
         returnStdout: true
   ).trim()
 
-  !output.isEmpty()
+  return !output.isEmpty()
 }
 
-def void buildAll(ArrayList<String> imageDirs) {
+def void buildAll(LinkedHashSet<String> imageDirs) {
   for (String imageDir in imageDirs) {
     buildImage(imageDir)
   }
@@ -51,7 +78,8 @@ def void buildImage(String imageDir) {
   def workingDir = pwd()
   sh "echo 'building the following image: $imageDir'"
   def exitCode = sh(
-    script: "$workingDir/build.sh $imageDir",
+    //; echo \"the build code was: \$?\""
+    script: "$workingDir/build.sh $imageDir 2>&1",
     returnStatus: true
   )
 
@@ -61,15 +89,18 @@ def void buildImage(String imageDir) {
   if (exitCode == 14) {
     println("The build script reported that building would result in overwritting an existing image. Setting build status to UNSTABLE. Consider updating the VERSION file for $imageDir")
     currentBuild.setResult("UNSTABLE")
-    prevDesc = currentBuild.getDescription() == null ? "" : currentBuild.getDescription() + "\n"
-    currentBuild.setDescription(prevDesc + "The build for image $imageDir failed because the image already exists.")
+    prevDesc = currentBuild.getDescription() == null ? "" : currentBuild.getDescription() + "<br/>"
+    currentBuild.setDescription(prevDesc + "The build for image $imageDir failed because the image already exists.<br/>")
   } else if (exitCode != 0) {
-    throw new RuntimeException("Unexpected error code recieved from build.sh: $exitCode")
+    println("Error detected building image $imageDir")
+    throw new RuntimeException("Unexpected error recieved from build.sh: \n\tCode: $exitCode")
+  } else {
+    println("Successfully build image $imageDir")
   }
   //we do nothing in the else case, the shell command exitted as expected
 }
 
-def LinkedHashMap<String, String> getVersionMap(imageDirs) {
+def LinkedHashMap<String, String> getVersionMap(LinkedHashSet<String> imageDirs) {
   def LinkedHashMap<String, String>  versionMap = [:]
 
   for (String currImageDir in imageDirs) {
@@ -90,11 +121,6 @@ def void updateConfigHashes(replacementMap) {
   for (String currConfig in configPaths) {
     println("Calling replaceTag function for $currConfig with $replacementMap")
     replaceTags(currConfig, replacementMap)
-
-    println("printing changes in $currConfig and running git add")
-    sh(
-      script: "git diff $currConfig; git add $currConfig"
-    )
   }
 }
 
@@ -144,10 +170,9 @@ def FilePath createFilePath(String path) {
     }
 }
 
-def abortBuild() {
+def abortBuild(reason) {
   currentBuild.setResult('ABORTED')
-  currentBuild.setDescription("No image changes detected. Aborting the build.")
-  sh "exit 0"
+  currentBuild.setDescription("$reason. Aborting the build.")
 }
 
 pipeline {
@@ -164,15 +189,44 @@ pipeline {
        pollSCM('')
   }
 
+  parameters {
+    booleanParam(name: "BUILD_SPECIFIED_IMAGES", defaultValue: false,
+          description: "Specify this, along with the images below, to force the build of specific images. Can be used in conjunction with the branch parameter for testing. Note this will fail if an image for the version in the VERSION file exists in google.")
+    string(name: "BRANCH", defaultValue: "master",
+          description: "Specify along with useCustomImageIdentifier to build the image with a specific name")
+    text(name: 'IMAGES_TO_BUILD', defaultValue: 'terra-jupyter-base\nterra-jupyter-python\nterra-jupyter-r\nterra-jupyter-gatk\nterra-jupyter-bioconductor\nterra-jupyter-hail', 
+      description: 'The is a text field for newline separate images to build. Each image should be specified via the directory it resides in. The default value is a working example.') 
+  }
+
    stages {
      
     stage('Terra Docker Git') {
       steps {
-
-        //TODO revert
-        git credentialsId: 'jenkins-ssh-github', url: 'git@github.com:DataBiosphere/terra-docker.git', branch: 'jc-update-jenkinsfile'
+        git credentialsId: 'jenkins-ssh-github', url: 'git@github.com:DataBiosphere/terra-docker.git', branch: "$BRANCH"
       }
     }
+
+    stage('Get Images') {
+      steps {
+        script {
+          if (BUILD_SPECIFIED_IMAGES.equals("false")) {
+            imagesToBuild = getSortedChangedImages()
+          } else {
+            //the cast is unecessary, but makes it explicit that this will eliminate duplicates in user-input
+            imagesToBuild = IMAGES_TO_BUILD.trim().split('\n') as LinkedHashSet
+          }
+
+          println("images that will be built: " + imagesToBuild.toString())
+
+          if (imagesToBuild.isEmpty()) {
+            abortBuild("No image changes detected")
+            shouldAbortBuild = true
+            return
+          }
+        }
+      }
+    }
+
 
     stage('Docker Auth') {
       steps {
@@ -191,17 +245,9 @@ pipeline {
     stage('Build Images') {
       steps {
         script {
-          def ArrayList<String> changedImageDirs = getChangedImages()
-
-          if (changedImageDirs.isEmpty()) {
-            abortBuild()
-            shouldAbortBuild = true
-          }
-          
-          //TODO REVERT
-          // buildAll(changedImageDirs)
+          buildAll(imagesToBuild)
           //this is maintained as state between stages
-          versionMap = getVersionMap(changedImageDirs)
+          versionMap = getVersionMap(imagesToBuild)
         }
       }
     }
@@ -230,22 +276,28 @@ pipeline {
             returnStdout: true
           )
 
+          println("Changes made: " + changesMade)
+
+          sh "git diff"
+          sh "git remote -v"
+
           //needed, because if a VERSION is not updated for all imageDirs with changes, the below git actions will cause the build to fail
           if (changesMade.isEmpty()) {
-            abortBuild()
+            abortBuild("No git changes detected")
             shouldAbortBuild = true 
+            return
           }
-        }
+        
+          sshagent(['jenkins-ssh-github']) {
+            sh """
+              git config --global user.name "Jenkins Role account"
+              git config --global user.email jenkins@dsp-fc-jenkins-slave-prod210.c.broad-dsp-techops.internal
 
-        sshagent(['jenkins-ssh-github']) {
-          sh """
-            git config --global user.name "Jenkins Role account"
-            git config --global user.email jenkins@dsp-fc-jenkins-slave-prod210.c.broad-dsp-techops.internal
-
-            git checkout -b $branchName${BUILD_NUMBER}
-            git commit -m "automated config hash updates"
-            git push origin $branchName${BUILD_NUMBER}
-          """
+              git checkout -b $branchName${BUILD_NUMBER}
+              git commit -am "automated config hash updates"
+              git push origin $branchName${BUILD_NUMBER}
+            """
+          }
         }
          
       }
@@ -268,7 +320,7 @@ pipeline {
 
         script {
              prLink = sh(
-              script: "docker exec --user dsde-jenkins hub-runtime hub pull-request -m \"$prBody\"",
+              script: "docker exec --user dsde-jenkins hub-runtime hub pull-request -b develop -m \"$prBody\"",
               returnStdout: true
             ).trim()
         }

--- a/jenkins/imageDirs.txt
+++ b/jenkins/imageDirs.txt
@@ -1,6 +1,5 @@
 terra-jupyter-base
-terra-jupyter-bioconductor
-terra-jupyter-gatk
-terra-jupyter-hail
 terra-jupyter-python
 terra-jupyter-r
+terra-jupyter-bioconductor
+terra-jupyter-gatk


### PR DESCRIPTION
- Update build script to be able to correctly source the vault token regardless of if it is run on jenkins or local (this is redundant, as the jenkins job gets the token, but I'd rather have redundant defensive code than auth errors)
- Fix issue where the job does not properly order image builds
- Job will now fail appropriately when an image fails to build
- Disable doc generation for gatk until pip is working
- Job will now create PRs
- Dockerimage for hub, the tool used to create PRs via CLI, is added
