### PR TITLE
[IA-2255] Add RStudio/Bioconductor image to cloud environments dropdown

### DIFF
--- a/config/community_images.json
+++ b/config/community_images.json
@@ -10,7 +10,7 @@
 },
 {
     "id": "RStudio",
-    "label": "RStudio / Bioconductor (Python 2.7.17, BiocVersion 3.11.1, tidyverse 4.0.0)",
+    "label": "RStudio (R 4.0.0, Bioconductor 3.11.1, Python 2.7.17)",
     "version": "0.0.6",
     "updated": "2020-07-01",
     "packages": "https://storage.googleapis.com/terra-docker-image-documentation/placeholder.json",

--- a/config/community_images.json
+++ b/config/community_images.json
@@ -7,4 +7,14 @@
     "image": "cumulusprod/pegasus-terra:1.0",
     "requiresSpark": false,
     "isCommunity": true
+},
+{
+    "id": "RStudio",
+    "label": "RStudio / Bioconductor (Python 2.7.17, BiocVersion 3.11.1, tidyverse 4.0.0)",
+    "version": "0.0.6",
+    "updated": "2020-07-01",
+    "packages": "https://storage.googleapis.com/terra-docker-image-documentation/placeholder.json",
+    "image": "us.gcr.io/anvil-gcr-public/anvil-rstudio-bioconductor:0.0.6",
+    "requiresSpark": false,
+    "isRStudio": true
 }]

--- a/config/static_images.json
+++ b/config/static_images.json
@@ -1,0 +1,29 @@
+[
+  {
+    "id": "leonardo-jupyter-dev",
+    "label": "Legacy Python/R (default prior to January 14, 2020)",
+    "version": "FINAL",
+    "updated": "2019-08-26",
+    "packages": "https://storage.googleapis.com/terra-docker-image-documentation/leonardo-jupyter-dev-versions.json",
+    "image": "us.gcr.io/broad-dsp-gcr-public/leonardo-jupyter:5c51ce6935da",
+    "requiresSpark": true
+  },
+  {
+    "id": "terra-jupyter-gatk_legacy",
+    "label": "Legacy GATK (default prior to June 1, 2020) (GATK 4.1.4.1, Python 3.7.7, R 3.6.3)",
+    "version": "0.0.16",
+    "updated": "2020-05-18",
+    "packages": "https://storage.googleapis.com/terra-docker-image-documentation/terra-jupyter-gatk-0.0.16-versions.json",
+    "image": "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:0.0.16",
+    "requiresSpark": false
+  },
+  {
+    "id": "terra-jupyter-bioconductor_legacy",
+    "label": "Legacy R / Bioconductor (R 3.6.3, Bioconductor 3.10, Python 3.7.7)",
+    "version": "0.0.15",
+    "updated": "2020-05-18",
+    "packages": "https://storage.googleapis.com/terra-docker-image-documentation/terra-jupyter-bioconductor-0.0.15-versions.json",
+    "image": "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:0.0.15",
+    "requiresSpark": false
+  }
+]

--- a/scripts/generate_version_docs.py
+++ b/scripts/generate_version_docs.py
@@ -6,6 +6,7 @@ def get_config(path):
 
 config_location = "config/conf.json"
 community_config_location = "config/community_images.json"
+static_config_location = "config/static_images.json"
 config = get_config(config_location)
 
 def main():
@@ -100,35 +101,7 @@ def get_last_updated(image_config):
 # See definitions in https://docs.google.com/document/d/1qAp1wJTEx1UNtZ4vz1aV4PZRfjyYfF7QkwwOjK4LoD8/edit
 def get_other_docs():
   community_docs = utils.read_json_file(community_config_location)
-  static_docs = [
-    {
-      "id": 'leonardo-jupyter-dev',
-      "label": 'Legacy Python/R (default prior to January 14, 2020)',
-      "version": 'FINAL',
-      "updated": '2019-08-26',
-      "packages": 'https://storage.googleapis.com/terra-docker-image-documentation/leonardo-jupyter-dev-versions.json',
-      "image": 'us.gcr.io/broad-dsp-gcr-public/leonardo-jupyter:5c51ce6935da',
-      "requiresSpark": True
-    },
-    {
-      "id": 'terra-jupyter-gatk_legacy',
-      "label": 'Legacy GATK (default prior to June 1, 2020) (GATK 4.1.4.1, Python 3.7.7, R 3.6.3)',
-      "version": '0.0.16',
-      "updated": '2020-05-18',
-      "packages": 'https://storage.googleapis.com/terra-docker-image-documentation/terra-jupyter-gatk-0.0.16-versions.json',
-      "image": 'us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:0.0.16',
-      "requiresSpark": False
-    },
-    {
-      "id": 'terra-jupyter-bioconductor_legacy',
-      "label": 'Legacy R / Bioconductor (R 3.6.3, Bioconductor 3.10, Python 3.7.7)',
-      "version": '0.0.15',
-      "updated": '2020-05-18',
-      "packages": 'https://storage.googleapis.com/terra-docker-image-documentation/terra-jupyter-bioconductor-0.0.15-versions.json',
-      "image": 'us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:0.0.15',
-      "requiresSpark": False
-    }
-  ]
+  static_docs = utils.read_json_file(static_config_location)
 
   return community_docs + static_docs
 


### PR DESCRIPTION
Tested by doing the following:
- ran the `generate_version_docs.py` script, replacing `terra-docker-versions-new.json` with `gabriela-test-rstudio.json` and verified that the json file that gets generated is what we expect it to be, the only difference being that the new file includes the RStudio image.
- The corresponding terra-ui changes can be found in this PR: https://github.com/DataBiosphere/terra-ui/pull/2291
- Tested that I could create a runtime using the new rstudio image on my local terra-ui branch (by using the `gabriela-test-rstudio.json` file that i pushed to the google bucket) and everything is working as expected

Screenshot of terra-ui changes:
<img width="668" alt="Screen Shot 2020-10-21 at 3 25 05 PM" src="https://user-images.githubusercontent.com/23626109/96772876-c3337280-13b1-11eb-8cfe-c7d24f233089.png">
