### PR TITLE
IA-1237 update hail dockerfile

### DIFF
--- a/config/conf.json
+++ b/config/conf.json
@@ -30,11 +30,11 @@
             "base_label": "Hail",
             "tools": ["python"],
             "packages": { "python": ["hail"] },
-            "version": "0.0.2",
+            "version": "0.0.3",
             "automated_flags": {
-                "generate_docs": false,
-                "include_in_ui": false,
-                "build": false,
+                "generate_docs": true,
+                "include_in_ui": true,
+                "build": true,
                 "include_in_custom_dataproc": false
             }
         },

--- a/terra-jupyter-hail/Dockerfile
+++ b/terra-jupyter-hail/Dockerfile
@@ -2,13 +2,8 @@ FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.3
 USER root
 ENV PIP_USER=false
 
-# COPY scripts $JUPYTER_HOME/scripts
-
-ENV SPARK_VER 2.4.4
-ENV SPARK_HOME=/usr/lib/spark
-ENV PYTHONPATH $PYTHONPATH:$SPARK_HOME/python
-ENV HAIL_HOME "/usr/local/lib/python3.7/dist-packages/hail"
-ENV HAILJAR "/usr/local/lib/python3.7/dist-packages/hail/hail-all-spark.jar"
+ENV PYTHONPATH $PYTHONPATH:/usr/lib/spark/python
+ENV HAIL_VERSION=0.2.27
 
 # Note Spark and Hadoop are mounted from the outside Dataproc VM.
 # Make empty conf dirs for the update-alternatives commands.
@@ -17,15 +12,14 @@ RUN mkdir -p /etc/spark/conf.dist && mkdir -p /etc/hadoop/conf.empty && mkdir -p
     && update-alternatives --install /etc/hadoop/conf hadoop-conf /etc/hadoop/conf.empty 100 \
     && update-alternatives --install /etc/hive/conf hive-conf /etc/hive/conf.dist 100 \
     && apt-get update && apt-get -yq dist-upgrade \
-    # && find $JUPYTER_HOME/scripts -name '*.sh' -type f | xargs chmod +x \    
     && apt install -yq --no-install-recommends openjdk-8-jdk \
         g++ \
         liblz4-dev \
     && pip3 install pypandoc \    
-    && pip3 install --no-dependencies hail==0.2.26 \
+    && pip3 install --no-dependencies hail==$HAIL_VERSION \
     && X=$(mktemp -d) \
     && mkdir -p $X \
-    && (cd $X && pip3 download hail==0.2.26 --no-dependencies && \
+    && (cd $X && pip3 download hail==$HAIL_VERSION --no-dependencies && \
         unzip hail*.whl &&  \
         grep 'Requires-Dist: ' hail*dist-info/METADATA | sed 's/Requires-Dist: //' | sed 's/ (//' | sed 's/)//' | grep -v 'pyspark' | xargs pip install) \
     && rm -rf $X

--- a/terra-jupyter-hail/Dockerfile
+++ b/terra-jupyter-hail/Dockerfile
@@ -1,24 +1,31 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.2
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.3
 USER root
 ENV PIP_USER=false
 
-COPY scripts $JUPYTER_HOME/scripts
+# COPY scripts $JUPYTER_HOME/scripts
 
-ENV SPARK_VER 2.2.3
+ENV SPARK_VER 2.4.4
 ENV SPARK_HOME=/usr/lib/spark
 ENV PYTHONPATH $PYTHONPATH:$SPARK_HOME/python
+ENV HAIL_HOME "/usr/local/lib/python3.7/dist-packages/hail"
+ENV HAILJAR "/usr/local/lib/python3.7/dist-packages/hail/hail-all-spark.jar"
 
 # Note Spark and Hadoop are mounted from the outside Dataproc VM.
 # Make empty conf dirs for the update-alternatives commands.
-RUN apt-get update && apt-get -yq dist-upgrade \
+RUN mkdir -p /etc/spark/conf.dist && mkdir -p /etc/hadoop/conf.empty && mkdir -p /etc/hive/conf.dist \
+    && update-alternatives --install /etc/spark/conf spark-conf /etc/spark/conf.dist 100 \
+    && update-alternatives --install /etc/hadoop/conf hadoop-conf /etc/hadoop/conf.empty 100 \
+    && update-alternatives --install /etc/hive/conf hive-conf /etc/hive/conf.dist 100 \
+    && apt-get update && apt-get -yq dist-upgrade \
+    # && find $JUPYTER_HOME/scripts -name '*.sh' -type f | xargs chmod +x \    
     && apt install -yq --no-install-recommends openjdk-8-jdk \
         g++ \
         liblz4-dev \
     && pip3 install pypandoc \    
-    && pip3 install --no-dependencies hail==0.2.1 \
+    && pip3 install --no-dependencies hail==0.2.26 \
     && X=$(mktemp -d) \
     && mkdir -p $X \
-    && (cd $X && pip3 download hail==0.2.1 --no-dependencies && \
+    && (cd $X && pip3 download hail==0.2.26 --no-dependencies && \
         unzip hail*.whl &&  \
         grep 'Requires-Dist: ' hail*dist-info/METADATA | sed 's/Requires-Dist: //' | sed 's/ (//' | sed 's/)//' | grep -v 'pyspark' | xargs pip install) \
     && rm -rf $X


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-1237

`hl.spark_context()` returns `yarn` properly now.

I tried the hl.balding_nichols_model(3, 100000, 10000)._force_count_rows() and I can see cpu spikes in workers clearly every time I run this, and it finishes a lot faster than previously. And I see logs like
```
DIR* completeFile: /yarn-logs/jupyter-user/logs/application_1574015922767_0002/saturn-3bdc666f-4a63-4265-b3fe-c769598f9f7a-w-0.c.qi-billing.internal_32843.tmp is closed by DFSClient_NONMAPREDUCE_-1710167753_128
```
in hadoop log (assuming this is indication that hadoops is running some job from jupyter)...