### PR TITLE
Update Bioconductor to version 3.10

### DIFF
--- a/config/conf.json
+++ b/config/conf.json
@@ -17,7 +17,7 @@
             "base_label": "Bioconductor",
             "tools": ["python", "r"],
             "packages": { "r": ["BiocVersion", "tidyverse"] },
-            "version": "0.0.6",
+            "version": "0.0.7",
             "automated_flags": {
                 "generate_docs": true,
                 "include_in_ui": true,

--- a/terra-jupyter-bioconductor/CHANGELOG.md
+++ b/terra-jupyter-bioconductor/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.0.7 - 11/22/2019
+## 0.0.7 - 11/27/2019
 - Use new Bioconductor version 3.10
 - Update `terra-jupyter-bioconductor` version to `0.0.7`
 

--- a/terra-jupyter-bioconductor/CHANGELOG.md
+++ b/terra-jupyter-bioconductor/CHANGELOG.md
@@ -2,7 +2,7 @@
 - Use new Bioconductor version 3.10
 - Update `terra-jupyter-bioconductor` version to `0.0.6`
 
-`Image URL: us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:0.0.5`
+`Image URL: us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:0.0.6`
 
 ## 0.0.5 - 11/22/2019
 - Install AnnotationHub, ExperimentHub, ensembldb, Rtse, scRNAseq, scran.

--- a/terra-jupyter-bioconductor/CHANGELOG.md
+++ b/terra-jupyter-bioconductor/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.0.6 - 11/22/2019
+- Use new Bioconductor version 3.10
+- Update `terra-jupyter-bioconductor` version to `0.0.6`
+
+`Image URL: us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:0.0.5`
+
 ## 0.0.5 - 11/22/2019
 - Install AnnotationHub, ExperimentHub, ensembldb, Rtse, scRNAseq, scran.
 - Update `terra-jupyter-bioconductor` version to `0.0.5`

--- a/terra-jupyter-bioconductor/Dockerfile
+++ b/terra-jupyter-bioconductor/Dockerfile
@@ -1,5 +1,4 @@
-#FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:0.0.7
-FROM terra-jupyter-r:0.0.7
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:0.0.7
 
 USER root
 

--- a/terra-jupyter-bioconductor/Dockerfile
+++ b/terra-jupyter-bioconductor/Dockerfile
@@ -1,4 +1,5 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:0.0.6
+#FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:0.0.7
+FROM terra-jupyter-r:0.0.7
 
 USER root
 

--- a/terra-jupyter-r/CHANGELOG.md
+++ b/terra-jupyter-r/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.0.7 - 11/25/2019
+- Update Bioconductor version to 3.10.
+- Update `terra-jupyter-r` version to 0.0.7
+`Image URL: us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:0.0.7`
+
 ## 0.0.6 - 11/22/2019
 - Update make recommended packages updatable.
 - Update `terra-jupyter-r` version to `0.0.6`

--- a/terra-jupyter-r/CHANGELOG.md
+++ b/terra-jupyter-r/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 0.0.7 - 11/25/2019
+## 0.0.7 - 11/26/2019
 - Update Bioconductor version to 3.10.
-- Update `terra-jupyter-r` version to 0.0.7
+- Fix `WORKSPACE_BUCKET` environment variable
+- Update `terra-jupyter-r` version to `0.0.7`
 `Image URL: us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:0.0.7`
 
 ## 0.0.6 - 11/22/2019

--- a/terra-jupyter-r/Dockerfile
+++ b/terra-jupyter-r/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update \
 	libgfortran-7-dev \
 	r-base-dev \
 	r-base-core \
-    && ln -s /usr/lib/gcc/x86_64-linux-gnu/7/libgfortran.so /usr/lib/x86_64-linux-gnu/libgfortran.so \ 
+    && ln -s /usr/lib/gcc/x86_64-linux-gnu/7/libgfortran.so /usr/lib/x86_64-linux-gnu/libgfortran.so \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
@@ -37,7 +37,7 @@ RUN mkdir -p /home/jupyter-user/.rpackages \
     "remotes", \
     "BiocManager", \
     "devtools"))' \
-    && R -e 'BiocManager::install(version="3.9", ask=FALSE)' \
+    && R -e 'BiocManager::install(version="3.10", ask=FALSE)' \
     && R -e 'BiocManager::install(c( \
     "boot", \
     "class", \
@@ -67,4 +67,3 @@ RUN mkdir -p /home/jupyter-user/.rpackages \
     "uuid"))' \
     && R -e 'IRkernel::installspec(user=FALSE)' \
     && chown -R $USER:users /home/jupyter-user/.local
-    

--- a/terra-jupyter-r/Dockerfile
+++ b/terra-jupyter-r/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:0.0.5
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:0.0.6
 USER root
 
 COPY scripts $JUPYTER_HOME/scripts


### PR DESCRIPTION
This PR will update the version of Bioconductor to the latest release 3.10. 