### PR TITLE
IA-1973 - Update jupyter R image so user installed packages persist

### DIFF
--- a/config/conf.json
+++ b/config/conf.json
@@ -73,7 +73,7 @@
             "base_label": "R",
             "tools": ["r"],
             "packages": {},
-            "version": "1.0.1",
+            "version": "1.0.2",
             "automated_flags": {
                 "include_in_ui": false,
                 "generate_docs": true,

--- a/config/conf.json
+++ b/config/conf.json
@@ -17,7 +17,7 @@
             "base_label": "R / Bioconductor",
             "tools": ["python", "r"],
             "packages": { "r": ["BiocVersion", "tidyverse"] },
-            "version": "1.0.1",
+            "version": "1.0.2",
             "automated_flags": {
                 "generate_docs": true,
                 "include_in_ui": true,
@@ -87,7 +87,7 @@
             "base_label": "Default",
             "tools": ["gatk", "python", "r"],
             "packages": {},
-            "version": "1.0.1",
+            "version": "1.0.2",
             "automated_flags": {
                 "include_in_ui": true,
                 "generate_docs": true,
@@ -101,7 +101,7 @@
             "base_label": "All of Us",
             "tools": ["python", "r"],
             "packages": {},
-            "version": "1.0.1",
+            "version": "1.0.2",
             "automated_flags": {
                 "include_in_ui": false,
                 "generate_docs": false,

--- a/terra-jupyter-aou/CHANGELOG.md
+++ b/terra-jupyter-aou/CHANGELOG.md
@@ -1,4 +1,12 @@
+## 1.0.2 - 06/26/2020
+
+- Update `terra-jupyter-r` base image to `1.0.2`
+- Update `terra-jupyter-aou` to version `1.0.2`
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:1.0.2`
+
 ## 1.0.1 - 06/15/2020
+
 - Update `terra-jupyter-r` base image to `1.0.1` and `terra-jupyter-python` base image to `0.0.13`
 - Update `terra-jupyter-aou` to version `1.0.1`
 

--- a/terra-jupyter-aou/Dockerfile
+++ b/terra-jupyter-aou/Dockerfile
@@ -1,6 +1,6 @@
 FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.13 AS python
 
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.1
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.2
 
 # copy everything pip installed from the python image
 COPY --from=python /usr/local/lib/python3.7/dist-packages /usr/local/lib/python3.7/dist-packages

--- a/terra-jupyter-bioconductor/CHANGELOG.md
+++ b/terra-jupyter-bioconductor/CHANGELOG.md
@@ -1,4 +1,11 @@
+## 1.0.2 - 06/26/2020
+
+- Update `terra-jupyter-r` version to `1.0.2`
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:1.0.2`
+
 ## 1.0.1 - 06/15/2020
+
 - Update `terra-jupyter-r` version to `1.0.1`
 
 Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:1.0.1`

--- a/terra-jupyter-bioconductor/Dockerfile
+++ b/terra-jupyter-bioconductor/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.1
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.2
 
 USER root
 

--- a/terra-jupyter-gatk/CHANGELOG.md
+++ b/terra-jupyter-gatk/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.0.2 - 06/26/2020
+
+- Update `terra-jupyter-r` version to `1.0.2`
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:1.0.2`
+
 ## 1.0.1 - 06/15/2020
 
 - Update `terra-jupyter-python` base image to `0.0.32` and `terra-jupyter-r` base image to `1.0.1`

--- a/terra-jupyter-gatk/Dockerfile
+++ b/terra-jupyter-gatk/Dockerfile
@@ -1,6 +1,6 @@
 FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.13 AS python
 
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.1
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.2
 
 # copy everything pip installed from the python image
 COPY --from=python /usr/local/lib/python3.7/dist-packages /usr/local/lib/python3.7/dist-packages

--- a/terra-jupyter-r/CHANGELOG.md
+++ b/terra-jupyter-r/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.0.2 - 06/23/2020
+- Install all image packages as root user
+- remove /home/jupyter-user/.rpackages
+- Add /home/jupyter-user/notebooks/packages so user installed packages persist
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.2`
+
 ## 1.0.1 - 06/15/2020
 - Update `terra-jupyter-base` image version to `0.0.11`
 - Add terra-notebook-utils package

--- a/terra-jupyter-r/CHANGELOG.md
+++ b/terra-jupyter-r/CHANGELOG.md
@@ -1,7 +1,8 @@
-## 1.0.2 - 06/23/2020
+## 1.0.2 - 06/26/2020
 - Install all image packages as root user
 - remove /home/jupyter-user/.rpackages
 - Add /home/jupyter-user/notebooks/packages so user installed packages persist
+
 Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.2`
 
 ## 1.0.1 - 06/15/2020

--- a/terra-jupyter-r/Dockerfile
+++ b/terra-jupyter-r/Dockerfile
@@ -155,8 +155,7 @@ ENV PIP_USER=true
 
 ## After image installations, switch back to jupyter-user and create packages lib
 USER $USER
-RUN mkdir -p /home/jupyter-user/notebooks/packages \
-    && echo "R_LIBS=/home/jupyter-user/notebooks/packages" > /home/jupyter-user/.Renviron
+RUN echo "R_LIBS=/home/jupyter-user/notebooks/packages" > /home/jupyter-user/.Renviron
 
 USER root
 

--- a/terra-jupyter-r/Dockerfile
+++ b/terra-jupyter-r/Dockerfile
@@ -156,11 +156,11 @@ ENV PIP_USER=true
 ## After image installations, switch back to jupyter-user and create packages lib
 USER $USER
 RUN mkdir -p /home/jupyter-user/notebooks/packages \
-    && echo "R_LIBS=/home/jupyter-user/notebooks/packages" > /home/jupyter-user/.Renviron \
-    && sudo chown -R $USER:users /usr/local/lib/R/site-library
+    && echo "R_LIBS=/home/jupyter-user/notebooks/packages" > /home/jupyter-user/.Renviron
 
 USER root
 
-RUN R -e 'IRkernel::installspec(user=FALSE)'
+RUN R -e 'IRkernel::installspec(user=FALSE)' \
+    && chown -R $USER:users /usr/local/lib/R/site-library
 
 USER $USER

--- a/terra-jupyter-r/Dockerfile
+++ b/terra-jupyter-r/Dockerfile
@@ -156,11 +156,11 @@ ENV PIP_USER=true
 ## After image installations, switch back to jupyter-user and create packages lib
 USER $USER
 RUN mkdir -p /home/jupyter-user/notebooks/packages \
-    && echo "R_LIBS=/home/jupyter-user/notebooks/packages" > /home/jupyter-user/.Renviron \
-    && chown -R $USER:users /usr/local/lib/R/site-library
+    && echo "R_LIBS=/home/jupyter-user/notebooks/packages" > /home/jupyter-user/.Renviron
 
 USER root
 
-RUN R -e 'IRkernel::installspec(user=FALSE)'
+RUN R -e 'IRkernel::installspec(user=FALSE)' \
+    && chown -R $USER:users /usr/local/lib/R/site-library
 
 USER $USER

--- a/terra-jupyter-r/Dockerfile
+++ b/terra-jupyter-r/Dockerfile
@@ -118,14 +118,10 @@ RUN apt-get update \
 ENV PIP_USER=true
 
 ## Change back to jupyter-user
-USER $USER
+## USER $USER
+USER root
 
-## Reasons for change, 1. Message during installation, 2. User cannot
-## update packages installed in the Dockerfile.
-
-RUN mkdir -p /home/jupyter-user/.rpackages \
-    && echo "R_LIBS=/home/jupyter-user/.rpackages" > /home/jupyter-user/.Renviron \
-    && R -e 'install.packages("BiocManager")' \
+RUN R -e 'install.packages("BiocManager")' \
     ## check version
     && R -e 'BiocManager::install(version="3.11", ask=FALSE)' \
     && R -e 'BiocManager::install(c( \
@@ -160,6 +156,11 @@ RUN mkdir -p /home/jupyter-user/.rpackages \
     "uuid"))' \
     && chown -R $USER:users /home/jupyter-user/.local
 
+
+## After image installations, switch back to jupyter-user and create packages lib
+USER $USER
+RUN mkdir -p /home/jupyter-user/notebooks/packages \
+    && echo "R_LIBS=/home/jupyter-user/notebooks/packages" > /home/jupyter-user/.Renviron
 
 USER root
 

--- a/terra-jupyter-r/Dockerfile
+++ b/terra-jupyter-r/Dockerfile
@@ -156,11 +156,11 @@ ENV PIP_USER=true
 ## After image installations, switch back to jupyter-user and create packages lib
 USER $USER
 RUN mkdir -p /home/jupyter-user/notebooks/packages \
-    && echo "R_LIBS=/home/jupyter-user/notebooks/packages" > /home/jupyter-user/.Renviron
+    && echo "R_LIBS=/home/jupyter-user/notebooks/packages" > /home/jupyter-user/.Renviron \
+    && sudo chown -R $USER:users /usr/local/lib/R/site-library
 
 USER root
 
-RUN R -e 'IRkernel::installspec(user=FALSE)' \
-    && chown -R $USER:users /usr/local/lib/R/site-library
+RUN R -e 'IRkernel::installspec(user=FALSE)'
 
 USER $USER

--- a/terra-jupyter-r/Dockerfile
+++ b/terra-jupyter-r/Dockerfile
@@ -114,13 +114,6 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-## pip runs as jupyter-user
-ENV PIP_USER=true
-
-## Change back to jupyter-user
-## USER $USER
-USER root
-
 RUN R -e 'install.packages("BiocManager")' \
     ## check version
     && R -e 'BiocManager::install(version="3.11", ask=FALSE)' \
@@ -156,11 +149,14 @@ RUN R -e 'install.packages("BiocManager")' \
     "uuid"))' \
     && chown -R $USER:users /home/jupyter-user/.local
 
+## pip runs as jupyter-user
+ENV PIP_USER=true
 
 ## After image installations, switch back to jupyter-user and create packages lib
 USER $USER
 RUN mkdir -p /home/jupyter-user/notebooks/packages \
-    && echo "R_LIBS=/home/jupyter-user/notebooks/packages" > /home/jupyter-user/.Renviron
+    && echo "R_LIBS=/home/jupyter-user/notebooks/packages" > /home/jupyter-user/.Renviron \
+    && chown -R $USER:users /usr/local/lib/R/site-library
 
 USER root
 


### PR DESCRIPTION
jupyter r image now installs image packages as root user and then creates directory `/home/jupyter-user/notebooks/packages` and uses that for user installed packages. 

removes directory `/home/jupyter-user/.rpackages` so `.libPaths()` doesn't have too many entries (we will be using new dir going forward since it's the same dir we mount the persistent disk on)

this PR also changes ownership of `/usr/local/lib/R/site-library` to `jupyter-user` as requested by @nturaga 