### PR TITLE
IA-1602 IA-1617  IA-1624 IA-1629 Make terra-docker images runnable locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This repo provides docker images for running jupyter notebook in [Terra](https:/
 [terra-jupyter-bioconductor](terra-jupyter-bioconductor/README.md)
 
 # How to create your own Custom image to use with notebooks on Terra
-Custom docker images need to use a Terra base image (see above) in order to work with the service that runs notebooks on Terra
+Custom docker images need to use a Terra base image (see above) in order to work with the service that runs notebooks on Terra.
 * You can use any of the base images above
 * Here is an example of how to build off of a base image: Add `FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:0.0.1` to your dockerfile (`terra-jupyter-base` is the smallest image you can extend from)
 * Customize your image (see the [terra-jupyter-python](terra-jupyter-python/Dockerfile) dockerfile for an example of how to extend from one of our base images
@@ -54,18 +54,23 @@ If you wish to build locally, run `docker build [your_dir] -t [name]`.
 It is not advised to run build.sh locally, as this will push to the remote docker repo and delete the image locally upon completion.  
 
 ## Testing your image manually
-- In a terminal, do `gcloud auth login` and follow the instructions to authenticate with a google account that has appropriate permissions in Terra
-- Create a cluster
-  - Do ```curl -X PUT --header 'Content-Type: application/json' --header "Authorization: Bearer `gcloud auth print-access-token`" -d @/tmp/createCluster https://leonardo.dsde-prod.broadinstitute.org/api/cluster/{google project}/{cluster name}```
-  - /tmp/createCluster looks like
-    ```
-    {
-        "jupyterDockerImage": "{your image url}"
-    }
-    ```
-- Go to `https://portal.firecloud.org/`
-- Create a notebook and choose the cluster you just created
-- Open the notebook and check if things work as expected
+All images can be run locally. For example:
+```
+docker run --rm -it -p 8000:8000 us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:0.0.7
+```
+Then navigate a browser to http://localhost:8000/notebooks to access the Jupyter UI.
+
+You can gain root access and open a bash terminal as follows:
+```
+docker run --rm -it -u root -p 8000:8000 --entrypoint /bin/bash us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:0.0.7
+```
+
+Running locally is conventient for quick development and exploring the image. However it has some limitations compared to running through Terra. Namely:
+- there are no service account credentials when run locally
+- there are no environment variables like `GOOGLE_PROJECT`, `WORKSPACE_NAME`, `WORKSPACE_BUCKET`, etc when running locally
+- there is no workspace-syncing when run locally
+
+To launch an image through Terra, navigate to https://app.terra.bio, select a workspace, enter your image in the "Custom Image" field, and click Create.
 
 ## Automation Tests
 [Here](https://github.com/DataBiosphere/leonardo/tree/develop/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks) are automation tests for various docker image, please update the image hash for relevant tests. You can run the job build-terra-docker to automatically create a PR with your branch if you manually specify versions.

--- a/config/conf.json
+++ b/config/conf.json
@@ -17,7 +17,7 @@
             "base_label": "Bioconductor",
             "tools": ["python", "r"],
             "packages": { "r": ["BiocVersion", "tidyverse"] },
-            "version": "0.0.9",
+            "version": "0.0.10",
             "automated_flags": {
                 "generate_docs": true,
                 "include_in_ui": true,
@@ -30,7 +30,7 @@
             "base_label": "Hail",
             "tools": ["python"],
             "packages": { "python": ["hail"] },
-            "version": "0.0.5",
+            "version": "0.0.6",
             "automated_flags": {
                 "generate_docs": true,
                 "include_in_ui": true,
@@ -43,7 +43,7 @@
             "base_label": "Python",
             "tools": ["python"],
             "packages": { "python": ["pandas", "scikit-learn"] },
-            "version": "0.0.7",
+            "version": "0.0.8",
             "automated_flags": {
                 "generate_docs": true,
                 "include_in_ui": true,
@@ -56,7 +56,7 @@
             "base_label": "Base",
             "tools": ["python"],
             "packages": {},
-            "version": "0.0.6",
+            "version": "0.0.7",
             "automated_flags": {
                 "generate_docs": true,
                 "include_in_ui": false,
@@ -69,7 +69,7 @@
             "base_label": "R",
             "tools": ["r"],
             "packages": {},
-            "version": "0.0.8",
+            "version": "0.0.9",
             "automated_flags": {
                 "include_in_ui": false,
                 "generate_docs": true,
@@ -82,7 +82,7 @@
             "base_label": "New Default (released on January 14)",
             "tools": ["gatk", "python", "r"],
             "packages": {},
-            "version": "0.0.9",
+            "version": "0.0.10",
             "automated_flags": {
                 "include_in_ui": true,
                 "generate_docs": true,

--- a/scripts/generate_version_docs.py
+++ b/scripts/generate_version_docs.py
@@ -69,7 +69,7 @@ def get_doc_label(image_config):
     labels = map(lambda package: "{} {}".format(package, packages[tool][package]), additional_package_names[tool])
     additional_package_labels = additional_package_labels + list(labels)
 
-  tool_labels = map(lambda tool: "{} {}".format(tool.capitalize(), packages[tool][tool]), tools)
+  tool_labels = map(lambda tool: "{} {}".format(get_tool_label(tool), packages[tool][tool]), tools)
 
   labels = list(tool_labels) + list(additional_package_labels)
 
@@ -108,6 +108,12 @@ def get_static_legacy_doc():
 def get_current_versions():
   utils.gsutil_cp(config["version_master_file"], config["doc_bucket"], copy_to_remote=False)
   return utils.read_json_file(config["version_master_file"])
+
+def get_tool_label(tool):
+  if tool == 'gatk':
+    return tool.upper()
+  else:
+    return tool.capitalize()
 
 if __name__ == "__main__":
   main()

--- a/scripts/generate_version_docs.py
+++ b/scripts/generate_version_docs.py
@@ -110,10 +110,7 @@ def get_current_versions():
   return utils.read_json_file(config["version_master_file"])
 
 def get_tool_label(tool):
-  if tool == 'gatk':
-    return tool.upper()
-  else:
-    return tool.capitalize()
+  return tool.upper() if tool == 'gatk' else tool.capitalize()
 
 if __name__ == "__main__":
   main()

--- a/terra-jupyter-base/CHANGELOG.md
+++ b/terra-jupyter-base/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Make image locally runnable with:
    - `docker run --rm -it -p 8000:8000 <image>`
 - Add FISS to base image
+- Add OpenJDK 11 to base image
 
 Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:0.0.7`
 

--- a/terra-jupyter-base/CHANGELOG.md
+++ b/terra-jupyter-base/CHANGELOG.md
@@ -1,21 +1,29 @@
+## 0.0.7 - 01/17/2020
+
+- Make image locally runnable with:
+   - `docker run --rm -it -p 8000:8000 <image>`
+- Add FISS to base image
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:0.0.7`
+
 ## 0.0.6 - 11/26/2019
 
 - Fix `WORKSPACE_BUCKET` environment variable
 
-Image URL: us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:0.0.6
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:0.0.6`
 
 ## 0.0.5 - 11/16/2019
 
 - Remove apt-get upgrade for security purposes
 
-Image URL: us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:0.0.5
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:0.0.5`
 
 ## 0.0.4 - 10/18/2019
 
 - Fix a bug in google_sign_in.js
 - Fix WORKSPACE_NAME environment variable
   
-Image URL: us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:0.0.4
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:0.0.4`
 
 ## 0.0.3 - 10/09/2019
 
@@ -35,4 +43,4 @@ Lint the .js extension files
 - Add Jupyter & JupyterLab
 - Add Leonardo customizations/extensions
 
-Image URL: us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:0.0.1
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:0.0.1`

--- a/terra-jupyter-base/Dockerfile
+++ b/terra-jupyter-base/Dockerfile
@@ -26,6 +26,7 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
     # useful utilities for debugging within the docker
     unzip \
     nano \
+    vim \
     procps \
 
     # python requirements

--- a/terra-jupyter-base/Dockerfile
+++ b/terra-jupyter-base/Dockerfile
@@ -7,7 +7,6 @@ USER root
 # Prerequisites
 #######################
 ENV DEBIAN_FRONTEND noninteractive
-ENV CRAN_REPO http://cran.mtu.edu
 
 RUN apt-get update && apt-get install -yq --no-install-recommends \
 
@@ -24,10 +23,10 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
     gcc-6 \
     gcc-8 \
 
-   #useful utilities for debugging within the docker
-   unzip \
-   nano \
-   procps \
+    # useful utilities for debugging within the docker
+    unzip \
+    nano \
+    procps \
 
     # python requirements
     checkinstall \
@@ -54,10 +53,15 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
     git \
     jq \
 
-# for jupyterlab extensions
+    # for jupyterlab extensions
     nodejs-dev \
     node-gyp \
     npm \
+
+    # java
+    default-jre \
+    default-jdk \
+
  # Uncomment en_US.UTF-8 for inclusion in generation
  && sed -i 's/^# *\(en_US.UTF-8\)/\1/' /etc/locale.gen \
  # Generate locale

--- a/terra-jupyter-base/Dockerfile
+++ b/terra-jupyter-base/Dockerfile
@@ -118,11 +118,10 @@ RUN pip3 -V \
  && pip3 install cookiecutter \
  && pip3 install jupyter_contrib_nbextensions \
  && pip3 install jupyter_nbextensions_configurator \
-
  # for jupyter_delocalize.py and jupyter_notebook_config.py
  && pip3 install tornado==4.5.3 \
  && pip3 install requests \
-
+ && pip3 install firecloud==0.16.25 \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 
@@ -137,7 +136,7 @@ ENV PIP_USER=true
 #######################
 # Install Conda
 #######################
-Run wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O /tmp/miniconda.sh \
+RUN wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O /tmp/miniconda.sh \
   && bash /tmp/miniconda.sh -b -p $HOME/miniconda \
   && echo 'eval "$(/home/jupyter-user/miniconda/bin/conda shell.bash hook)"' >> /home/jupyter-user/.bashrc
 
@@ -147,6 +146,7 @@ Run wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -
 
 COPY scripts $JUPYTER_HOME/scripts
 COPY custom $JUPYTER_HOME/custom
+COPY jupyter_notebook_config.py $JUPYTER_HOME
 
 RUN chown -R $USER:users $JUPYTER_HOME \
  && chown -R $USER:users /usr/local/share/jupyter/lab \

--- a/terra-jupyter-base/Dockerfile
+++ b/terra-jupyter-base/Dockerfile
@@ -160,7 +160,8 @@ RUN chown -R $USER:users $JUPYTER_HOME \
  && cp $JUPYTER_HOME/custom/safe-mode.js $HOME/.jupyter/custom/ \
  && cp $JUPYTER_HOME/custom/edit-mode.js $HOME/.jupyter/custom/ \
  && $JUPYTER_HOME/scripts/extension/jupyter_install_lab_extension.sh $JUPYTER_HOME/custom/extension_entry_jupyterlab.js \
- && mkdir $JUPYTER_HOME/nbconfig
+ && mkdir $JUPYTER_HOME/nbconfig \
+ && $JUPYTER_HOME/scripts/kernel/kernelspec.sh $JUPYTER_HOME/scripts/kernel /usr/local/share/jupyter/kernels
 
 USER $USER
 WORKDIR $HOME

--- a/terra-jupyter-base/Dockerfile
+++ b/terra-jupyter-base/Dockerfile
@@ -58,7 +58,7 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
     node-gyp \
     npm \
 
-    # java
+    # openjdk 11
     default-jre \
     default-jdk \
 

--- a/terra-jupyter-base/README.md
+++ b/terra-jupyter-base/README.md
@@ -13,6 +13,7 @@ The terra-jupyter-base extends the [Ubuntu base image]("https://github.com/tiano
 - conda
 - Jupyter & JupyterLab
 - Leonardo customizations/extensions
+- Terra python client library ([FISS](https://github.com/broadinstitute/fiss))
 
 To see the complete contents of this image please see the [Dockerfile](./Dockerfile).
 

--- a/terra-jupyter-base/README.md
+++ b/terra-jupyter-base/README.md
@@ -14,6 +14,7 @@ The terra-jupyter-base extends the [Ubuntu base image]("https://github.com/tiano
 - Jupyter & JupyterLab
 - Leonardo customizations/extensions
 - Terra python client library ([FISS](https://github.com/broadinstitute/fiss))
+- OpenJDK 11
 
 To see the complete contents of this image please see the [Dockerfile](./Dockerfile).
 

--- a/terra-jupyter-base/jupyter_notebook_config.py
+++ b/terra-jupyter-base/jupyter_notebook_config.py
@@ -18,7 +18,7 @@ c.NotebookApp.allow_origin = '*'
 c.NotebookApp.terminado_settings={'shell_command': ['bash']}
 
 if 'GOOGLE_PROJECT' in os.environ and 'CLUSTER_NAME' in os.environ:
-  fragment = '/' + os.envirion['GOOGLE_PROJECT'] + '/' + os.environ['CLUSTER_NAME'] + '/'
+  fragment = '/' + os.environ['GOOGLE_PROJECT'] + '/' + os.environ['CLUSTER_NAME'] + '/'
 else:
   fragment = '/'
 

--- a/terra-jupyter-base/jupyter_notebook_config.py
+++ b/terra-jupyter-base/jupyter_notebook_config.py
@@ -1,0 +1,51 @@
+# adapted from https://github.com/jupyter/docker-stacks/blob/master/base-notebook/jupyter_notebook_config.py
+
+from jupyter_core.paths import jupyter_data_dir
+import subprocess
+import os
+import errno
+import stat
+
+c = get_config()
+c.NotebookApp.ip = '0.0.0.0'
+c.NotebookApp.port = 8000
+c.NotebookApp.open_browser = False
+
+c.NotebookApp.token = ''
+c.NotebookApp.disable_check_xsrf = True #see https://github.com/nteract/hydrogen/issues/922
+c.NotebookApp.allow_origin = '*'
+
+c.NotebookApp.terminado_settings={'shell_command': ['bash']}
+
+if 'GOOGLE_PROJECT' in os.environ and 'CLUSTER_NAME' in os.environ:
+  fragment = '/' + os.envirion['GOOGLE_PROJECT'] + '/' + os.environ['CLUSTER_NAME'] + '/'
+else:
+  fragment = '/'
+
+c.NotebookApp.base_url = '/notebooks' + fragment
+
+# Using an alternate notebooks_dir allows for mounting of a shared volume here.
+# The default notebook root dir is /home/jupyter-user, which is also the home
+# directory (which contains several other files on the image). We don't want
+# to mount there as it effectively deletes existing files on the image.
+# See https://docs.google.com/document/d/1b8wIydzC4D7Sbb6h2zWe-jCvoNq-bbD02CT1cnKLbGk
+if os.environ.get('WELDER_ENABLED') == 'true':
+  # Only enable this along with Welder, as this change is backwards incompatible
+  # for older localization users.
+  c.NotebookApp.notebook_dir = os.environ.get('NOTEBOOKS_DIR', '/home/jupyter-user/notebooks')
+
+# This is also specified in run-jupyter.sh
+c.NotebookApp.nbserver_extensions = {
+    'jupyter_localize_extension': True
+}
+
+mgr_class = 'DelocalizingContentsManager'
+if os.environ.get('WELDER_ENABLED') == 'true':
+  mgr_class = 'WelderContentsManager'
+c.NotebookApp.contents_manager_class = 'jupyter_delocalize.' + mgr_class
+
+# Content-Security-Policy is set by the Leo proxy so Jupyter can be rendered in an iframe
+# See https://jupyter-notebook.readthedocs.io/en/latest/public_server.html?highlight=server#embedding-the-notebook-in-another-website
+c.NotebookApp.tornado_settings = {
+    'static_url_prefix':'/notebooks' + fragment + 'static/'
+}

--- a/terra-jupyter-base/jupyter_notebook_config.py
+++ b/terra-jupyter-base/jupyter_notebook_config.py
@@ -1,4 +1,7 @@
 # adapted from https://github.com/jupyter/docker-stacks/blob/master/base-notebook/jupyter_notebook_config.py
+# Note: this file also lives in the Leonardo repo here: 
+# https://github.com/DataBiosphere/leonardo/blob/develop/http/src/main/resources/jupyter/jupyter_notebook_config.py
+# If you change this please keep the other version consistent as well.
 
 import os
 

--- a/terra-jupyter-base/jupyter_notebook_config.py
+++ b/terra-jupyter-base/jupyter_notebook_config.py
@@ -1,10 +1,6 @@
 # adapted from https://github.com/jupyter/docker-stacks/blob/master/base-notebook/jupyter_notebook_config.py
 
-from jupyter_core.paths import jupyter_data_dir
-import subprocess
 import os
-import errno
-import stat
 
 c = get_config()
 c.NotebookApp.ip = '0.0.0.0'
@@ -44,8 +40,6 @@ if os.environ.get('WELDER_ENABLED') == 'true':
   mgr_class = 'WelderContentsManager'
 c.NotebookApp.contents_manager_class = 'jupyter_delocalize.' + mgr_class
 
-# Content-Security-Policy is set by the Leo proxy so Jupyter can be rendered in an iframe
-# See https://jupyter-notebook.readthedocs.io/en/latest/public_server.html?highlight=server#embedding-the-notebook-in-another-website
 c.NotebookApp.tornado_settings = {
     'static_url_prefix':'/notebooks' + fragment + 'static/'
 }

--- a/terra-jupyter-bioconductor/CHANGELOG.md
+++ b/terra-jupyter-bioconductor/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Make docker image locally runnable with:
    - `docker run --rm -it -p 8000:8000 <image>`
 - Add FISS library
+- Add OpenJDK 11
 
 Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:0.0.10`
 

--- a/terra-jupyter-bioconductor/CHANGELOG.md
+++ b/terra-jupyter-bioconductor/CHANGELOG.md
@@ -1,52 +1,60 @@
-# 0.0.9 - 12/17/2019
+## 0.0.10 - 01/17/2020
+- Update `terra-jupyter-r` version to `0.0.9`
+- Make docker image locally runnable with:
+   - `docker run --rm -it -p 8000:8000 <image>`
+- Add FISS library
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:0.0.10`
+
+## 0.0.9 - 12/17/2019
 - Upgrade pandas from 0.25.1 to 0.25.3
 
-`Image URL: us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:0.0.9`
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:0.0.9`
 
-# 0.0.8 - 12/11/2019
+## 0.0.8 - 12/11/2019
 - Standardize both Jupyter and RStudio Bioconductor package installation.
 - Update `terra-jupyter-bioconductor` version to `0.0.8`
 
-`Image URL: us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:0.0.8`
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:0.0.8`
 
 ## 0.0.7 - 11/27/2019
 - Use new Bioconductor version 3.10
 - Update `terra-jupyter-bioconductor` version to `0.0.7`
 
-`Image URL: us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:0.0.7`
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:0.0.7`
 
 ## 0.0.6 - 11/26/2019
 
 - Fix `WORKSPACE_BUCKET` environment variable
 
-`Image URL: us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:0.0.6`
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:0.0.6`
 
 ## 0.0.5 - 11/22/2019
 - Install AnnotationHub, ExperimentHub, ensembldb, Rtse, scRNAseq, scran.
 - Update `terra-jupyter-bioconductor` version to `0.0.5`
 
-`Image URL: us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:0.0.5`
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:0.0.5`
 
 ## 0.0.4 - 11/16/2019
 - Update `terra-jupyter-r` version to `0.0.5`
 - Remove apt-get upgrade for security purposes
 
-`Image URL: us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:0.0.4`
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:0.0.4`
 
 ## 0.0.3 - 10/18/2019
 - Update `terra-jupyter-r` version to `0.0.3`
 
-`Image URL: us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:0.0.3`
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:0.0.3`
 
 ## 0.0.2 - 09/04/2019
 - Install python packages needed for BiocSklearn, Rcwl.
 - Install python3.7-dev for headers required to compile python modules.
 
-`Image URL: us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:0.0.2`
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:0.0.2`
 
 ## 0.0.1 - 09/03/2019
 - Add system-dependencies needed for terra-jupyter-r image to install
   Bioconductor packages.
 - Install core bioconductor packages to use out of the box.
 
-`Image URL: us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:0.0.1`
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:0.0.1`

--- a/terra-jupyter-bioconductor/Dockerfile
+++ b/terra-jupyter-bioconductor/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:0.0.7
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:0.0.9
 
 USER root
 

--- a/terra-jupyter-gatk/CHANGELOG.md
+++ b/terra-jupyter-gatk/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 0.0.10 - 01/17/2020
+
+- Update `terra-jupyter-python` version to `0.0.8`
+- Update `terra-jupyter-r` version to `0.0.9`
+- Make docker image locally runnable with:
+   - `docker run --rm -it -p 8000:8000 <image>`
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:0.0.10`
+
 ## 0.0.9 - 1/15/2020
 
 - Update `terra-jupyter-python` version to `0.0.7`

--- a/terra-jupyter-gatk/CHANGELOG.md
+++ b/terra-jupyter-gatk/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Update `terra-jupyter-r` version to `0.0.9`
 - Make docker image locally runnable with:
    - `docker run --rm -it -p 8000:8000 <image>`
+- Remove `default-jre` and `default-jdk` since they are now provided in the base image
 
 Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:0.0.10`
 

--- a/terra-jupyter-gatk/CHANGELOG.md
+++ b/terra-jupyter-gatk/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.0.10 - 01/17/2020
+## 0.0.10 - 01/17/2020
 
 - Update `terra-jupyter-python` version to `0.0.8`
 - Update `terra-jupyter-r` version to `0.0.9`

--- a/terra-jupyter-gatk/Dockerfile
+++ b/terra-jupyter-gatk/Dockerfile
@@ -20,8 +20,6 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
   liblzo2-dev \
   zlib1g-dev \
   libz-dev \
-  default-jre \
-  default-jdk \
   samtools \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*

--- a/terra-jupyter-gatk/Dockerfile
+++ b/terra-jupyter-gatk/Dockerfile
@@ -1,6 +1,6 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.7 AS python
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.8 AS python
 
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:0.0.8
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:0.0.9
 
 # copy everything pip installed from the python image
 COPY --from=python /usr/local/lib/python3.7/dist-packages /usr/local/lib/python3.7/dist-packages

--- a/terra-jupyter-hail/CHANGELOG.md
+++ b/terra-jupyter-hail/CHANGELOG.md
@@ -1,29 +1,37 @@
+## 0.0.6 - 01/17/2020
+
+- Update `terra-jupyter-python` version to `0.0.8`
+- Make docker image locally runnable with:
+   - `docker run --rm -it -p 8000:8000 <image>`
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-hail:0.0.6`
+
 ## 0.0.5 - 1/2/2020
 
 - Upgrade `terra-jupyter-python` version
 - Upgrade `hail` to `0.20.30`
 
-`Image URL: us.gcr.io/broad-dsp-gcr-public/terra-jupyter-hail:0.0.5`
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-hail:0.0.5`
 
 ## 0.0.4 - 11/26/2019
 
 - Fix `WORKSPACE_BUCKET` environment variable
 
-`Image URL: us.gcr.io/broad-dsp-gcr-public/terra-jupyter-hail:0.0.4`
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-hail:0.0.4`
 
 ## 0.0.3 - 11/16/2019 
 
 - Update to use python 0.0.4
 - Remove apt-get upgrade for security purposes 
 
-`Image URL: us.gcr.io/broad-dsp-gcr-public/terra-jupyter-hail:0.0.3`
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-hail:0.0.3`
 
 ## 0.0.2 - 10/10/2019 
 
 Update to use python 0.0.2 
 
-`Image URL: us.gcr.io/broad-dsp-gcr-public/terra-jupyter-hail:0.0.2`
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-hail:0.0.2`
 
 ## 0.0.1 - 09/03/2019
 
-`Image URL: us.gcr.io/broad-dsp-gcr-public/terra-jupyter-hail:0.0.1`
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-hail:0.0.1`

--- a/terra-jupyter-hail/Dockerfile
+++ b/terra-jupyter-hail/Dockerfile
@@ -15,6 +15,8 @@ RUN mkdir -p /etc/spark/conf.dist && mkdir -p /etc/hadoop/conf.empty && mkdir -p
     && apt install -yq --no-install-recommends openjdk-8-jdk \
         g++ \
         liblz4-dev \
+    # specify Java 8
+    && update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java \
     && pip3 install pypandoc \
     && pip3 install --no-dependencies hail==$HAIL_VERSION \
     && X=$(mktemp -d) \

--- a/terra-jupyter-hail/Dockerfile
+++ b/terra-jupyter-hail/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.6
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.8
 USER root
 ENV PIP_USER=false
 

--- a/terra-jupyter-python/CHANGELOG.md
+++ b/terra-jupyter-python/CHANGELOG.md
@@ -5,7 +5,7 @@
    - `docker run --rm -it -p 8000:8000 <image>`
 - Remove FISS from this image since it's now included in the base
 
-Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.7`
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.8`
 
 ## 0.0.7 - 01/15/2020
 

--- a/terra-jupyter-python/CHANGELOG.md
+++ b/terra-jupyter-python/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Make docker image locally runnable with:
    - `docker run --rm -it -p 8000:8000 <image>`
 - Remove FISS from this image since it's now included in the base
+- Add OpenJDK 11
 
 Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.8`
 

--- a/terra-jupyter-python/CHANGELOG.md
+++ b/terra-jupyter-python/CHANGELOG.md
@@ -1,8 +1,17 @@
+## 0.0.8 - 01/17/2020
+
+- Update `terra-jupyter-base` version to `0.0.7`
+- Make docker image locally runnable with:
+   - `docker run --rm -it -p 8000:8000 <image>`
+- Remove FISS from this image since it's now included in the base
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.7`
+
 ## 0.0.7 - 01/15/2020
 
 - Install `pandas-profiling` version `2.4.0`
 
-`Image URL: us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.7`
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.7`
 
 ## 0.0.6 - 12/12/2019
 
@@ -18,24 +27,26 @@
 - Upgrade `setuptools` to `42.0.2`
 - Install `pdoc3` instead of `pdoc`
 
-`Image URL: us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.6`
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.6`
 
 ## 0.0.5 - 11/26/2019
 
 - Fix `WORKSPACE_BUCKET` environment variable
 
-`Image URL: us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.5`
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.5`
 
 ## 0.0.4 - 11/16/2019
 
 - Update `terra-jupyter-base` version to `0.0.5`
 - Removed apt-get upgrade for security purposes
-`Image URL: us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.4`
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.4`
 
 ## 0.0.3 - 10/18/2019
 
 - Update `terra-jupyter-base` version to `0.0.4`
-`Image URL: us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.3`
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.3`
 
 ## 0.0.2 - 10/10/2019
 
@@ -58,4 +69,4 @@ Use jupyter base image 0.0.3
 | certifi |	2016.2.28 | 2017.4.17 |
 | google-cloud-bigquery | 1.7.0 | 1.9.0 |
 
-`Image URL: us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.1`
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.1`

--- a/terra-jupyter-python/Dockerfile
+++ b/terra-jupyter-python/Dockerfile
@@ -74,8 +74,9 @@ RUN pip3 -V \
  && pip3 install tqdm==4.19.4 \
  && pip3 install werkzeug==0.12.2 \
  && pip3 install certifi==2017.4.17 \
- && pip3 install intel-openmp==2018.0.0 \
- && pip3 install mkl==2018.0.3 \
+# TODO having trouble installing intel-openmp and mkl on a Mac. Commenting for now.
+ #&& pip3 install intel-openmp==2018.0.0 \
+ #&& pip3 install mkl==2018.0.3 \
  && pip3 install readline==6.2 \
  && pip3 install setuptools==42.0.2 \
  && pip3 install wheel

--- a/terra-jupyter-python/Dockerfile
+++ b/terra-jupyter-python/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:0.0.6
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:0.0.7
 USER root
 #this makes it so pip runs as root, not the user
 ENV PIP_USER=false
@@ -35,7 +35,6 @@ RUN pip3 -V \
  && pip3 install google-cloud-datastore==1.10.0 \
  && pip3 install google-cloud-resource-manager==0.30.0 \
  && pip3 install google-cloud-storage==1.23.0 \
- && pip3 install --ignore-installed firecloud==0.16.25 \
  && pip3 install scikit-learn==0.20.0 \
  && pip3 install statsmodels==0.9.0 \
  && pip3 install ggplot==0.11.5 \

--- a/terra-jupyter-python/Dockerfile
+++ b/terra-jupyter-python/Dockerfile
@@ -74,9 +74,8 @@ RUN pip3 -V \
  && pip3 install tqdm==4.19.4 \
  && pip3 install werkzeug==0.12.2 \
  && pip3 install certifi==2017.4.17 \
-# TODO having trouble installing intel-openmp and mkl on a Mac. Commenting for now.
- #&& pip3 install intel-openmp==2018.0.0 \
- #&& pip3 install mkl==2018.0.3 \
+ && pip3 install intel-openmp==2018.0.0 \
+ && pip3 install mkl==2018.0.3 \
  && pip3 install readline==6.2 \
  && pip3 install setuptools==42.0.2 \
  && pip3 install wheel

--- a/terra-jupyter-r/CHANGELOG.md
+++ b/terra-jupyter-r/CHANGELOG.md
@@ -3,7 +3,7 @@
 - Make docker image locally runnable with:
    - `docker run --rm -it -p 8000:8000 <image>`
 - Add FISS library
-Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:0.0.8`
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:0.0.9`
 
 ## 0.0.8 - 01/15/2020
 - Install reticulate.

--- a/terra-jupyter-r/CHANGELOG.md
+++ b/terra-jupyter-r/CHANGELOG.md
@@ -1,39 +1,45 @@
+## 0.0.9 - 01/17/2020
+- Update `terra-jupyter-base` version to `0.0.7`
+- Make docker image locally runnable with:
+   - `docker run --rm -it -p 8000:8000 <image>`
+- Add FISS library
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:0.0.8`
+
 ## 0.0.8 - 01/15/2020
 - Install reticulate.
 - Update `terra-jupyter-r` version to `0.0.8`
-`Image URL: us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:0.0.8`
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:0.0.8`
 
 ## 0.0.7 - 11/26/2019
 - Update Bioconductor version to 3.10.
 - Fix `WORKSPACE_BUCKET` environment variable
 - Update `terra-jupyter-r` version to `0.0.7`
-`Image URL: us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:0.0.7`
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:0.0.7`
 
 ## 0.0.6 - 11/22/2019
 - Update make recommended packages updatable.
 - Update `terra-jupyter-r` version to `0.0.6`
-`Image URL: us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:0.0.6`
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:0.0.6`
 
 ## 0.0.5 - 11/16/2019
 - Update `terra-jupyter-base` version to `0.0.5`
 - Remove apt-get upgrade for security purposes
-`Image URL: us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:0.0.5`
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:0.0.5`
 
 ## 0.0.4 - 10/18/2019
 - Update `terra-jupyter-base` version to `0.0.4`
-`Image URL: us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:0.0.4`
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:0.0.4`
 
 ## 0.0.3 - 09/03/2019
 - Install all R packages in same location.
 - Make packges updatable with `BiocManager::valid()`
-`Image URL: us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:0.0.3`
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:0.0.3`
 
 ## 0.0.2 - 08/28/2019
 - Add devtools R package
 - Remove spark
-`Image URL: us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:0.0.2`
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:0.0.2`
 
 ## 0.0.1 - 08/21/2019
 - Add R 3.6
-
-`Image URL: us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:0.0.1`
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:0.0.1`

--- a/terra-jupyter-r/CHANGELOG.md
+++ b/terra-jupyter-r/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Make docker image locally runnable with:
    - `docker run --rm -it -p 8000:8000 <image>`
 - Add FISS library
+- Add OpenJDK 11
 Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:0.0.9`
 
 ## 0.0.8 - 01/15/2020

--- a/terra-jupyter-r/Dockerfile
+++ b/terra-jupyter-r/Dockerfile
@@ -3,7 +3,8 @@ USER root
 
 COPY scripts $JUPYTER_HOME/scripts
 
-RUN find $JUPYTER_HOME/scripts -name '*.sh' -type f | xargs chmod +x
+RUN find $JUPYTER_HOME/scripts -name '*.sh' -type f | xargs chmod +x \
+ && $JUPYTER_HOME/scripts/kernel/kernelspec.sh $JUPYTER_HOME/scripts/kernel /usr/local/share/jupyter/kernels
 
 # https://cran.r-project.org/bin/linux/ubuntu/README.html
 RUN apt-get update \

--- a/terra-jupyter-r/Dockerfile
+++ b/terra-jupyter-r/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:0.0.6
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:0.0.7
 USER root
 
 COPY scripts $JUPYTER_HOME/scripts


### PR DESCRIPTION
Not fully tested yet. This resolves a few tickets:

1. https://broadworkbench.atlassian.net/browse/IA-1602 (make docker images runnable locally)
2. https://broadworkbench.atlassian.net/browse/IA-1617 (install FISS in base image)
3. https://broadworkbench.atlassian.net/browse/IA-1624 (gatk label should be all caps)
4. https://broadworkbench.atlassian.net/browse/IA-1629 (add openjdk to the base image)

Also, while I'm updating the base, let me know if there are other updates we should make!