### PR TITLE
include gatk image in custom dataproc image

### DIFF
--- a/config/conf.json
+++ b/config/conf.json
@@ -84,10 +84,10 @@
             "packages": {},
             "version": "0.0.6",
             "automated_flags": {
-                "include_in_ui": true,
+                "include_in_ui": false,
                 "generate_docs": false,
                 "build": true,
-                "include_in_custom_dataproc": false
+                "include_in_custom_dataproc": true
             }
         }
     ]


### PR DESCRIPTION
One theory about why AOU cluster startup increased since 11/19 is that they started to use terra-jupyter-gatk image, and we saw huge increased startup time since then in perf (altho it doesn't seem to affected prod much)

<img width="720" alt="Screen Shot 2019-11-27 at 11 58 02 AM" src="https://user-images.githubusercontent.com/32771737/69744922-1b64e480-110f-11ea-804c-afdcf5a6389d.png">
