### PR TITLE
IA-1973 Persist only user installed packages

### DIFF
--- a/config/conf.json
+++ b/config/conf.json
@@ -73,7 +73,7 @@
             "base_label": "R",
             "tools": ["r"],
             "packages": {},
-            "version": "1.0.2",
+            "version": "1.0.3",
             "automated_flags": {
                 "include_in_ui": false,
                 "generate_docs": true,

--- a/config/conf.json
+++ b/config/conf.json
@@ -17,7 +17,7 @@
             "base_label": "R / Bioconductor",
             "tools": ["python", "r"],
             "packages": { "r": ["BiocVersion", "tidyverse"] },
-            "version": "1.0.2",
+            "version": "1.0.3",
             "automated_flags": {
                 "generate_docs": true,
                 "include_in_ui": true,
@@ -87,7 +87,7 @@
             "base_label": "Default",
             "tools": ["gatk", "python", "r"],
             "packages": {},
-            "version": "1.0.2",
+            "version": "1.0.3",
             "automated_flags": {
                 "include_in_ui": true,
                 "generate_docs": true,
@@ -101,7 +101,7 @@
             "base_label": "All of Us",
             "tools": ["python", "r"],
             "packages": {},
-            "version": "1.0.2",
+            "version": "1.0.3",
             "automated_flags": {
                 "include_in_ui": false,
                 "generate_docs": false,

--- a/terra-jupyter-aou/CHANGELOG.md
+++ b/terra-jupyter-aou/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 1.0.3 - 06/29/2020
 
+- Image package installations should not persist
 - Update `terra-jupyter-r` base image to `1.0.3`
 - Update `terra-jupyter-aou` to version `1.0.3`
 

--- a/terra-jupyter-aou/CHANGELOG.md
+++ b/terra-jupyter-aou/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.0.3 - 06/29/2020
+
+- Update `terra-jupyter-r` base image to `1.0.3`
+- Update `terra-jupyter-aou` to version `1.0.3`
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:1.0.3`
+
 ## 1.0.2 - 06/26/2020
 
 - Update `terra-jupyter-r` base image to `1.0.2`

--- a/terra-jupyter-aou/Dockerfile
+++ b/terra-jupyter-aou/Dockerfile
@@ -1,6 +1,6 @@
 FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.13 AS python
 
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.2
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.3
 
 # copy everything pip installed from the python image
 COPY --from=python /usr/local/lib/python3.7/dist-packages /usr/local/lib/python3.7/dist-packages

--- a/terra-jupyter-bioconductor/CHANGELOG.md
+++ b/terra-jupyter-bioconductor/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.0.3 - 06/29/2020
+
+- Update `terra-jupyter-r` version to `1.0.3`
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:1.0.3`
+
 ## 1.0.2 - 06/26/2020
 
 - Update `terra-jupyter-r` version to `1.0.2`

--- a/terra-jupyter-bioconductor/CHANGELOG.md
+++ b/terra-jupyter-bioconductor/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 1.0.3 - 06/29/2020
 
+- Image package installations should not persist
 - Update `terra-jupyter-r` version to `1.0.3`
 
 Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:1.0.3`

--- a/terra-jupyter-bioconductor/Dockerfile
+++ b/terra-jupyter-bioconductor/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.2
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.3
 
 USER root
 

--- a/terra-jupyter-gatk/CHANGELOG.md
+++ b/terra-jupyter-gatk/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 1.0.3 - 06/29/2020
 
+- Image package installations should not persist
 - Update `terra-jupyter-r` version to `1.0.3`
 
 Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:1.0.3`

--- a/terra-jupyter-gatk/CHANGELOG.md
+++ b/terra-jupyter-gatk/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.0.3 - 06/29/2020
+
+- Update `terra-jupyter-r` version to `1.0.3`
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:1.0.3`
+
 ## 1.0.2 - 06/26/2020
 
 - Update `terra-jupyter-r` version to `1.0.2`

--- a/terra-jupyter-gatk/Dockerfile
+++ b/terra-jupyter-gatk/Dockerfile
@@ -1,6 +1,6 @@
 FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.13 AS python
 
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.2
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.3
 
 # copy everything pip installed from the python image
 COPY --from=python /usr/local/lib/python3.7/dist-packages /usr/local/lib/python3.7/dist-packages

--- a/terra-jupyter-r/CHANGELOG.md
+++ b/terra-jupyter-r/CHANGELOG.md
@@ -1,6 +1,5 @@
 ## 1.0.2 - 06/29/2020
-- Remove `/home/jupyter-user/notebooks/packages` from .Renviron file because derived images need
-to install packages as root user so derived image installed packages don't persist
+- Remove `/home/jupyter-user/notebooks/packages` from .Renviron file because derived images installed packages should not persist
 
 Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.3`
 

--- a/terra-jupyter-r/CHANGELOG.md
+++ b/terra-jupyter-r/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.0.2 - 06/29/2020
+## 1.0.3 - 06/29/2020
 - Remove `/home/jupyter-user/notebooks/packages` from .Renviron file because derived images installed packages should not persist
 
 Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.3`

--- a/terra-jupyter-r/CHANGELOG.md
+++ b/terra-jupyter-r/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.0.2 - 06/29/2020
+- Remove `/home/jupyter-user/notebooks/packages` from .Renviron file because derived images need
+to install packages as root user so derived image installed packages don't persist
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.3`
+
 ## 1.0.2 - 06/26/2020
 - Install all image packages as root user
 - remove /home/jupyter-user/.rpackages

--- a/terra-jupyter-r/Dockerfile
+++ b/terra-jupyter-r/Dockerfile
@@ -150,15 +150,6 @@ RUN R -e 'install.packages("BiocManager")' \
     "uuid"))' \
     && chown -R $USER:users /home/jupyter-user/.local
 
-## pip runs as jupyter-user
-ENV PIP_USER=true
-
-## After image installations, switch back to jupyter-user and create packages lib
-USER $USER
-RUN echo "R_LIBS=/home/jupyter-user/notebooks/packages" > /home/jupyter-user/.Renviron
-
-USER root
-
 RUN R -e 'IRkernel::installspec(user=FALSE)' \
     && chown -R $USER:users /usr/local/lib/R/site-library
 


### PR DESCRIPTION
This PR removes `/home/jupyter-user/notebooks/packages` from `.Renviron` in `terra-jupyter-r` so that derived images such as `terra-jupyter-bioconductor` package installations don't persist