### PR TITLE
Update install_jupyter_contrib_nbextensions.sh

### DIFF
--- a/config/conf.json
+++ b/config/conf.json
@@ -59,7 +59,7 @@
             "base_label": "Base",
             "tools": ["python"],
             "packages": {},
-            "version": "0.0.9",
+            "version": "0.0.10",
             "automated_flags": {
                 "generate_docs": true,
                 "include_in_ui": false,

--- a/config/conf.json
+++ b/config/conf.json
@@ -17,7 +17,7 @@
             "base_label": "Bioconductor",
             "tools": ["python", "r"],
             "packages": { "r": ["BiocVersion", "tidyverse"] },
-            "version": "0.0.14",
+            "version": "0.0.15",
             "automated_flags": {
                 "generate_docs": true,
                 "include_in_ui": true,
@@ -31,7 +31,7 @@
             "base_label": "Hail",
             "tools": ["python", "spark"],
             "packages": { "python": ["hail"] },
-            "version": "0.0.12",
+            "version": "0.0.13",
             "automated_flags": {
                 "generate_docs": true,
                 "include_in_ui": true,
@@ -45,7 +45,7 @@
             "base_label": "Python",
             "tools": ["python"],
             "packages": { "python": ["pandas", "scikit-learn"] },
-            "version": "0.0.11",
+            "version": "0.0.12",
             "automated_flags": {
                 "generate_docs": true,
                 "include_in_ui": true,
@@ -73,7 +73,7 @@
             "base_label": "R",
             "tools": ["r"],
             "packages": {},
-            "version": "0.0.13",
+            "version": "0.0.14",
             "automated_flags": {
                 "include_in_ui": false,
                 "generate_docs": true,
@@ -87,7 +87,7 @@
             "base_label": "New Default (released on January 14)",
             "tools": ["gatk", "python", "r"],
             "packages": {},
-            "version": "0.0.15",
+            "version": "0.0.16",
             "automated_flags": {
                 "include_in_ui": true,
                 "generate_docs": true,
@@ -101,7 +101,7 @@
             "base_label": "All of Us",
             "tools": ["python", "r"],
             "packages": {},
-            "version": "0.0.3",
+            "version": "0.0.4",
             "automated_flags": {
                 "include_in_ui": false,
                 "generate_docs": false,

--- a/terra-jupyter-aou/CHANGELOG.md
+++ b/terra-jupyter-aou/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.0.4 - 05/18/2020
+
+- Update `terra-jupyter-python` base image to `0.0.12` and `terra-jupyter-r` base image to `0.0.14`
+   - Adds jupyter notebook extension collapsible headers and code-folding
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:0.0.4`
+
 ## 0.0.3 - 04/28/2020
 
 - Update `terra-jupyter-python` base image to `0.0.11`

--- a/terra-jupyter-aou/Dockerfile
+++ b/terra-jupyter-aou/Dockerfile
@@ -1,6 +1,6 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.11 AS python
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.12 AS python
 
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:0.0.13
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:0.0.14
 
 # copy everything pip installed from the python image
 COPY --from=python /usr/local/lib/python3.7/dist-packages /usr/local/lib/python3.7/dist-packages

--- a/terra-jupyter-base/CHANGELOG.md
+++ b/terra-jupyter-base/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.0.10 - 05/18/2020
+- Adds jupyter notebook extension collapsible headers and code-folding
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:0.0.10`
+
 ## 0.0.9 - 02/25/2020
 - Fixes https://broadworkbench.atlassian.net/browse/IA-1676 in `google_sign_in.js` 
     - Adds a fallback method to set needed config when in non-notebook views

--- a/terra-jupyter-base/scripts/extension/install_jupyter_contrib_nbextensions.sh
+++ b/terra-jupyter-base/scripts/extension/install_jupyter_contrib_nbextensions.sh
@@ -6,3 +6,6 @@ set -e
 sudo -E -u jupyter-user jupyter nbextensions_configurator enable --user
 sudo -E -u jupyter-user jupyter contrib nbextension install --user
 sudo -E -u jupyter-user jupyter nbextension enable toc2/main
+sudo -E -u jupyter-user jupyter nbextension enable codefolding/main
+sudo -E -u jupyter-user jupyter nbextension enable collapsible_headings/main
+

--- a/terra-jupyter-bioconductor/CHANGELOG.md
+++ b/terra-jupyter-bioconductor/CHANGELOG.md
@@ -1,7 +1,7 @@
 # 0.0.15 - 05/18/2020
 
 - Update `terra-jupyter-r` base image to `0.0.14`
-   - - Adds jupyter notebook extension collapsible headers and code-folding
+   - Adds jupyter notebook extension collapsible headers and code-folding
 
 Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:0.0.15`
 

--- a/terra-jupyter-bioconductor/CHANGELOG.md
+++ b/terra-jupyter-bioconductor/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.0.15 - 05/18/2020
+
+- Update `terra-jupyter-r` base image to `0.0.14`
+   - - Adds jupyter notebook extension collapsible headers and code-folding
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:0.0.15`
+
 ## 0.0.14 - 04/28/2020
 
 - Fix bug in version `0.0.13`: switch back to `jupyter-user` at the end

--- a/terra-jupyter-bioconductor/Dockerfile
+++ b/terra-jupyter-bioconductor/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:0.0.13
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:0.0.14
 
 USER root
 

--- a/terra-jupyter-gatk/CHANGELOG.md
+++ b/terra-jupyter-gatk/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.0.16 - 05/18/2020
+
+- Update `terra-jupyter-python` base image to `0.0.12` and `terra-jupyter-r` base image to `0.0.14`
+   - Adds jupyter notebook extension collapsible headers and code-folding
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:0.0.16`
+
 ## 0.0.15 - 04/28/2020
 
 - Update `terra-jupyter-python` base image to `0.0.11`

--- a/terra-jupyter-gatk/Dockerfile
+++ b/terra-jupyter-gatk/Dockerfile
@@ -1,6 +1,6 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.11 AS python
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.12 AS python
 
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:0.0.13
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:0.0.14
 
 # copy everything pip installed from the python image
 COPY --from=python /usr/local/lib/python3.7/dist-packages /usr/local/lib/python3.7/dist-packages

--- a/terra-jupyter-hail/CHANGELOG.md
+++ b/terra-jupyter-hail/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.0.13 - 05/18/2020
+
+- Update `terra-jupyter-python` image to 0.0.12
+   - Adds jupyter notebook extension collapsible headers and code-folding
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-hail:0.0.13`
+
 ## 0.0.12 - 4/30/2020
 
 - Upgrade `hail` to `0.2.39`

--- a/terra-jupyter-hail/Dockerfile
+++ b/terra-jupyter-hail/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.11
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.12
 USER root
 
 COPY scripts $JUPYTER_HOME/scripts

--- a/terra-jupyter-python/CHANGELOG.md
+++ b/terra-jupyter-python/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.0.12 - 05/18/2020
+
+- Update `terra-jupyter-base` image version to `0.0.10`
+   - Adds jupyter notebook extension collapsible headers and code-folding
+
+Image URL `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.12`
+
 ## 0.0.11 - 04/17/2020
 
 - Add Google Cloud support to pysam.

--- a/terra-jupyter-python/Dockerfile
+++ b/terra-jupyter-python/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:0.0.9
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:0.0.10
 USER root
 #this makes it so pip runs as root, not the user
 ENV PIP_USER=false

--- a/terra-jupyter-r/CHANGELOG.md
+++ b/terra-jupyter-r/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.0.14 - 05/18/2020
+- Update `terra-jupyter-base` image version to `0.0.10`
+   - Adds jupyter notebook extension collapsible headers and code-folding
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:0.0.14`
+
 ## 0.0.13 - 04/23/2020
 - Update `terra-jupyter-r` version to `0.0.13`
 - Change env var names to avoid conflict.

--- a/terra-jupyter-r/Dockerfile
+++ b/terra-jupyter-r/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:0.0.9
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:0.0.10
 USER root
 
 COPY scripts $JUPYTER_HOME/scripts


### PR DESCRIPTION
Overview:
Added code to enable the Codefolding and Collapsible_header extension to the base image using the install_jupyter_contrib_nbextensions.sh

Background:
Many of CD notebooks (GATK workshop notebooks, as well as many template notebooks) include long code functions that users don’t usually (or ever) need to modify. Codefolding could satisfy two distinct audiences - help users without a lot of coding experience by tucking all the nitty gritty details of defining functions away-  while allowing people who want to see the code to do so.

CD use these extensions a lot in tutorials and template and enabling them as default would keep us from having to walk users through the process of enabling these extensions.

Enabling codefolding and collapsible sections extensions for everyone would not clutter up existing notebooks, or those of people who didn’t want to use the extensions. Cells are un-folded and un-collapsed by default, even if the extension is enabled) and the pale grey arrows that exist when they’re enabled are unobtrusive. 