### PR TITLE
IA-2040 remove explicit notebook install from python image

### DIFF
--- a/terra-jupyter-python/Dockerfile
+++ b/terra-jupyter-python/Dockerfile
@@ -30,7 +30,6 @@ RUN pip3 -V \
  && pip3 install pandas-gbq==0.12.0 \
  && pip3 install pandas-profiling==2.4.0 \
  && pip3 install seaborn==0.9.0 \
- && pip3 install notebook==5.7.8 \
  && pip3 install terra-notebook-utils==0.2.1 \
  && pip3 install python-lzo==1.12 \
  && pip3 install google-cloud-bigquery==1.23.1 \


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-2040

We install notebook in base. it shouldn't be needed in python image.
I'll delete the `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.15` from gcr, hence not bumping version