### PR TITLE
Bump hail to 0.0.22 to force a rebuild. No changes to the image since 0.0.21.

### DIFF
--- a/config/conf.json
+++ b/config/conf.json
@@ -47,7 +47,7 @@
                     "hail"
                 ]
             },
-            "version" : "0.0.21",
+            "version" : "0.0.22",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : true,

--- a/terra-jupyter-hail/CHANGELOG.md
+++ b/terra-jupyter-hail/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.0.22 - 2020-09-30
+- No changes; version bump due to CI/CD issues
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-hail:0.0.22`
+
 ## 0.0.21 - 2020-09-17
 
 - Update `hail` to `0.2.57`


### PR DESCRIPTION
Making a dummy 0.0.22 hail version because I think 0.0.21 was skipped due to CI/CD issues.