### PR TITLE
Avoid r-recommended packages being installed in /usr/lib/R/library 

### DIFF
--- a/config/conf.json
+++ b/config/conf.json
@@ -17,7 +17,7 @@
             "base_label": "Bioconductor",
             "tools": ["python", "r"],
             "packages": { "r": ["BiocVersion", "tidyverse"] },
-            "version": "0.0.4",
+            "version": "0.0.5",
             "automated_flags": {
                 "generate_docs": true,
                 "include_in_ui": true,
@@ -69,7 +69,7 @@
             "base_label": "R",
             "tools": ["r"],
             "packages": {},
-            "version": "0.0.5",
+            "version": "0.0.6",
             "automated_flags": {
                 "include_in_ui": false,
                 "generate_docs": true,

--- a/terra-jupyter-bioconductor/CHANGELOG.md
+++ b/terra-jupyter-bioconductor/CHANGELOG.md
@@ -1,24 +1,29 @@
+## 0.0.5 - 11/22/2019
+- Install AnnotationHub, ExperimentHub, ensembldb, Rtse, scRNAseq.
+- Update `terra-jupyter-bioconductor` version to `0.0.5`
+
+`Image URL: us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:0.0.5`
+
 ## 0.0.4 - 11/16/2019
 - Update `terra-jupyter-r` version to `0.0.5`
 - Remove apt-get upgrade for security purposes
 
-`Image URL: us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:0.0.3`
+`Image URL: us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:0.0.4`
 
 ## 0.0.3 - 10/18/2019
-- Update `terra-jupyter-r` version to `0.0.4`
+- Update `terra-jupyter-r` version to `0.0.3`
 
 `Image URL: us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:0.0.3`
-
 
 ## 0.0.2 - 09/04/2019
 - Install python packages needed for BiocSklearn, Rcwl.
 - Install python3.7-dev for headers required to compile python modules.
 
-Image URL: us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:0.0.2
+`Image URL: us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:0.0.2`
 
 ## 0.0.1 - 09/03/2019
 - Add system-dependencies needed for terra-jupyter-r image to install
   Bioconductor packages.
 - Install core bioconductor packages to use out of the box.
 
-Image URL: us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:0.0.1
+`Image URL: us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:0.0.1`

--- a/terra-jupyter-bioconductor/CHANGELOG.md
+++ b/terra-jupyter-bioconductor/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 0.0.5 - 11/22/2019
-- Install AnnotationHub, ExperimentHub, ensembldb, Rtse, scRNAseq.
+- Install AnnotationHub, ExperimentHub, ensembldb, Rtse, scRNAseq, scran.
 - Update `terra-jupyter-bioconductor` version to `0.0.5`
 
 `Image URL: us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:0.0.5`

--- a/terra-jupyter-bioconductor/Dockerfile
+++ b/terra-jupyter-bioconductor/Dockerfile
@@ -64,8 +64,6 @@ RUN apt-get update \
     xfonts-100dpi \
     xfonts-75dpi \
     biber \
-    ## symlink libgfortran.so as versions of gcc and gfortran are different(installs DESeq2) \
-    && ln -s /usr/lib/x86_64-linux-gnu/libgfortran.so.4 /usr/lib/x86_64-linux-gnu/libgfortran.so \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/terra-jupyter-bioconductor/Dockerfile
+++ b/terra-jupyter-bioconductor/Dockerfile
@@ -107,4 +107,9 @@ RUN R -e 'BiocManager::install(c( \
     "GenomicFeatures", \
     "GenomicAlignments", \
     "ShortRead", \
-    "DESeq2"))'
+    "DESeq2", \
+    "AnnotationHub", \
+    "ExperimentHub", \
+    "ensembldb", \
+    "scRNAseq", \
+    "Rtsne"))'

--- a/terra-jupyter-bioconductor/Dockerfile
+++ b/terra-jupyter-bioconductor/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:0.0.5-snap
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:0.0.6
 
 USER root
 

--- a/terra-jupyter-bioconductor/Dockerfile
+++ b/terra-jupyter-bioconductor/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:0.0.5
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:0.0.5-snap
 
 USER root
 

--- a/terra-jupyter-bioconductor/Dockerfile
+++ b/terra-jupyter-bioconductor/Dockerfile
@@ -110,4 +110,5 @@ RUN R -e 'BiocManager::install(c( \
     "ExperimentHub", \
     "ensembldb", \
     "scRNAseq", \
+    "scran", \
     "Rtsne"))'

--- a/terra-jupyter-r/CHANGELOG.md
+++ b/terra-jupyter-r/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.0.6 - 11/22/2019
+- Update make recommended packages updatable.
+- Update `terra-jupyter-r` version to `0.0.6`
+`Image URL: us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:0.0.6`
+
 ## 0.0.5 - 11/16/2019
 - Update `terra-jupyter-base` version to `0.0.5`
 - Remove apt-get upgrade for security purposes

--- a/terra-jupyter-r/Dockerfile
+++ b/terra-jupyter-r/Dockerfile
@@ -11,7 +11,6 @@ RUN apt-get update \
     && add-apt-repository 'deb https://cloud.r-project.org/bin/linux/ubuntu bionic-cran35/' \
     && apt-get install -yq --no-install-recommends apt-transport-https \
     && apt update \
