### PR TITLE
Update to R-4.0.0

### DIFF
--- a/config/conf.json
+++ b/config/conf.json
@@ -17,7 +17,7 @@
             "base_label": "Bioconductor",
             "tools": ["python", "r"],
             "packages": { "r": ["BiocVersion", "tidyverse"] },
-            "version": "0.0.15",
+            "version": "1.0.0",
             "automated_flags": {
                 "generate_docs": true,
                 "include_in_ui": true,
@@ -73,7 +73,7 @@
             "base_label": "R",
             "tools": ["r"],
             "packages": {},
-            "version": "0.0.14",
+            "version": "1.0.0",
             "automated_flags": {
                 "include_in_ui": false,
                 "generate_docs": true,
@@ -87,7 +87,7 @@
             "base_label": "New Default (released on January 14)",
             "tools": ["gatk", "python", "r"],
             "packages": {},
-            "version": "0.0.16",
+            "version": "1.0.0",
             "automated_flags": {
                 "include_in_ui": true,
                 "generate_docs": true,
@@ -101,7 +101,7 @@
             "base_label": "All of Us",
             "tools": ["python", "r"],
             "packages": {},
-            "version": "0.0.4",
+            "version": "1.0.0",
             "automated_flags": {
                 "include_in_ui": false,
                 "generate_docs": false,

--- a/terra-jupyter-aou/CHANGELOG.md
+++ b/terra-jupyter-aou/CHANGELOG.md
@@ -3,6 +3,8 @@
 - Update `terra-jupyter-aou` to version `1.0.0`
 - Update `terra-jupyter-r` base image to `1.0.0`
 
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:1.0.0`
+
 ## 0.0.4 - 05/18/2020
 
 - Update `terra-jupyter-python` base image to `0.0.12` and `terra-jupyter-r` base image to `0.0.14`

--- a/terra-jupyter-aou/CHANGELOG.md
+++ b/terra-jupyter-aou/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.0 - 05/21/2020
+
+- Update `terra-jupyter-aou` to version `1.0.0`
+- Update `terra-jupyter-r` base image to `1.0.0`
+
 ## 0.0.4 - 05/18/2020
 
 - Update `terra-jupyter-python` base image to `0.0.12` and `terra-jupyter-r` base image to `0.0.14`

--- a/terra-jupyter-aou/Dockerfile
+++ b/terra-jupyter-aou/Dockerfile
@@ -1,6 +1,6 @@
 FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.12 AS python
 
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:0.0.14
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.0
 
 # copy everything pip installed from the python image
 COPY --from=python /usr/local/lib/python3.7/dist-packages /usr/local/lib/python3.7/dist-packages

--- a/terra-jupyter-bioconductor/CHANGELOG.md
+++ b/terra-jupyter-bioconductor/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.0.0 - 05/21/2020
+
+- Inherit from terra-jupyter-r:1.0.0.
+- This version updates to R-4.0.0 and Bioconductor RELEASE_3_11.
+- Update `terra-jupyter-bioconductor` version to `1.0.0`
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:1.0.0`
+
 # 0.0.15 - 05/18/2020
 
 - Update `terra-jupyter-r` base image to `0.0.14`
@@ -12,18 +20,18 @@ Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:0.0.15`
 Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:0.0.14`
 
 ## 0.0.13 - 04/24/2020
-          
+
 - Inherit from terra-jupyter-r:0.0.13
 - Remove redundant system libraries.
 - Update `terra-jupyter-bioconductor` version to `0.0.13`.
- 
+
 Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:0.0.13`
 
 ## 0.0.12 - 02/25/2020
-          
+
 - Update `terra-jupyter-r` version to `0.0.11`
     - Fixes https://broadworkbench.atlassian.net/browse/IA-1676
- 
+
 Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:0.0.12`
 
 ## 0.0.11 - 02/05/2020

--- a/terra-jupyter-bioconductor/Dockerfile
+++ b/terra-jupyter-bioconductor/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:0.0.14
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.0
 
 USER root
 

--- a/terra-jupyter-gatk/CHANGELOG.md
+++ b/terra-jupyter-gatk/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.0.0 - 05/21/2020
+
+- Update `terra-jupyter-r` base image to `1.0.0`
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:1.0.0`
+
+
 ## 0.0.16 - 05/18/2020
 
 - Update `terra-jupyter-python` base image to `0.0.12` and `terra-jupyter-r` base image to `0.0.14`

--- a/terra-jupyter-gatk/Dockerfile
+++ b/terra-jupyter-gatk/Dockerfile
@@ -1,6 +1,6 @@
 FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.12 AS python
 
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:0.0.14
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.0
 
 # copy everything pip installed from the python image
 COPY --from=python /usr/local/lib/python3.7/dist-packages /usr/local/lib/python3.7/dist-packages

--- a/terra-jupyter-r/CHANGELOG.md
+++ b/terra-jupyter-r/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.0 - 05/21/2020
+- Update `terra-jupyter-r` version to `1.0.0`
+- Update R_VERSION to 4.0 and Bioconductor version to release 3.11.
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.0`
+
 ## 0.0.14 - 05/18/2020
 - Update `terra-jupyter-base` image version to `0.0.10`
    - Adds jupyter notebook extension collapsible headers and code-folding

--- a/terra-jupyter-r/Dockerfile
+++ b/terra-jupyter-r/Dockerfile
@@ -5,7 +5,7 @@ COPY scripts $JUPYTER_HOME/scripts
 
 # Add env vars to identify binary package installation
 ENV TERRA_R_PLATFORM="terra-jupyter-r"
-ENV TERRA_R_PLATFORM_BINARY_VERSION=0.99.0
+ENV TERRA_R_PLATFORM_BINARY_VERSION=0.99.1
 
 
 RUN find $JUPYTER_HOME/scripts -name '*.sh' -type f | xargs chmod +x \
@@ -14,7 +14,7 @@ RUN find $JUPYTER_HOME/scripts -name '*.sh' -type f | xargs chmod +x \
 # https://cran.r-project.org/bin/linux/ubuntu/README.html
 RUN apt-get update \
     && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9 \
-    && add-apt-repository 'deb https://cloud.r-project.org/bin/linux/ubuntu bionic-cran35/' \
+    && add-apt-repository 'deb https://cloud.r-project.org/bin/linux/ubuntu bionic-cran40/' \
     && apt-get install -yq --no-install-recommends apt-transport-https \
     && apt update \
     && apt install -yq --no-install-recommends \
@@ -127,7 +127,7 @@ RUN mkdir -p /home/jupyter-user/.rpackages \
     && echo "R_LIBS=/home/jupyter-user/.rpackages" > /home/jupyter-user/.Renviron \
     && R -e 'install.packages("BiocManager")' \
     ## check version
-    && R -e 'BiocManager::install(version="3.10", ask=FALSE)' \
+    && R -e 'BiocManager::install(version="3.11", ask=FALSE)' \
     && R -e 'BiocManager::install(c( \
     "boot", \
     "class", \


### PR DESCRIPTION
- Update terra-jupyter-r to include the latest release version of R,
R-4.0.0

- terra-jupyter-r also updates the Bioconductor version to release 3.11.

- The terra-jupyter-bioconductor and terra-jupyter-aou images are
updated as a consequence of the updates to the terra-jupyter-r images.

- Updates to CHANGELOG.md in all the files.