### PR TITLE
[IA-1805] add requiresSpark flag to UI-facing documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,9 @@ To launch an image through Terra, navigate to https://app.terra.bio, select a wo
 
 There is a config file located at `config/conf.json` that contains the configuration used by all automated jobs and build scripts that interface with this repo. 
 
+There is a field for "spark_version" top-level which must be updated if we update the debian version used in the custom image. 
+Currently it assumes 1.4x https://cloud.google.com/dataproc/docs/concepts/versioning/dataproc-release-1.4
+
 There are some constants included, such as the tools supported by this repo. Of particular interest is the image_data array.
 
 Each time you update or add an image, you will need to update the appropriate entry in this array:
@@ -108,9 +111,13 @@ Each time you update or add an image, you will need to update the appropriate en
 
         "build": true,            //Whether or not the jenkins job that builds the docker images in this repo should build this image
 
-        "include_in_custom_dataproc": true  //Whether or not the jenkins job that builds the custom dataproc image should include this image. 
+        "include_in_custom_dataproc": true,  //Whether or not the jenkins job that builds the custom dataproc image should include this image. 
                                             //This is superceded by the build flag
-    }
+        "include_in_ui": true, // Whether or not this should be included in the .json file that power the terra ui dropdown for available images
+        "include_in_custom_gce": true, //Whether or not the jenkins job that builds the custom gce image should include this image.
+                                 //This is superceded by the build flag   
+        "requires_spark": true // Whether or not this image requires a dataproc cluster to run (as opposed to most, which just need a GCE VM)
+    }   
 },
 ```
 

--- a/config/conf.json
+++ b/config/conf.json
@@ -4,14 +4,14 @@
         "python",
         "r",
         "gatk",
-        "spark",
-        "samtools"
+        "spark"
     ],
     "version_master_file": "terra-docker-versions-new.json",
     "doc_suffix": "versions.json",
     "gcr_image_repo": "us.gcr.io/broad-dsp-gcr-public",
     "doc_bucket": "gs://terra-docker-image-documentation",
     "doc_bucket_no_prefix": "terra-docker-image-documentation",
+    "spark_version": "2.4.5",
     "image_data": [{
             "name": "terra-jupyter-bioconductor",
             "base_label": "Bioconductor",
@@ -29,7 +29,7 @@
         {
             "name": "terra-jupyter-hail",
             "base_label": "Hail",
-            "tools": ["python"],
+            "tools": ["python", "spark"],
             "packages": { "python": ["hail"] },
             "version": "0.0.9",
             "automated_flags": {

--- a/scripts/generate_version_docs.py
+++ b/scripts/generate_version_docs.py
@@ -50,7 +50,8 @@ def generate_doc_for_image(image_config):
     "version": version,
     "updated": get_last_updated(image_config),
     "packages": get_doc_link(image_config),
-    "image": "{}/{}:{}".format(config['gcr_image_repo'], image_dir, version)
+    "image": "{}/{}:{}".format(config['gcr_image_repo'], image_dir, version),
+    "requiresSpark": "spark" in image_config["tools"]
   }
 
   return doc
@@ -101,7 +102,8 @@ def get_static_legacy_doc():
     "version": 'FINAL',
     "updated": '2019-08-26',
     "packages": 'https://storage.googleapis.com/terra-docker-image-documentation/leonardo-jupyter-dev-versions.json',
-    "image": 'us.gcr.io/broad-dsp-gcr-public/leonardo-jupyter:5c51ce6935da'
+    "image": 'us.gcr.io/broad-dsp-gcr-public/leonardo-jupyter:5c51ce6935da',
+    "requiresSpark": True
   }
 
   return doc


### PR DESCRIPTION
- doc scripts updated to have docs include requiresSpark
- hail doc updated to include spark version

I chose to refactor the usage of 'tools' so that 'spark' is actually a valid tool instead of duplicating spark as a flag in `conf.json`

I've uploaded the new hail doc with the spark version, but I haven't renamed the `..versions-new.json` file that terra reads from yet (aka hail docs in UI are live with spark version, but requireSpark flag isn't included yet).

After merge I will need to rename the `-new.json` file for this to take effect.