-#     && apt-get -y build-dep libcurl4-gnutls-dev \
     && apt install -yq --no-install-recommends \
 	apt-utils \
 	curl \
@@ -20,9 +19,10 @@ RUN apt-get update \
 	libcurl4-gnutls-dev \
 	libgit2-dev \
 	libxml2-dev \
-	# libcurl4-gnutls-dev \
+	libgfortran-7-dev \
 	r-base-dev \
 	r-base-core \
+    && ln -s /usr/lib/gcc/x86_64-linux-gnu/7/libgfortran.so /usr/lib/x86_64-linux-gnu/libgfortran.so \ 
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
@@ -31,14 +31,14 @@ USER $USER
 ## Reasons for change, 1. Message during installation, 2. User cannot
 ## update packages installed in the Dockerfile.
 
-RUN  mkdir -p /home/jupyter-user/.rpackages \
- && echo "R_LIBS=/home/jupyter-user/.rpackages" > /home/jupyter-user/.Renviron \
- && R -e 'install.packages(c( \
+RUN mkdir -p /home/jupyter-user/.rpackages \
+    && echo "R_LIBS=/home/jupyter-user/.rpackages" > /home/jupyter-user/.Renviron \
+    && R -e 'install.packages(c( \
     "remotes", \
     "BiocManager", \
     "devtools"))' \
- && R -e 'BiocManager::install(version="3.9", ask=FALSE)' \
- && R -e 'BiocManager::install(c( \
+    && R -e 'BiocManager::install(version="3.9", ask=FALSE)' \
+    && R -e 'BiocManager::install(c( \
     "boot", \
     "class", \
     "cluster", \
@@ -47,7 +47,7 @@ RUN  mkdir -p /home/jupyter-user/.rpackages \
     "kernsmooth", \
     "lattice", \
     "mass", \
-    "matrix", \
+    "Matrix", \
     "mgcv", \
     "nlme", \
     "nnet", \
@@ -65,6 +65,6 @@ RUN  mkdir -p /home/jupyter-user/.rpackages \
     "tidyverse", \
     "pbdZMQ", \
     "uuid"))' \
- && R -e 'IRkernel::installspec(user=FALSE)' \
- && chown -R $USER:users /home/jupyter-user/.local
-
+&& R -e 'BiocManager::install("IRkernel")' \
+    && R -e 'IRkernel::installspec(user=FALSE)' \
+    && chown -R $USER:users /home/jupyter-user/.local 

--- a/terra-jupyter-r/Dockerfile
+++ b/terra-jupyter-r/Dockerfile
@@ -57,7 +57,7 @@ RUN mkdir -p /home/jupyter-user/.rpackages \
     # Jupyter notebook essentials
     "IRdisplay",  \
     "DataBiosphere/Ronaldo", \
-    "IRkernel/IRkernel", \
+    "IRkernel", \
     # GCP essentials
     "bigrquery",  \
     "googleCloudStorageR", \
@@ -65,6 +65,6 @@ RUN mkdir -p /home/jupyter-user/.rpackages \
     "tidyverse", \
     "pbdZMQ", \
     "uuid"))' \
-&& R -e 'BiocManager::install("IRkernel")' \
     && R -e 'IRkernel::installspec(user=FALSE)' \
-    && chown -R $USER:users /home/jupyter-user/.local 
+    && chown -R $USER:users /home/jupyter-user/.local
+    

--- a/terra-jupyter-r/Dockerfile
+++ b/terra-jupyter-r/Dockerfile
@@ -21,10 +21,8 @@ RUN apt-get update \
 	libgit2-dev \
 	libxml2-dev \
 	# libcurl4-gnutls-dev \
-	r-base \
 	r-base-dev \
 	r-base-core \
-	r-recommended \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
@@ -41,6 +39,21 @@ RUN  mkdir -p /home/jupyter-user/.rpackages \
     "devtools"))' \
  && R -e 'BiocManager::install(version="3.9", ask=FALSE)' \
  && R -e 'BiocManager::install(c( \
+    "boot", \
+    "class", \
+    "cluster", \
+    "codetools", \
+    "foreign", \
+    "kernsmooth", \
+    "lattice", \
+    "mass", \
+    "matrix", \
+    "mgcv", \
+    "nlme", \
+    "nnet", \
+    "rpart", \
+    "spatial", \
+    "survival", \
     # Jupyter notebook essentials
     "IRdisplay",  \
     "DataBiosphere/Ronaldo", \


### PR DESCRIPTION
1. r-base: this installs the r-recommended packages since it's a
dependency and these packages get installed in "/usr/lib/R/library".

2. r-recommended: this basically does the same thing as installing the
packages in the /usr/lib/R/library location.

We want to avoid installing the r-recommended packages, so both r-base
and r-recommended are removed. To allow installation to happen for these
recommended packages in /home/jupyter-user/.rpackages, they are
individually listed in the BiocManager::install command.

The "ask" option is added as FALSE to the BiocManager, as we don't want
to update unprompted. See below,

 ask: 'logical(1)' indicating whether to prompt user before
      installed packages are updated.  If TRUE, user can choose
      whether to update all outdated packages without further
      prompting, to pick packages to update, or to cancel updating
      (in a non-interactive session, no packages will be updated
      unless 'ask = FALSE').
This solves Bioconductor#2