### PR TITLE
[IA-1706] Install JDK 8 in the gatk image

### DIFF
--- a/config/conf.json
+++ b/config/conf.json
@@ -82,7 +82,7 @@
             "base_label": "New Default (released on January 14)",
             "tools": ["gatk", "python", "r"],
             "packages": {},
-            "version": "0.0.12",
+            "version": "0.0.13",
             "automated_flags": {
                 "include_in_ui": true,
                 "generate_docs": true,

--- a/terra-jupyter-gatk/CHANGELOG.md
+++ b/terra-jupyter-gatk/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.0.13 - 02/26/2020
 
-- Install OpenJDK 8
+- Install OpenJDK 8 instead of OpenJDK 11 to be compatible with GATK
    - Fixes https://broadworkbench.atlassian.net/browse/IA-1706
 
 Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:0.0.13`

--- a/terra-jupyter-gatk/CHANGELOG.md
+++ b/terra-jupyter-gatk/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.0.13 - 02/26/2020
+
+- Install OpenJDK 8
+   - Fixes https://broadworkbench.atlassian.net/browse/IA-1706
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:0.0.13`
+
 ## 0.0.12 - 02/25/2020
 
 - Update `terra-jupyter-python` version to `0.0.10`

--- a/terra-jupyter-gatk/Dockerfile
+++ b/terra-jupyter-gatk/Dockerfile
@@ -11,6 +11,7 @@ USER root
 RUN apt-get update && apt-get install -yq --no-install-recommends \
   python3.7-dev \
   python-tk \
+  openjdk-8-jdk \
   tk-dev \
   libssl-dev \
   xz-utils \
@@ -21,6 +22,8 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
   zlib1g-dev \
   libz-dev \
   samtools \
+  # specify Java 8
+  && update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
See https://broadworkbench.atlassian.net/browse/IA-1706

We currently install Java 11. Apparently GATK requires exactly Java 8:

https://gatk.broadinstitute.org/hc/en-us/articles/360035889531

> Java 8 / JRE or SDK 1.8
> The GATK is a Java-based program, so you'll need to have Java installed on your machine. The Java runtime version should be at 1.8 exactly. To be clear: we do not yet support 1.9, and older versions (1.6 and 1.7) no longer work. You can check what version you have by typing java -version at the command line. This article has some more details about what to do if you don't have the right version. Both the Sun/Oracle Java JDK and OpenJDK versions are fully supported.