### PR TITLE
Fix pandas version on AoU docker image

### DIFF
--- a/config/conf.json
+++ b/config/conf.json
@@ -101,7 +101,7 @@
             "base_label": "All of Us",
             "tools": ["python", "r"],
             "packages": {},
-            "version": "1.0.4",
+            "version": "1.0.5",
             "automated_flags": {
                 "include_in_ui": false,
                 "generate_docs": false,

--- a/config/conf.json
+++ b/config/conf.json
@@ -101,7 +101,7 @@
             "base_label": "All of Us",
             "tools": ["python", "r"],
             "packages": {},
-            "version": "1.0.5",
+            "version": "1.0.4",
             "automated_flags": {
                 "include_in_ui": false,
                 "generate_docs": false,

--- a/terra-jupyter-aou/CHANGELOG.md
+++ b/terra-jupyter-aou/CHANGELOG.md
@@ -1,10 +1,10 @@
-## 1.0.5 - 07/28/2020
+## 1.0.4 - 07/28/2020
 
 - Drop fork install of bigrquery (patches have now been merged and released in the main bigrquery package)
 - Install new AoU Python library
 - Avoid installing pandas 1.0 for now; pin other packages
 
-Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:1.0.5`
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:1.0.4`
 
 ## 1.0.3 - 06/29/2020
 

--- a/terra-jupyter-aou/CHANGELOG.md
+++ b/terra-jupyter-aou/CHANGELOG.md
@@ -1,9 +1,10 @@
-## 1.0.4 - 07/28/2020
+## 1.0.5 - 07/28/2020
 
 - Drop fork install of bigrquery (patches have now been merged and released in the main bigrquery package)
 - Install new AoU Python library
+- Avoid installing pandas 1.0 for now; pin other packages
 
-Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:1.0.4`
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:1.0.5`
 
 ## 1.0.3 - 06/29/2020
 

--- a/terra-jupyter-aou/Dockerfile
+++ b/terra-jupyter-aou/Dockerfile
@@ -44,7 +44,10 @@ USER $USER
 # Install Notebook libraries as the user.
 
 RUN pip3 install --upgrade \
-  plotnine \
+  # Fix plotnine and its dependency mizani to a version that's compatible with 0.25.* of pandas.
+  # The next versions require pandas 1.0 which we're not ready to upgrade to just yet.
+  plotnine==0.6.0 \
+  mizani==0.6.0 \
   statsmodels==0.10.0rc2 \
   "git+git://github.com/all-of-us/workbench-snippets.git#egg=terra_widgets&subdirectory=py"
 


### PR DESCRIPTION
plotnine 0.7.0 requires pandas 1.0, which I think will have other side-effects. Will investigate upgrading this separately.