### PR TITLE
[IA-1637] Hail jobs fail with "mismatched python version"

### DIFF
--- a/config/conf.json
+++ b/config/conf.json
@@ -30,7 +30,7 @@
             "base_label": "Hail",
             "tools": ["python"],
             "packages": { "python": ["hail"] },
-            "version": "0.0.6",
+            "version": "0.0.7",
             "automated_flags": {
                 "generate_docs": true,
                 "include_in_ui": true,

--- a/terra-jupyter-hail/CHANGELOG.md
+++ b/terra-jupyter-hail/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 - Specify PYSPARK_PYTHON="python3" in Jupyter kernel to resolve pyspark python mismatch errors
    - See https://broadworkbench.atlassian.net/browse/IA-1637
-- Upgrade Hail to 0.2.31
-   - Release notes here: https://hail.is/docs/0.2/change_log.html#version-0-2-31
 
 Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-hail:0.0.7`
 

--- a/terra-jupyter-hail/CHANGELOG.md
+++ b/terra-jupyter-hail/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.0.7 - 01/27/2020
+
+- Specify PYSPARK_PYTHON="python3" in Jupyter kernel to resolve pyspark python mismatch errors
+   - See https://broadworkbench.atlassian.net/browse/IA-1637
+
 ## 0.0.6 - 01/17/2020
 
 - Update `terra-jupyter-python` version to `0.0.8`

--- a/terra-jupyter-hail/CHANGELOG.md
+++ b/terra-jupyter-hail/CHANGELOG.md
@@ -3,6 +3,8 @@
 - Specify PYSPARK_PYTHON="python3.6" in Jupyter kernel to resolve pyspark python mismatch errors
    - See https://broadworkbench.atlassian.net/browse/IA-1637
 
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-hail:0.0.7`
+
 ## 0.0.6 - 01/17/2020
 
 - Update `terra-jupyter-python` version to `0.0.8`

--- a/terra-jupyter-hail/CHANGELOG.md
+++ b/terra-jupyter-hail/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.0.7 - 01/27/2020
 
-- Specify PYSPARK_PYTHON="python3" in Jupyter kernel to resolve pyspark python mismatch errors
+- Specify PYSPARK_PYTHON="python3.6" in Jupyter kernel to resolve pyspark python mismatch errors
    - See https://broadworkbench.atlassian.net/browse/IA-1637
 
 ## 0.0.6 - 01/17/2020

--- a/terra-jupyter-hail/CHANGELOG.md
+++ b/terra-jupyter-hail/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - Specify PYSPARK_PYTHON="python3" in Jupyter kernel to resolve pyspark python mismatch errors
    - See https://broadworkbench.atlassian.net/browse/IA-1637
+- Upgrade Hail to 0.2.31
+   - Release notes here: https://hail.is/docs/0.2/change_log.html#version-0-2-31
 
 Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-hail:0.0.7`
 

--- a/terra-jupyter-hail/CHANGELOG.md
+++ b/terra-jupyter-hail/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.0.7 - 01/27/2020
 
-- Specify PYSPARK_PYTHON="python3.6" in Jupyter kernel to resolve pyspark python mismatch errors
+- Specify PYSPARK_PYTHON="python3" in Jupyter kernel to resolve pyspark python mismatch errors
    - See https://broadworkbench.atlassian.net/browse/IA-1637
 
 Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-hail:0.0.7`

--- a/terra-jupyter-hail/Dockerfile
+++ b/terra-jupyter-hail/Dockerfile
@@ -5,7 +5,7 @@ COPY scripts $JUPYTER_HOME/scripts
 
 ENV PIP_USER=false
 ENV PYTHONPATH $PYTHONPATH:/usr/lib/spark/python
-ENV HAIL_VERSION=0.2.31
+ENV HAIL_VERSION=0.2.30
 
 RUN find $JUPYTER_HOME/scripts -name '*.sh' -type f | xargs chmod +x \
     && $JUPYTER_HOME/scripts/kernel/kernelspec.sh $JUPYTER_HOME/scripts/kernel /usr/local/share/jupyter/kernels \

--- a/terra-jupyter-hail/Dockerfile
+++ b/terra-jupyter-hail/Dockerfile
@@ -5,7 +5,7 @@ COPY scripts $JUPYTER_HOME/scripts
 
 ENV PIP_USER=false
 ENV PYTHONPATH $PYTHONPATH:/usr/lib/spark/python
-ENV HAIL_VERSION=0.2.30
+ENV HAIL_VERSION=0.2.31
 
 RUN find $JUPYTER_HOME/scripts -name '*.sh' -type f | xargs chmod +x \
     && $JUPYTER_HOME/scripts/kernel/kernelspec.sh $JUPYTER_HOME/scripts/kernel /usr/local/share/jupyter/kernels \

--- a/terra-jupyter-hail/Dockerfile
+++ b/terra-jupyter-hail/Dockerfile
@@ -1,7 +1,9 @@
 FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.8
 USER root
-ENV PIP_USER=false
 
+COPY scripts $JUPYTER_HOME/scripts
+
+ENV PIP_USER=false
 ENV PYTHONPATH $PYTHONPATH:/usr/lib/spark/python
 ENV HAIL_VERSION=0.2.30
 

--- a/terra-jupyter-hail/Dockerfile
+++ b/terra-jupyter-hail/Dockerfile
@@ -7,9 +7,11 @@ ENV PIP_USER=false
 ENV PYTHONPATH $PYTHONPATH:/usr/lib/spark/python
 ENV HAIL_VERSION=0.2.30
 
-# Note Spark and Hadoop are mounted from the outside Dataproc VM.
-# Make empty conf dirs for the update-alternatives commands.
-RUN mkdir -p /etc/spark/conf.dist && mkdir -p /etc/hadoop/conf.empty && mkdir -p /etc/hive/conf.dist \
+RUN find $JUPYTER_HOME/scripts -name '*.sh' -type f | xargs chmod +x \
+    && $JUPYTER_HOME/scripts/kernel/kernelspec.sh $JUPYTER_HOME/scripts/kernel /usr/local/share/jupyter/kernels \
+    # Note Spark and Hadoop are mounted from the outside Dataproc VM.
+    # Make empty conf dirs for the update-alternatives commands.
+    && mkdir -p /etc/spark/conf.dist && mkdir -p /etc/hadoop/conf.empty && mkdir -p /etc/hive/conf.dist \
     && update-alternatives --install /etc/spark/conf spark-conf /etc/spark/conf.dist 100 \
     && update-alternatives --install /etc/hadoop/conf hadoop-conf /etc/hadoop/conf.empty 100 \
     && update-alternatives --install /etc/hive/conf hive-conf /etc/hive/conf.dist 100 \
@@ -26,7 +28,9 @@ RUN mkdir -p /etc/spark/conf.dist && mkdir -p /etc/hadoop/conf.empty && mkdir -p
     && (cd $X && pip3 download hail==$HAIL_VERSION --no-dependencies && \
         unzip hail*.whl &&  \
         grep 'Requires-Dist: ' hail*dist-info/METADATA | sed 's/Requires-Dist: //' | sed 's/ (//' | sed 's/)//' | grep -v 'pyspark' | xargs pip install) \
-    && rm -rf $X
+    && rm -rf $X \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 ENV PIP_USER=true
 USER $USER

--- a/terra-jupyter-hail/scripts/kernel/kernelspec.sh
+++ b/terra-jupyter-hail/scripts/kernel/kernelspec.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+TMP_KERNELSPEC_DIR=$1
+KERNELSPEC_HOME=$2
+
+# Replace the contents of the Python kernel scripts
+sed -e 's/${PY_VERSION}/3/g' -e 's|${JUPYTER_HOME}|'${JUPYTER_HOME}'|g' ${TMP_KERNELSPEC_DIR}/python_kernelspec.tmpl > ${KERNELSPEC_HOME}/python3/kernel.json

--- a/terra-jupyter-hail/scripts/kernel/kernelspec.sh
+++ b/terra-jupyter-hail/scripts/kernel/kernelspec.sh
@@ -4,4 +4,4 @@ TMP_KERNELSPEC_DIR=$1
 KERNELSPEC_HOME=$2
 
 # Replace the contents of the Python kernel scripts
-sed -e 's/${PY_VERSION}/3.6/g' -e 's|${JUPYTER_HOME}|'${JUPYTER_HOME}'|g' ${TMP_KERNELSPEC_DIR}/python_kernelspec.tmpl > ${KERNELSPEC_HOME}/python3/kernel.json
+sed -e 's/${PY_VERSION}/3/g' -e 's|${JUPYTER_HOME}|'${JUPYTER_HOME}'|g' ${TMP_KERNELSPEC_DIR}/python_kernelspec.tmpl > ${KERNELSPEC_HOME}/python3/kernel.json

--- a/terra-jupyter-hail/scripts/kernel/kernelspec.sh
+++ b/terra-jupyter-hail/scripts/kernel/kernelspec.sh
@@ -4,4 +4,4 @@ TMP_KERNELSPEC_DIR=$1
 KERNELSPEC_HOME=$2
 
 # Replace the contents of the Python kernel scripts
-sed -e 's/${PY_VERSION}/3/g' -e 's|${JUPYTER_HOME}|'${JUPYTER_HOME}'|g' ${TMP_KERNELSPEC_DIR}/python_kernelspec.tmpl > ${KERNELSPEC_HOME}/python3/kernel.json
+sed -e 's/${PY_VERSION}/3.6/g' -e 's|${JUPYTER_HOME}|'${JUPYTER_HOME}'|g' ${TMP_KERNELSPEC_DIR}/python_kernelspec.tmpl > ${KERNELSPEC_HOME}/python3/kernel.json

--- a/terra-jupyter-hail/scripts/kernel/python_kernelspec.tmpl
+++ b/terra-jupyter-hail/scripts/kernel/python_kernelspec.tmpl
@@ -1,0 +1,15 @@
+{
+ "language": "python",
+ "display_name": "Python ${PY_VERSION}",
+ "argv": [
+  "${JUPYTER_HOME}/scripts/kernel/kernel_bootstrap.sh",
+  "python${PY_VERSION}",
+  "-m",
+  "ipykernel_launcher",
+  "-f",
+  "{connection_file}"
+ ],
+ "env": {
+  "PYSPARK_PYTHON": "python${PY_VERSION}"
+ }
+}


### PR DESCRIPTION
The main fix is to specify the `PYSPARK_PYTHON=python3` env variable in the kernel definition. Otherwise it seems to default to python 2.7. See: https://cloud.google.com/dataproc/docs/tutorials/python-configuration