### PR TITLE
Fix bug in bioconductor image

### DIFF
--- a/config/conf.json
+++ b/config/conf.json
@@ -17,7 +17,7 @@
             "base_label": "Bioconductor",
             "tools": ["python", "r"],
             "packages": { "r": ["BiocVersion", "tidyverse"] },
-            "version": "0.0.13",
+            "version": "0.0.14",
             "automated_flags": {
                 "generate_docs": true,
                 "include_in_ui": true,

--- a/terra-jupyter-bioconductor/CHANGELOG.md
+++ b/terra-jupyter-bioconductor/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.0.14 - 04/28/2020
+
+- Fix bug in version `0.0.13`: switch back to `jupyter-user` at the end
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:0.0.14`
+
 ## 0.0.13 - 04/24/2020
           
 - Inherit from terra-jupyter-r:0.0.13

--- a/terra-jupyter-bioconductor/Dockerfile
+++ b/terra-jupyter-bioconductor/Dockerfile
@@ -6,3 +6,5 @@ USER root
 RUN curl -O https://raw.githubusercontent.com/Bioconductor/anvil-docker/master/anvil-rstudio-bioconductor/install.R \
 	&& R -f install.R \
 	&& rm -rf install.R
+
+USER $USER


### PR DESCRIPTION
All images need to launch as `jupyter-user`, not as `root`. Will run Leo automation tests against this.