### PR TITLE
IA-1915 Legacy R images and new labels

### DIFF
--- a/config/conf.json
+++ b/config/conf.json
@@ -14,7 +14,7 @@
     "spark_version": "2.4.5",
     "image_data": [{
             "name": "terra-jupyter-bioconductor",
-            "base_label": "Bioconductor",
+            "base_label": "R / Bioconductor",
             "tools": ["python", "r"],
             "packages": { "r": ["BiocVersion", "tidyverse"] },
             "version": "1.0.0",
@@ -84,7 +84,7 @@
         },
         {
             "name": "terra-jupyter-gatk",
-            "base_label": "New Default (released on January 14)",
+            "base_label": "Default",
             "tools": ["gatk", "python", "r"],
             "packages": {},
             "version": "1.0.0",

--- a/scripts/generate_version_docs.py
+++ b/scripts/generate_version_docs.py
@@ -38,7 +38,7 @@ def generate_docs():
 
       docs.append(doc)
 
-  docs.append(get_static_legacy_doc())
+  docs.extend(get_static_docs())
   return docs
 
 def generate_doc_for_image(image_config):
@@ -95,18 +95,39 @@ def get_last_updated(image_config):
 
   return terra_date
 
-def get_static_legacy_doc():
-  doc = {
-    "id": 'leonardo-jupyter-dev',
-    "label": 'Legacy (default prior to January 14)',
-    "version": 'FINAL',
-    "updated": '2019-08-26',
-    "packages": 'https://storage.googleapis.com/terra-docker-image-documentation/leonardo-jupyter-dev-versions.json',
-    "image": 'us.gcr.io/broad-dsp-gcr-public/leonardo-jupyter:5c51ce6935da',
-    "requiresSpark": True
-  }
+# See definitions in https://docs.google.com/document/d/1qAp1wJTEx1UNtZ4vz1aV4PZRfjyYfF7QkwwOjK4LoD8/edit
+def get_static_docs():
+  docs = [
+    {
+      "id": 'leonardo-jupyter-dev',
+      "label": 'Legacy Python/R (default prior to January 14, 2020)',
+      "version": 'FINAL',
+      "updated": '2019-08-26',
+      "packages": 'https://storage.googleapis.com/terra-docker-image-documentation/leonardo-jupyter-dev-versions.json',
+      "image": 'us.gcr.io/broad-dsp-gcr-public/leonardo-jupyter:5c51ce6935da',
+      "requiresSpark": True
+    },
+    {
+      "id": 'terra-jupyter-gatk_legacy',
+      "label": 'Legacy GATK (GATK 4.1.4.1, Python 3.7.7, R 3.6.3)',
+      "version": '0.0.16',
+      "updated": '2020-05-18',
+      "packages": 'https://storage.googleapis.com/terra-docker-image-documentation/terra-jupyter-gatk-0.0.16-versions.json',
+      "image": 'us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:0.0.16',
+      "requiresSpark": False
+    },
+    {
+      "id": 'terra-jupyter-bioconductor_legacy',
+      "label": 'Legacy R / Bioconductor (R 3.6.3, Bioconductor 3.10, Python 3.7.7)',
+      "version": '0.0.15',
+      "updated": '2020-05-18',
+      "packages": 'https://storage.googleapis.com/terra-docker-image-documentation/terra-jupyter-bioconductor-0.0.15-versions.json',
+      "image": 'us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:0.0.15',
+      "requiresSpark": False
+    }
+  ]
 
-  return doc
+  return docs
 
 def get_current_versions():
   try:


### PR DESCRIPTION
Made labelling changes based on https://docs.google.com/document/d/1qAp1wJTEx1UNtZ4vz1aV4PZRfjyYfF7QkwwOjK4LoD8/edit

Manually ran `generate_version_docs.py` and pushed result to `gs://terra-docker-image-documentation/terra-docker-versions-new.json`. It looks correct to me -- we can push to Terra UI whenever we are ready (probably next Leo release).

```
$ gsutil cat gs://terra-docker-image-documentation/terra-docker-versions-new.json
[
    {
        "updated": "2020-05-21", 
        "image": "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:1.0.0", 
        "label": "R / Bioconductor: (Python 3.7.7, R 4.0.0, BiocVersion 3.11.1, tidyverse 1.3.0)", 
        "version": "1.0.0", 
        "requiresSpark": false, 
        "packages": "https://storage.googleapis.com/terra-docker-image-documentation/terra-jupyter-bioconductor-1.0.0-versions.json", 
        "id": "terra-jupyter-bioconductor"
    }, 
    {
        "updated": "2020-05-21", 
        "image": "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-hail:0.0.13", 
        "label": "Hail: (Python 3.7.7, Spark 2.4.5, hail 0.2.39)", 
        "version": "0.0.13", 
        "requiresSpark": true, 
        "packages": "https://storage.googleapis.com/terra-docker-image-documentation/terra-jupyter-hail-0.0.13-versions.json", 
        "id": "terra-jupyter-hail"
    }, 
    {
        "updated": "2020-05-21", 
        "image": "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.12", 
        "label": "Python: (Python 3.7.7, pandas 0.25.3, scikit-learn 0.20.0)", 
        "version": "0.0.12", 
        "requiresSpark": false, 
        "packages": "https://storage.googleapis.com/terra-docker-image-documentation/terra-jupyter-python-0.0.12-versions.json", 
        "id": "terra-jupyter-python"
    }, 
    {
        "updated": "2020-05-21", 
        "image": "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:1.0.0", 
        "label": "Default: (GATK 4.1.4.1, Python 3.7.7, R 4.0.0)", 
        "version": "1.0.0", 
        "requiresSpark": false, 
        "packages": "https://storage.googleapis.com/terra-docker-image-documentation/terra-jupyter-gatk-1.0.0-versions.json", 
        "id": "terra-jupyter-gatk"
    }, 
    {
        "updated": "2019-08-26", 
        "image": "us.gcr.io/broad-dsp-gcr-public/leonardo-jupyter:5c51ce6935da", 
        "label": "Legacy Python/R (default prior to January 14, 2020)", 
        "version": "FINAL", 
        "requiresSpark": true, 
        "packages": "https://storage.googleapis.com/terra-docker-image-documentation/leonardo-jupyter-dev-versions.json", 
        "id": "leonardo-jupyter-dev"
    }, 
    {
        "updated": "2020-05-18", 
        "image": "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:0.0.16", 
        "label": "Legacy GATK (GATK 4.1.4.1, Python 3.7.7, R 3.6.3)", 
        "version": "0.0.16", 
        "requiresSpark": false, 
        "packages": "https://storage.googleapis.com/terra-docker-image-documentation/terra-jupyter-gatk-0.0.16-versions.json", 
        "id": "terra-jupyter-gatk_legacy"
    }, 
    {
        "updated": "2020-05-18", 
        "image": "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:0.0.15", 
        "label": "Legacy R / Bioconductor (R 3.6.3, Bioconductor 3.10, Python 3.7.7)", 
        "version": "0.0.15", 
        "requiresSpark": false, 
        "packages": "https://storage.googleapis.com/terra-docker-image-documentation/terra-jupyter-bioconductor-0.0.15-versions.json", 
        "id": "terra-jupyter-bioconductor_legacy"
    }
]
```