### PR TITLE
Jc fix build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -10,7 +10,7 @@ TAG_NAME=$(git log --pretty=format:'%h' -n 1)
 GCR_IMAGE_REPO=$(cat config/conf.json | jq -r .gcr_image_repo)
 
 #for some reason, this command fails if the script is in strict mode because grep not finding something exits with 1
-#we grep for "$VERSION," because the result we are interested will always be of the form "$VERSION,$GIT_HASH" and this ensures we don't match on substrings
+#we grep for "$VERSION," because the result we are interested will always be of the form " $VERSION,$GIT_HASH " and this ensures we don't match on substrings
 #This is subject to being broken if we tag/push the images in a different order.  
 IMAGE_EXISTS=$(gcloud container images list-tags $GCR_IMAGE_REPO/$IMAGE_DIR | grep " $VERSION,") || true
 

--- a/build.sh
+++ b/build.sh
@@ -56,6 +56,8 @@ docker run --rm -itd -u root -e PIP_USER=false --entrypoint='/bin/bash' --name $
 gcloud auth list
 python scripts/generate_package_docs.py "$IMAGE_DIR"
 
+docker kill $IMAGE_DIR || true 
+docker rm -f $IMAGE_DIR || true
 docker image rm -f $GCR_IMAGE_REPO/$IMAGE_DIR:$VERSION
 docker image rm -f $GCR_IMAGE_REPO/$IMAGE_DIR:$TAG_NAME
 

--- a/build.sh
+++ b/build.sh
@@ -12,7 +12,7 @@ GCR_IMAGE_REPO=$(cat config/conf.json | jq -r .gcr_image_repo)
 #for some reason, this command fails if the script is in strict mode because grep not finding something exits with 1
 #we grep for "$VERSION," because the result we are interested will always be of the form " $VERSION,$GIT_HASH " and this ensures we don't match on substrings
 #This is subject to being broken if we tag/push the images in a different order.  
-IMAGE_EXISTS=$(gcloud container images list-tags $GCR_IMAGE_REPO/$IMAGE_DIR | grep " $VERSION,") || true
+IMAGE_EXISTS=$(gcloud container images list-tags  --filter="TAGS~^$VERSION$" $GCR_IMAGE_REPO/$IMAGE_DIR)
 
 if [ -z "$IMAGE_EXISTS" ]; then
     echo "An image for this version does not exist. Proceeding with build"

--- a/build.sh
+++ b/build.sh
@@ -10,7 +10,9 @@ TAG_NAME=$(git log --pretty=format:'%h' -n 1)
 GCR_IMAGE_REPO=$(cat config/conf.json | jq -r .gcr_image_repo)
 
 #for some reason, this command fails if the script is in strict mode because grep not finding something exits with 1
-IMAGE_EXISTS=$(gcloud container images list-tags $GCR_IMAGE_REPO/$IMAGE_DIR | grep $VERSION) | true
+#we grep for "$VERSION," because the result we are interested will always be of the form "$VERSION,$GIT_HASH" and this ensures we don't match on substrings
+#This is subject to being broken if we tag/push the images in a different order.  
+IMAGE_EXISTS=$(gcloud container images list-tags $GCR_IMAGE_REPO/$IMAGE_DIR | grep $VERSION,) || true
 
 if [ -z "$IMAGE_EXISTS" ]; then
     echo "An image for this version does not exist. Proceeding with build"
@@ -47,8 +49,8 @@ if [ $IMAGE_DIR = "terra-jupyter-gatk" ]; then
   docker push broadinstitute/$IMAGE_DIR:$TAG_NAME
 fi
 
-docker kill $IMAGE_DIR | true 
-docker rm -f $IMAGE_DIR | true
+docker kill $IMAGE_DIR || true 
+docker rm -f $IMAGE_DIR || true
 docker run --rm -itd -u root -e PIP_USER=false --entrypoint='/bin/bash' --name $IMAGE_DIR $GCR_IMAGE_REPO/$IMAGE_DIR:$VERSION
 
 gcloud auth list

--- a/build.sh
+++ b/build.sh
@@ -9,9 +9,7 @@ VERSION=$(cat config/conf.json | jq -r ".image_data | .[] | select(.name == \"$I
 TAG_NAME=$(git log --pretty=format:'%h' -n 1)
 GCR_IMAGE_REPO=$(cat config/conf.json | jq -r .gcr_image_repo)
 
-#for some reason, this command fails if the script is in strict mode because grep not finding something exits with 1
-#we grep for "$VERSION," because the result we are interested will always be of the form " $VERSION,$GIT_HASH " and this ensures we don't match on substrings
-#This is subject to being broken if we tag/push the images in a different order.  
+#below is a regex to match strictly on $VERSION, not any tags which have a substring of $VERSION
 IMAGE_EXISTS=$(gcloud container images list-tags  --filter="TAGS~^$VERSION$" $GCR_IMAGE_REPO/$IMAGE_DIR)
 
 if [ -z "$IMAGE_EXISTS" ]; then

--- a/build.sh
+++ b/build.sh
@@ -12,7 +12,7 @@ GCR_IMAGE_REPO=$(cat config/conf.json | jq -r .gcr_image_repo)
 #for some reason, this command fails if the script is in strict mode because grep not finding something exits with 1
 #we grep for "$VERSION," because the result we are interested will always be of the form "$VERSION,$GIT_HASH" and this ensures we don't match on substrings
 #This is subject to being broken if we tag/push the images in a different order.  
-IMAGE_EXISTS=$(gcloud container images list-tags $GCR_IMAGE_REPO/$IMAGE_DIR | grep $VERSION,) || true
+IMAGE_EXISTS=$(gcloud container images list-tags $GCR_IMAGE_REPO/$IMAGE_DIR | grep " $VERSION,") || true
 
 if [ -z "$IMAGE_EXISTS" ]; then
     echo "An image for this version does not exist. Proceeding with build"


### PR DESCRIPTION
- prevents IMAGE_EXISTS being triggered on VERSIONS containing a substring of the VERSION we care about
- changes from pipe to or to avoid termination on failed commands, which was messing up line 15