### PR TITLE
bump terra-jupyter-gatk to 0.0.5 - includes terra-jupyter-r:0.0.6

### DIFF
--- a/config/conf.json
+++ b/config/conf.json
@@ -82,7 +82,7 @@
             "base_label": "GATK",
             "tools": ["python", "gatk"],
             "packages": {},
-            "version": "0.0.4",
+            "version": "0.0.5",
             "automated_flags": {
                 "include_in_ui": true,
                 "generate_docs": false,

--- a/terra-jupyter-gatk/CHANGELOG.md
+++ b/terra-jupyter-gatk/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.0.5 - 11/22/2019
+- Update `terra-jupyter-r` version to `0.0.6`
+
+`Image URL: us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:0.0.5`
+
 ## 0.0.4 - 11/16/2019
 - Update `terra-jupyter-r` version to `0.0.5`
 - Update `terra-jupyter-python` version to `0.0.4`

--- a/terra-jupyter-gatk/Dockerfile
+++ b/terra-jupyter-gatk/Dockerfile
@@ -1,6 +1,6 @@
 FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.4 AS python
 
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:0.0.5
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:0.0.6
 
 # copy everything pip installed from the python image
 COPY --from=python /usr/local/lib/python3.7/dist-packages /usr/local/lib/python3.7/dist-packages


### PR DESCRIPTION
Corrects an issue seen in All of Us for the terra-jupyter-gatk:0.0.3 image (also present in 0.0.4) when installing packages which depend on `-lgfortran` such as `questionr`.

Before:
![Screen Shot 2019-11-22 at 5 39 15 PM](https://user-images.githubusercontent.com/2701406/69465541-68cc0500-0d4f-11ea-8a12-59daadbcaa85.png)


After:
![Screen Shot 2019-11-22 at 5 41 41 PM](https://user-images.githubusercontent.com/2701406/69465545-6bc6f580-0d4f-11ea-8201-6ae67fdfc16c.png)

