### PR TITLE
[IA-2169] Terminal default directory is now where PD is mounted

### DIFF
--- a/config/conf.json
+++ b/config/conf.json
@@ -26,7 +26,7 @@
                     "tidyverse"
                 ]
             },
-            "version" : "1.0.5",
+            "version" : "1.0.6",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : true,
@@ -47,7 +47,7 @@
                     "hail"
                 ]
             },
-            "version" : "0.0.19",
+            "version" : "0.0.20",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : true,
@@ -68,7 +68,7 @@
                     "scikit-learn"
                 ]
             },
-            "version" : "0.0.15",
+            "version" : "0.0.16",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : true,
@@ -86,7 +86,7 @@
             "packages" : {
                 
             },
-            "version" : "0.0.13",
+            "version" : "0.0.14",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : false,
@@ -104,7 +104,7 @@
             "packages" : {
                 
             },
-            "version" : "1.0.5",
+            "version" : "1.0.6",
             "automated_flags" : {
                 "include_in_ui" : false,
                 "generate_docs" : true,
@@ -124,7 +124,7 @@
             "packages" : {
                 
             },
-            "version" : "1.0.5",
+            "version" : "1.0.6",
             "automated_flags" : {
                 "include_in_ui" : true,
                 "generate_docs" : true,
@@ -143,7 +143,7 @@
             "packages" : {
                 
             },
-            "version" : "1.0.7",
+            "version" : "1.0.8",
             "automated_flags" : {
                 "include_in_ui" : false,
                 "generate_docs" : false,

--- a/terra-jupyter-aou/CHANGELOG.md
+++ b/terra-jupyter-aou/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.0.8 - 2020-09-02T15:12:19.917Z
+
+- Update `terra-jupyter-base` to `0.0.14`
+  - Terminal now opens to /notebooks directory where PD is mounted
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:1.0.8`
+
 ## 1.0.7 - 2020-08-18T13:43:26.277Z
 
 - Update `terra-jupyter-base` to `0.0.13`

--- a/terra-jupyter-aou/Dockerfile
+++ b/terra-jupyter-aou/Dockerfile
@@ -1,6 +1,6 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.15 AS python
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.16 AS python
 
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.5
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.6
 
 # copy everything pip installed from the python image
 COPY --from=python /usr/local/lib/python3.7/dist-packages /usr/local/lib/python3.7/dist-packages

--- a/terra-jupyter-base/CHANGELOG.md
+++ b/terra-jupyter-base/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.0.14 - 2020-09-02T15:12:19.821Z
+
+- Terminal now opens to /notebooks directory where PD is mounted
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:0.0.14`
+
 ## 0.0.13 - 2020-08-18T13:43:26.123Z
 
 - update notebook to 6.1.1, tornado to 5.1.1

--- a/terra-jupyter-base/Dockerfile
+++ b/terra-jupyter-base/Dockerfile
@@ -145,7 +145,8 @@ ENV PIP_USER=true
 #######################
 RUN wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O /tmp/miniconda.sh \
   && bash /tmp/miniconda.sh -b -p $HOME/miniconda \
-  && echo 'eval "$(/home/jupyter-user/miniconda/bin/conda shell.bash hook)"' >> /home/jupyter-user/.bashrc
+  && echo 'eval "$(/home/jupyter-user/miniconda/bin/conda shell.bash hook)"' >> /home/jupyter-user/.bashrc \
+  && echo 'cd /home/jupyter-user/notebooks' >> /home/jupyter-user/.bashrc
 
 #######################
 # Utilities

--- a/terra-jupyter-bioconductor/CHANGELOG.md
+++ b/terra-jupyter-bioconductor/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.0.6 - 2020-09-02T15:12:19.845Z
+
+- Update `terra-jupyter-base` to `0.0.14`
+  - Terminal now opens to /notebooks directory where PD is mounted
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:1.0.6`
+
 ## 1.0.5 - 2020-08-18T13:43:26.184Z
 
 - Update `terra-jupyter-base` to `0.0.13`

--- a/terra-jupyter-bioconductor/Dockerfile
+++ b/terra-jupyter-bioconductor/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.5
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.6
 
 USER root
 

--- a/terra-jupyter-gatk/CHANGELOG.md
+++ b/terra-jupyter-gatk/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.0.6 - 2020-09-02T15:12:19.908Z
+
+- Update `terra-jupyter-base` to `0.0.14`
+  - Terminal now opens to /notebooks directory where PD is mounted
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:1.0.6`
+
 ## 1.0.5 - 2020-08-18T13:43:26.263Z
 
 - Update `terra-jupyter-base` to `0.0.13`

--- a/terra-jupyter-gatk/Dockerfile
+++ b/terra-jupyter-gatk/Dockerfile
@@ -1,6 +1,6 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.15 AS python
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.16 AS python
 
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.5
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.6
 
 # copy everything pip installed from the python image
 COPY --from=python /usr/local/lib/python3.7/dist-packages /usr/local/lib/python3.7/dist-packages

--- a/terra-jupyter-hail/CHANGELOG.md
+++ b/terra-jupyter-hail/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.0.20 - 2020-09-02T15:12:19.860Z
+
+- Update `terra-jupyter-base` to `0.0.14`
+  - Terminal now opens to /notebooks directory where PD is mounted
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-hail:0.0.20`
+
 ## 0.0.19 - 2020-08-18T13:43:26.202Z
 
 - Update `terra-jupyter-base` to `0.0.13`

--- a/terra-jupyter-hail/Dockerfile
+++ b/terra-jupyter-hail/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.15
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.16
 USER root
 
 COPY scripts $JUPYTER_HOME/scripts

--- a/terra-jupyter-python/CHANGELOG.md
+++ b/terra-jupyter-python/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.0.16 - 2020-09-02T15:12:19.878Z
+
+- Update `terra-jupyter-base` to `0.0.14`
+  - Terminal now opens to /notebooks directory where PD is mounted
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.16`
+
 ## 0.0.15 - 2020-08-18T13:43:26.223Z
 
 - Update `terra-jupyter-base` to `0.0.13`

--- a/terra-jupyter-python/Dockerfile
+++ b/terra-jupyter-python/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:0.0.13
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:0.0.14
 USER root
 #this makes it so pip runs as root, not the user
 ENV PIP_USER=false

--- a/terra-jupyter-r/CHANGELOG.md
+++ b/terra-jupyter-r/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.0.6 - 2020-09-02T15:12:19.899Z
+
+- Update `terra-jupyter-base` to `0.0.14`
+  - Terminal now opens to /notebooks directory where PD is mounted
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.6`
+
 ## 1.0.5 - 2020-08-18T13:43:26.250Z
 
 - Update `terra-jupyter-base` to `0.0.13`

--- a/terra-jupyter-r/Dockerfile
+++ b/terra-jupyter-r/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:0.0.13
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:0.0.14
 USER root
 
 COPY scripts $JUPYTER_HOME/scripts


### PR DESCRIPTION
Add line to `/home/jupyter-user/.bashrc` that defaults the user's terminal to the directory where the PD is mounted.

Tested all of the following images (built them with my test base image with the new change): `terra-jupyter-base`, `terra-jupyter-python`, `terra-jupyter-aou` and verified that when I opened Jupyter then clicked New --> Terminal that the default directory is the correct one:
![Screen Shot 2020-09-02 at 12 18 46 PM](https://user-images.githubusercontent.com/23626109/92009476-8f738f00-ed16-11ea-9d35-ccceacdff9ba.png)

I also verified that everything pip that the images install is in the same directory as before (installed as root user and for the aou image some are installed as `jupyter-user` so I made sure those are where they're supposed to be as well)