### PR TITLE
terra-jupyter-r:0.0.12

### DIFF
--- a/config/conf.json
+++ b/config/conf.json
@@ -73,7 +73,7 @@
             "base_label": "R",
             "tools": ["r"],
             "packages": {},
-            "version": "0.0.11",
+            "version": "0.0.12",
             "automated_flags": {
                 "include_in_ui": false,
                 "generate_docs": true,

--- a/terra-jupyter-r/CHANGELOG.md
+++ b/terra-jupyter-r/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.0.12 - 04/15/2020
+- Update `terra-jupyter-r` version to `0.0.12`
+- Install most system dependencies needed for CRAN and Bioconductor packages.
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:0.0.12`
+
 ## 0.0.11 - 02/25/2020
 - Update `terra-jupyter-base` version to `0.0.9`
    - Fixes https://broadworkbench.atlassian.net/browse/IA-1676

--- a/terra-jupyter-r/Dockerfile
+++ b/terra-jupyter-r/Dockerfile
@@ -3,6 +3,11 @@ USER root
 
 COPY scripts $JUPYTER_HOME/scripts
 
+# Add env vars to identify binary package installation
+ENV R_PLATFORM="terra-jupyter-r"
+ENV R_PLATFORM_BINARY_VERSION=0.99.0
+
+
 RUN find $JUPYTER_HOME/scripts -name '*.sh' -type f | xargs chmod +x \
  && $JUPYTER_HOME/scripts/kernel/kernelspec.sh $JUPYTER_HOME/scripts/kernel /usr/local/share/jupyter/kernels
 
@@ -23,10 +28,96 @@ RUN apt-get update \
 	libgfortran-7-dev \
 	r-base-dev \
 	r-base-core \
+	## This section installs libraries
+	libnetcdf-dev \
+	libhdf5-serial-dev \
+	libfftw3-dev \
+	libopenbabel-dev \
+	libopenmpi-dev \
+	libexempi3 \
+	libgdal-dev \
+	libcairo2-dev \
+	libtiff5-dev \
+	libgsl0-dev \
+	libgtk2.0-dev \
+	libgl1-mesa-dev \
+	libglu1-mesa-dev \
+	libgmp3-dev \
+	libhdf5-dev \
+	libncurses-dev \
+	libxpm-dev \
+	libv8-3.14-dev \
+	libgtkmm-2.4-dev \
+	libmpfr-dev \
+	libudunits2-dev \
+	libmodule-build-perl \
+	libapparmor-dev \
+	libgeos-dev \
+	libprotoc-dev \
+	librdf0-dev \
+	libmagick++-dev \
+	libsasl2-dev \
+	libpoppler-cpp-dev \
+	libprotobuf-dev \
+	libpq-dev \
+	libperl-dev \
+	## software - perl extentions and modules
+	libarchive-extract-perl \
+	libfile-copy-recursive-perl \
+	libcgi-pm-perl \
+	libdbi-perl \
+	libdbd-mysql-perl \
+	libxml-simple-perl \
+	## Databases and other software
+	sqlite \
+	mpi-default-bin \
+	openmpi-common \
+	tcl8.5-dev \
+	imagemagick \
+	tabix \
+	ggobi \
+	graphviz \
+	protobuf-compiler \
+	jags \
+	## Additional resources
+	xfonts-100dpi \
+	xfonts-75dpi \
+	biber \
     && ln -s /usr/lib/gcc/x86_64-linux-gnu/7/libgfortran.so /usr/lib/x86_64-linux-gnu/libgfortran.so \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
+# Install libsbml
+RUN cd /tmp \
+    && curl -O https://s3.amazonaws.com/linux-provisioning/libSBML-5.10.2-core-src.tar.gz \
+    && tar zxf libSBML-5.10.2-core-src.tar.gz \
+    && cd libsbml-5.10.2 \
+    && ./configure --enable-layout \
+    && make \
+    && make install \
+    && ldconfig \
+    && rm -rf /tmp/libsbml-5.10.2 \
+    && rm -rf /tmp/libSBML-5.10.2-core-src.tar.gz
+
+## set pip3 to run as root, not as jupyter-user
+ENV PIP_USER=false
+
+## Install python packages needed for a few Bioc packages
+RUN apt-get update \
+    && apt-get install -yq --no-install-recommends python3.7-dev \
+    && pip3 -V \
+    && pip3 install --upgrade pip \
+    && pip3 install cwltool==1.0.20190228155703 \
+    && pip3 install pandas==0.25.3 \
+    && pip3 install pyyaml \
+    && pip3 install scikit-learn==0.21.3 \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+## pip runs as jupyter-user
+ENV PIP_USER=true
+
+## Change back to jupyter-user
 USER $USER
 
 ## Reasons for change, 1. Message during installation, 2. User cannot
@@ -34,17 +125,9 @@ USER $USER
 
 RUN mkdir -p /home/jupyter-user/.rpackages \
     && echo "R_LIBS=/home/jupyter-user/.rpackages" > /home/jupyter-user/.Renviron \
-    && R -e 'install.packages(c( \
-    "remotes", \
-    "BiocManager", \
-    "devtools"))' \
-
+    && R -e 'install.packages("BiocManager")' \
+    ## check version
     && R -e 'BiocManager::install(version="3.10", ask=FALSE)' \
-
-    # fix for AoU-blocking bug https://github.com/rstudio/reticulate/issues/693
-    # after version 1.15 is released to CRAN, we can install reticulate in the standard way
-    && R -e 'BiocManager::install("rstudio/reticulate", ref="00172079")' \
-
     && R -e 'BiocManager::install(c( \
     "boot", \
     "class", \
@@ -69,8 +152,11 @@ RUN mkdir -p /home/jupyter-user/.rpackages \
     "bigrquery",  \
     "googleCloudStorageR", \
     # User oriented packages
+    "reticulate", \
+    "remotes", \
+    "devtools", \
     "tidyverse", \
     "pbdZMQ", \
     "uuid"))' \
-    && R -e 'IRkernel::installspec(user=FALSE)' \
+    && R -e 'IRkernel::installspec(user=TRUE)' \
     && chown -R $USER:users /home/jupyter-user/.local

--- a/terra-jupyter-r/README.md
+++ b/terra-jupyter-r/README.md
@@ -8,6 +8,8 @@ The terra-jupyter-r extends the [terra-jupyter-base](../terra-jupyter-base/READM
 
 - R 3.6
 
+- CRAN and Bioc 3.10 package system dependencies
+
 To see the complete contents of this image please see the [Dockerfile](./Dockerfile).
 
 ## Selecting prior versions of this image


### PR DESCRIPTION
- Create new entry in CHANGELOG file.

- This image will include most of CRAN and Bioconductor system dependencies.

- Makes the notebook actually useable by analysts.

- Remove Bioconductor packages

- Add environment variables R_PLATFORM and R_PLATFORM_BINARY_VERSION, these are needed to make the binary package installation of R packages.
