### PR TITLE
[IA-2076] fix issue with path and update all images

### DIFF
--- a/config/conf.json
+++ b/config/conf.json
@@ -17,7 +17,7 @@
             "base_label": "R / Bioconductor",
             "tools": ["python", "r"],
             "packages": { "r": ["BiocVersion", "tidyverse"] },
-            "version": "1.0.3",
+            "version": "1.0.4",
             "automated_flags": {
                 "generate_docs": true,
                 "include_in_ui": true,
@@ -31,7 +31,7 @@
             "base_label": "Hail",
             "tools": ["python", "spark"],
             "packages": { "python": ["hail"] },
-            "version": "0.0.16",
+            "version": "0.0.17",
             "automated_flags": {
                 "generate_docs": true,
                 "include_in_ui": true,
@@ -45,7 +45,7 @@
             "base_label": "Python",
             "tools": ["python"],
             "packages": { "python": ["pandas", "scikit-learn"] },
-            "version": "0.0.13",
+            "version": "0.0.14",
             "automated_flags": {
                 "generate_docs": true,
                 "include_in_ui": true,
@@ -59,7 +59,7 @@
             "base_label": "Base",
             "tools": ["python"],
             "packages": {},
-            "version": "0.0.11",
+            "version": "0.0.12",
             "automated_flags": {
                 "generate_docs": true,
                 "include_in_ui": false,
@@ -73,7 +73,7 @@
             "base_label": "R",
             "tools": ["r"],
             "packages": {},
-            "version": "1.0.3",
+            "version": "1.0.4",
             "automated_flags": {
                 "include_in_ui": false,
                 "generate_docs": true,
@@ -87,7 +87,7 @@
             "base_label": "Default",
             "tools": ["gatk", "python", "r"],
             "packages": {},
-            "version": "1.0.3",
+            "version": "1.0.4",
             "automated_flags": {
                 "include_in_ui": true,
                 "generate_docs": true,
@@ -101,7 +101,7 @@
             "base_label": "All of Us",
             "tools": ["python", "r"],
             "packages": {},
-            "version": "1.0.4",
+            "version": "1.0.5",
             "automated_flags": {
                 "include_in_ui": false,
                 "generate_docs": false,

--- a/terra-jupyter-aou/CHANGELOG.md
+++ b/terra-jupyter-aou/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.0.5 - 07/27/2020
+
+- Update `terra-jupyter-python` to `0.0.14`
+- Update `terra-jupyter-r` to `1.0.4`
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:1.0.5`
+
 ## 1.0.4 - 07/28/2020
 
 - Drop fork install of bigrquery (patches have now been merged and released in the main bigrquery package)

--- a/terra-jupyter-aou/Dockerfile
+++ b/terra-jupyter-aou/Dockerfile
@@ -1,6 +1,6 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.13 AS python
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.14 AS python
 
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.3
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.4
 
 # copy everything pip installed from the python image
 COPY --from=python /usr/local/lib/python3.7/dist-packages /usr/local/lib/python3.7/dist-packages
@@ -38,10 +38,10 @@ RUN cd /usr/local/share && \
 
 RUN echo "Sys.setenv(RETICULATE_PYTHON = '$(which python3)')" >> ~/.Rprofile
 
+# Install Notebook libraries as the user.
+
 ENV USER jupyter-user
 USER $USER
-
-# Install Notebook libraries as the user.
 
 RUN pip3 install --upgrade \
   plotnine \

--- a/terra-jupyter-base/CHANGELOG.md
+++ b/terra-jupyter-base/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.0.12 - 07/27/2020
+- Fix issue where packages with CLI functionality were not available on path
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:0.0.12`
+
 ## 0.0.11 - 06/15/2020
 - Add terra-notebook-utils to base image
 - Add /home/jupyter-user/notebooks/packages to PYTHONPATH so user package installs persist using PDs

--- a/terra-jupyter-base/Dockerfile
+++ b/terra-jupyter-base/Dockerfile
@@ -106,6 +106,7 @@ ENV USER_INSTALL_DIR /home/jupyter-user/notebooks/packages
 
 # Prepend existing PYTHONPATH if it's not empty; otherwise prepend it
 ENV PYTHONPATH ${PYTHONPATH:+$PYTHONPATH:}$JUPYTER_HOME/custom:$USER_INSTALL_DIR
+ENV PATH ${PATH:+$PATH:}$USER_INSTALL_DIR/bin
 
 # # Python3, kernel, and pip
 RUN apt update \

--- a/terra-jupyter-bioconductor/CHANGELOG.md
+++ b/terra-jupyter-bioconductor/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.0.4 - 07/27/2020
+
+- Update `terra-jupyter-r` version to `1.0.4`
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:1.0.4`
+
 ## 1.0.3 - 06/29/2020
 
 - Only user package installations (not image package installations) will persist

--- a/terra-jupyter-bioconductor/Dockerfile
+++ b/terra-jupyter-bioconductor/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.3
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.4
 
 USER root
 

--- a/terra-jupyter-gatk/CHANGELOG.md
+++ b/terra-jupyter-gatk/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.0.4 - 07/27/2020
+
+- Update `terra-jupyter-r` to `1.0.4`
+- Update `terra-jupyter-python` to `0.0.14`
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:1.0.4`
+
 ## 1.0.3 - 06/29/2020
 
 - Only user package installations (not image package installations) will persist

--- a/terra-jupyter-gatk/Dockerfile
+++ b/terra-jupyter-gatk/Dockerfile
@@ -1,6 +1,6 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.13 AS python
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.14 AS python
 
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.3
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.4
 
 # copy everything pip installed from the python image
 COPY --from=python /usr/local/lib/python3.7/dist-packages /usr/local/lib/python3.7/dist-packages

--- a/terra-jupyter-hail/CHANGELOG.md
+++ b/terra-jupyter-hail/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.0.17 - 07/27/2020
+
+- Update `terra-jupyter-python` image to `0.0.14`
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-hail:0.0.17`
+
 ## 0.0.16 - 06/27/2020
 - Upgrade `hail` to `0.2.50`
    - See https://hail.is/docs/0.2/change_log.html#version-0-2-50 for details.

--- a/terra-jupyter-hail/Dockerfile
+++ b/terra-jupyter-hail/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.13
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.14
 USER root
 
 COPY scripts $JUPYTER_HOME/scripts

--- a/terra-jupyter-python/CHANGELOG.md
+++ b/terra-jupyter-python/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.0.14 - 07/27/2020
+
+- Update `terra-jupyter-base` image version to `0.0.12`
+
+Image URL `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.14`
+
 ## 0.0.13 - 06/15/2020
 
 - Update `terra-jupyter-base` image version to `0.0.11`

--- a/terra-jupyter-python/Dockerfile
+++ b/terra-jupyter-python/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:0.0.11
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:0.0.12
 USER root
 #this makes it so pip runs as root, not the user
 ENV PIP_USER=false

--- a/terra-jupyter-r/CHANGELOG.md
+++ b/terra-jupyter-r/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.0.4 - 07/27/2020
+
+- Update `terra-jupyter-base` image version to `0.0.12`
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.4`
+
 ## 1.0.3 - 06/29/2020
 - Remove `/home/jupyter-user/notebooks/packages` from .Renviron file because derived images installed packages should not persist
 - Only user package installations (not image package installations) will persist

--- a/terra-jupyter-r/Dockerfile
+++ b/terra-jupyter-r/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:0.0.11
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:0.0.12
 USER root
 
 COPY scripts $JUPYTER_HOME/scripts


### PR DESCRIPTION
Tested by building a custom image, pushing it, and installing a pip package with cli functionality. (`janis-pipelines` to be specific).

Worth noting that I couldn't test this locally with an image because of the directory setup our init script does... may be worth touching up a terra-docker script that sets up the pathing as the init script does. 