### PR TITLE
Include pip binary installation location in PATH

### DIFF
--- a/config/conf.json
+++ b/config/conf.json
@@ -26,7 +26,7 @@
                     "tidyverse"
                 ]
             },
-            "version" : "1.0.6",
+            "version" : "1.0.7",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : true,
@@ -47,7 +47,7 @@
                     "hail"
                 ]
             },
-            "version" : "0.0.22",
+            "version" : "0.0.23",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : true,
@@ -68,7 +68,7 @@
                     "scikit-learn"
                 ]
             },
-            "version" : "0.0.16",
+            "version" : "0.0.17",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : true,
@@ -86,7 +86,7 @@
             "packages" : {
                 
             },
-            "version" : "0.0.14",
+            "version" : "0.0.15",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : false,
@@ -104,7 +104,7 @@
             "packages" : {
                 
             },
-            "version" : "1.0.6",
+            "version" : "1.0.7",
             "automated_flags" : {
                 "include_in_ui" : false,
                 "generate_docs" : true,
@@ -124,7 +124,7 @@
             "packages" : {
                 
             },
-            "version" : "1.0.6",
+            "version" : "1.0.7",
             "automated_flags" : {
                 "include_in_ui" : true,
                 "generate_docs" : true,
@@ -143,7 +143,7 @@
             "packages" : {
                 
             },
-            "version" : "1.0.11",
+            "version" : "1.0.12",
             "automated_flags" : {
                 "include_in_ui" : false,
                 "generate_docs" : false,

--- a/terra-jupyter-aou/CHANGELOG.md
+++ b/terra-jupyter-aou/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.0.12 - 2020-10-08T18:42:19.744Z
+
+- Update `terra-jupyter-base` to `0.0.15`
+  - include pip binary installation location in PATH
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:1.0.12`
+
 ## 1.0.11 - 09/29/2020
 
  - Just download the custom GATK jar instead of building it.

--- a/terra-jupyter-aou/Dockerfile
+++ b/terra-jupyter-aou/Dockerfile
@@ -1,6 +1,6 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.16 AS python
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.17 AS python
 
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.6
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.7
 
 # copy everything pip installed from the python image
 COPY --from=python /usr/local/lib/python3.7/dist-packages /usr/local/lib/python3.7/dist-packages

--- a/terra-jupyter-base/CHANGELOG.md
+++ b/terra-jupyter-base/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.0.15 - 2020-10-08T18:42:19.647Z
+
+- include pip binary installation location in PATH
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:0.0.15`
+
 ## 0.0.14 - 2020-09-02T15:12:19.821Z
 
 - Terminal now opens to /notebooks directory where PD is mounted

--- a/terra-jupyter-base/Dockerfile
+++ b/terra-jupyter-base/Dockerfile
@@ -142,6 +142,10 @@ RUN mkdir -p /usr/local/share/jupyter/lab
 # make pip install to a user directory, instead of a system directory which requires root.
 # this is useful so `pip install` commands can be run in the context of a notebook.
 ENV PIP_USER=true
+# When using PIP_USER=true packages are installed into Python site.USER_BASE, which is '/home/jupyter-user' for this system.
+# Append '/home/jupyter-user/.local/bin' to PATH
+# pip docs: https://pip.pypa.io/en/stable/reference/pip_install/#cmdoption-user
+ENV PATH="${PATH}:/home/jupyter-user/.local/bin"
 
 #######################
 # Install Conda

--- a/terra-jupyter-bioconductor/CHANGELOG.md
+++ b/terra-jupyter-bioconductor/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.0.7 - 2020-10-08T18:42:19.678Z
+
+- Update `terra-jupyter-base` to `0.0.15`
+  - include pip binary installation location in PATH
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:1.0.7`
+
 ## 1.0.6 - 2020-09-02T15:12:19.845Z
 
 - Update `terra-jupyter-base` to `0.0.14`

--- a/terra-jupyter-bioconductor/Dockerfile
+++ b/terra-jupyter-bioconductor/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.6
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.7
 
 USER root
 

--- a/terra-jupyter-gatk/CHANGELOG.md
+++ b/terra-jupyter-gatk/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.0.7 - 2020-10-08T18:42:19.735Z
+
+- Update `terra-jupyter-base` to `0.0.15`
+  - include pip binary installation location in PATH
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:1.0.7`
+
 ## 1.0.6 - 2020-09-02T15:12:19.908Z
 
 - Update `terra-jupyter-base` to `0.0.14`

--- a/terra-jupyter-gatk/Dockerfile
+++ b/terra-jupyter-gatk/Dockerfile
@@ -1,6 +1,6 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.16 AS python
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.17 AS python
 
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.6
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.7
 
 # copy everything pip installed from the python image
 COPY --from=python /usr/local/lib/python3.7/dist-packages /usr/local/lib/python3.7/dist-packages

--- a/terra-jupyter-hail/CHANGELOG.md
+++ b/terra-jupyter-hail/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.0.23 - 2020-10-08T18:42:19.690Z
+
+- Update `terra-jupyter-base` to `0.0.15`
+  - include pip binary installation location in PATH
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-hail:0.0.23`
+
 ## 0.0.22 - 2020-09-30
 - No changes; version bump due to CI/CD issues
 

--- a/terra-jupyter-hail/Dockerfile
+++ b/terra-jupyter-hail/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.16
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.17
 USER root
 
 COPY scripts $JUPYTER_HOME/scripts

--- a/terra-jupyter-python/CHANGELOG.md
+++ b/terra-jupyter-python/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.0.17 - 2020-10-08T18:42:19.709Z
+
+- Update `terra-jupyter-base` to `0.0.15`
+  - include pip binary installation location in PATH
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.17`
+
 ## 0.0.16 - 2020-09-02T15:12:19.878Z
 
 - Update `terra-jupyter-base` to `0.0.14`

--- a/terra-jupyter-python/Dockerfile
+++ b/terra-jupyter-python/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:0.0.14
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:0.0.15
 USER root
 #this makes it so pip runs as root, not the user
 ENV PIP_USER=false

--- a/terra-jupyter-r/CHANGELOG.md
+++ b/terra-jupyter-r/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.0.7 - 2020-10-08T18:42:19.728Z
+
+- Update `terra-jupyter-base` to `0.0.15`
+  - include pip binary installation location in PATH
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.7`
+
 ## 1.0.6 - 2020-09-02T15:12:19.899Z
 
 - Update `terra-jupyter-base` to `0.0.14`

--- a/terra-jupyter-r/Dockerfile
+++ b/terra-jupyter-r/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:0.0.14
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:0.0.15
 USER root
 
 COPY scripts $JUPYTER_HOME/scripts

--- a/updateVersions.sc
+++ b/updateVersions.sc
@@ -108,7 +108,7 @@ def main(updatedImage: String, updatedImageReleaseNote: String): Unit = {
                 val firstSplit = s.split(":")
                 val splited = firstSplit(1).split("\\.")
                 s"${firstSplit(0)}:${splited(0)}.${splited(1)}.${splited(2).toInt + 1}\n"
-              } else if(s.contains("AS")) {
+              } else if(s.contains(" AS ")) {
                 val firstSplit = s.split(":")
                 val secondSplit = firstSplit(1).split(" ")
                 val splited = secondSplit(0).split("\\.")


### PR DESCRIPTION
This should allow Terra terminal users to execute pip installed binaries without manually modifying PATH.

It is also useful for automated CI/CD testing of notebook code in Leo environments, e.g. https://github.com/DataBiosphere/bdcat_notebooks