### PR TITLE
AoU image: add Hail dependencies

### DIFF
--- a/config/conf.json
+++ b/config/conf.json
@@ -143,7 +143,7 @@
             "packages" : {
                 
             },
-            "version" : "1.0.9",
+            "version" : "1.0.10",
             "automated_flags" : {
                 "include_in_ui" : false,
                 "generate_docs" : false,

--- a/terra-jupyter-aou/CHANGELOG.md
+++ b/terra-jupyter-aou/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 1.0.10 - 09/18/2020
 
+ - Add Hail / Spark libs.
  - Bump GATK jar to latest commit ah_var_store branch:
    https://github.com/broadinstitute/gatk/tree/ah_var_store
 

--- a/terra-jupyter-aou/CHANGELOG.md
+++ b/terra-jupyter-aou/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.0.10 - 09/18/2020
+
+ - Bump GATK jar to latest commit ah_var_store branch:
+   https://github.com/broadinstitute/gatk/tree/ah_var_store
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:1.0.10`
+
 ## 1.0.9 - 09/17/2020
 
  - Install plink binary

--- a/terra-jupyter-aou/Dockerfile
+++ b/terra-jupyter-aou/Dockerfile
@@ -19,6 +19,8 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
   libhdf5-dev \
   openssl \
   make \
+  g++ \
+  liblz4-dev \
   liblzo2-dev \
   zlib1g-dev \
   libz-dev \
@@ -28,6 +30,36 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
   && update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
+
+
+# Spark setup.
+# Copied from terra-jupyter-hail; keep updated.
+
+# Note Spark and Hadoop are mounted from the outside Dataproc VM.
+# Make empty conf dirs for the update-alternatives commands.
+RUN mkdir -p /etc/spark/conf.dist && mkdir -p /etc/hadoop/conf.empty && mkdir -p /etc/hive/conf.dist \
+    && update-alternatives --install /etc/spark/conf spark-conf /etc/spark/conf.dist 100 \
+    && update-alternatives --install /etc/hadoop/conf hadoop-conf /etc/hadoop/conf.empty 100 \
+    && update-alternatives --install /etc/hive/conf hive-conf /etc/hive/conf.dist 100
+
+ENV HAIL_VERSION=0.2.57
+ENV PIP_USER=false
+
+# For dataproc clusters, this path with will be automatically mounted. Else,
+# this is effectively ignored. On GCE VMs, this will result in failures to
+# import the pyspark package.
+ENV PYTHONPATH $PYTHONPATH:/usr/lib/spark/python
+
+RUN pip3 install pypandoc \
+    && pip3 install --no-dependencies hail==$HAIL_VERSION \
+    && X=$(mktemp -d) \
+    && mkdir -p $X \
+    && (cd $X && pip3 download hail==$HAIL_VERSION --no-dependencies && \
+        unzip hail*.whl &&  \
+        grep 'Requires-Dist: ' hail*dist-info/METADATA | sed 's/Requires-Dist: //' | sed 's/ (//' | sed 's/)//' | grep -v 'pyspark' | xargs pip install) \
+    && rm -rf $X
+
+ENV PIP_USER=true
 
 # Install Wondershaper from source, for client-side egress limiting.
 RUN cd /usr/local/share && \

--- a/terra-jupyter-aou/Dockerfile
+++ b/terra-jupyter-aou/Dockerfile
@@ -39,7 +39,7 @@ RUN cd /usr/local/share && \
 # Install the variantstore branch of the GATK jar. This will eventually be
 # merged into the main release, at which point we can simply download the usual
 # GATK release jar and delete this entire section.
-ENV GATK_COMMIT=9b83e93
+ENV GATK_COMMIT=c79cd40
 
 # GATK build process requires git-lfs.
 RUN mkdir /tmp/git-lfs && \


### PR DESCRIPTION
AoU ticket: https://precisionmedicineinitiative.atlassian.net/browse/RW-5412

- Add Hail to AoU image
- Bump GATK branch commit

Verified that Hail is functional with Dataproc, and pyspark fails to import on GCE, which is reasonable behavior for now.

CC @ahaessly @petesantos @ericsong @rtitle @als364 