### PR TITLE
IA-1856 Compile pysam explicitly with google cloud support

### DIFF
--- a/config/conf.json
+++ b/config/conf.json
@@ -45,7 +45,7 @@
             "base_label": "Python",
             "tools": ["python"],
             "packages": { "python": ["pandas", "scikit-learn"] },
-            "version": "0.0.10",
+            "version": "0.0.11",
             "automated_flags": {
                 "generate_docs": true,
                 "include_in_ui": true,

--- a/terra-jupyter-python/CHANGELOG.md
+++ b/terra-jupyter-python/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.0.11 - 04/17/2020
+
+- Add Google Cloud support to pysam.
+   
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.11`
+
 ## 0.0.10 - 02/25/2020
 
 - Update `terra-jupyter-base` version to `0.0.9`

--- a/terra-jupyter-python/Dockerfile
+++ b/terra-jupyter-python/Dockerfile
@@ -80,7 +80,7 @@ RUN pip3 -V \
  && pip3 install wheel
 
 ENV HTSLIB_CONFIGURE_OPTIONS="--enable-plugins --enable-libcurl --enable-gcs"
-pip3 install pysam==0.15.4 --no-binary pysam
+pip3 install Cython && pip3 install pysam==0.15.4 --no-binary pysam
 
 ENV USER jupyter-user
 USER $USER

--- a/terra-jupyter-python/Dockerfile
+++ b/terra-jupyter-python/Dockerfile
@@ -62,7 +62,6 @@ RUN pip3 -V \
  && pip3 install protobuf==3.7.1 \
  && pip3 install pymc3==3.1 \
  && pip3 install pyparsing==2.2.0 \
- && pip3 install pysam==0.15.1 \
  && pip3 install python-dateutil==2.6.1 \
  && pip3 install pytz==2017.3 \
  && pip3 install pyvcf==0.6.8 \
@@ -79,6 +78,9 @@ RUN pip3 -V \
  && pip3 install readline==6.2 \
  && pip3 install setuptools==42.0.2 \
  && pip3 install wheel
+
+ENV HTSLIB_CONFIGURE_OPTIONS="--enable-plugins --enable-libcurl --enable-gcs”
+pip3 install pysam==0.15.4 --no-binary pysam
 
 ENV USER jupyter-user
 USER $USER

--- a/terra-jupyter-python/Dockerfile
+++ b/terra-jupyter-python/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
   liblzo2-dev \
   zlib1g-dev \
   libz-dev \
+  libcurl4-openssl-dev \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
@@ -79,7 +80,7 @@ RUN pip3 -V \
  && pip3 install setuptools==42.0.2 \
  && pip3 install wheel
 
-ENV HTSLIB_CONFIGURE_OPTIONS="--enable-plugins --enable-libcurl --enable-gcs"
+ENV HTSLIB_CONFIGURE_OPTIONS="--enable-gcs"
 pip3 install Cython && pip3 install pysam==0.15.4 --no-binary pysam
 
 ENV USER jupyter-user

--- a/terra-jupyter-python/Dockerfile
+++ b/terra-jupyter-python/Dockerfile
@@ -79,7 +79,7 @@ RUN pip3 -V \
  && pip3 install setuptools==42.0.2 \
  && pip3 install wheel
 
-ENV HTSLIB_CONFIGURE_OPTIONS="--enable-plugins --enable-libcurl --enable-gcs”
+ENV HTSLIB_CONFIGURE_OPTIONS="--enable-plugins --enable-libcurl --enable-gcs"
 pip3 install pysam==0.15.4 --no-binary pysam
 
 ENV USER jupyter-user

--- a/terra-jupyter-python/Dockerfile
+++ b/terra-jupyter-python/Dockerfile
@@ -19,6 +19,8 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
+ENV HTSLIB_CONFIGURE_OPTIONS="--enable-gcs"
+
 RUN pip3 -V \
  && pip3 install --upgrade pip \
  && pip3 install numpy==1.15.2 \
@@ -63,6 +65,8 @@ RUN pip3 -V \
  && pip3 install protobuf==3.7.1 \
  && pip3 install pymc3==3.1 \
  && pip3 install pyparsing==2.2.0 \
+ && pip3 install Cython \
+ && pip3 install pysam==0.15.4 --no-binary pysam \
  && pip3 install python-dateutil==2.6.1 \
  && pip3 install pytz==2017.3 \
  && pip3 install pyvcf==0.6.8 \

--- a/terra-jupyter-python/Dockerfile
+++ b/terra-jupyter-python/Dockerfile
@@ -84,9 +84,6 @@ RUN pip3 -V \
  && pip3 install setuptools==42.0.2 \
  && pip3 install wheel
 
-ENV HTSLIB_CONFIGURE_OPTIONS="--enable-gcs"
-pip3 install Cython && pip3 install pysam==0.15.4 --no-binary pysam
-
 ENV USER jupyter-user
 USER $USER
 #we want pip to install into the user's dir when the notebook is running


### PR DESCRIPTION
Google bucket support of pysam is not enabled by default in the PyPI package. It would be great to enable it explicitly in the docker file.