### PR TITLE
Update workbench-snippets and bigrquery AoU libraries

### DIFF
--- a/config/conf.json
+++ b/config/conf.json
@@ -101,7 +101,7 @@
             "base_label": "All of Us",
             "tools": ["python", "r"],
             "packages": {},
-            "version": "1.0.3",
+            "version": "1.0.4",
             "automated_flags": {
                 "include_in_ui": false,
                 "generate_docs": false,

--- a/terra-jupyter-aou/CHANGELOG.md
+++ b/terra-jupyter-aou/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.0.4 - 07/28/2020
+
+- Drop fork install of bigrquery (patches have now been merged and released in the main bigrquery package)
+- Install new AoU Python library
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:1.0.4`
+
 ## 1.0.3 - 06/29/2020
 
 - Only user package installations will persist (installed to `/home/jupyter-user/notebooks/packages`) not image installed packages

--- a/terra-jupyter-aou/Dockerfile
+++ b/terra-jupyter-aou/Dockerfile
@@ -45,7 +45,6 @@ USER $USER
 
 RUN pip3 install --upgrade \
   plotnine \
-  statsmodels==0.10.0rc2
-
-RUN R -e 'devtools::install_github("all-of-us/bigrquery")'
+  statsmodels==0.10.0rc2 \
+  "git+git://github.com/all-of-us/workbench-snippets.git#egg=terra_widgets&subdirectory=py"
 


### PR DESCRIPTION
- Drop fork install of bigrquery (patches have now been merged and released in the main bigrquery package)
- Install new AoU Python library
- Bump aou image tag to 0.0.4

Tested via building locally and executing Python and R shells within the docker container.