### PR TITLE
Fix env variables name and bug fix

### DIFF
--- a/config/conf.json
+++ b/config/conf.json
@@ -73,7 +73,7 @@
             "base_label": "R",
             "tools": ["r"],
             "packages": {},
-            "version": "0.0.12",
+            "version": "0.0.13",
             "automated_flags": {
                 "include_in_ui": false,
                 "generate_docs": true,

--- a/terra-jupyter-r/CHANGELOG.md
+++ b/terra-jupyter-r/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.0.13 - 04/23/2020
+- Update `terra-jupyter-r` version to `0.0.13`
+- Change env var names to avoid conflict.
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:0.0.13`
+
 ## 0.0.12 - 04/15/2020
 - Update `terra-jupyter-r` version to `0.0.12`
 - Install most system dependencies needed for CRAN and Bioconductor packages.

--- a/terra-jupyter-r/Dockerfile
+++ b/terra-jupyter-r/Dockerfile
@@ -4,8 +4,8 @@ USER root
 COPY scripts $JUPYTER_HOME/scripts
 
 # Add env vars to identify binary package installation
-ENV R_PLATFORM="terra-jupyter-r"
-ENV R_PLATFORM_BINARY_VERSION=0.99.0
+ENV TERRA_R_PLATFORM="terra-jupyter-r"
+ENV TERRA_R_PLATFORM_BINARY_VERSION=0.99.0
 
 
 RUN find $JUPYTER_HOME/scripts -name '*.sh' -type f | xargs chmod +x \
@@ -158,5 +158,11 @@ RUN mkdir -p /home/jupyter-user/.rpackages \
     "tidyverse", \
     "pbdZMQ", \
     "uuid"))' \
-    && R -e 'IRkernel::installspec(user=TRUE)' \
     && chown -R $USER:users /home/jupyter-user/.local
+
+
+USER root
+
+RUN R -e 'IRkernel::installspec(user=FALSE)'
+
+USER $USER


### PR DESCRIPTION
This PR fixes the bug where env variables WORKSPACE_BUCKET and
WORKSPACE_NAME are not found.

Alters the names R_PLATFORM to TERRA_R_PLATFORM so that there is no
conflict between base R installation.