### PR TITLE
Don't use gsutil in the aou Dockerfile, causes CLI issues

### DIFF
--- a/config/conf.json
+++ b/config/conf.json
@@ -143,7 +143,7 @@
             "packages" : {
                 
             },
-            "version" : "1.0.13",
+            "version" : "1.0.14",
             "automated_flags" : {
                 "include_in_ui" : false,
                 "generate_docs" : false,

--- a/terra-jupyter-aou/CHANGELOG.md
+++ b/terra-jupyter-aou/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.0.14 - 2020-10-22
+
+- Don't use gsutil, it creates local credentials files which break downstream CLI usage
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:1.0.14`
+
 ## 1.0.13 - 2020-10-21
 
 - Add [variantstore](https://github.com/broadinstitute/variantstore) extraction tool

--- a/terra-jupyter-aou/Dockerfile
+++ b/terra-jupyter-aou/Dockerfile
@@ -74,9 +74,8 @@ RUN cd /usr/local/share && \
 ENV VARSTORE_GATK_RELEASE=4.1.8.1-127-g0360115-SNAPSHOT-local
 ENV GATK_LOCAL_JAR=/usr/local/share/gatk.jar
 
-RUN gsutil cp \
-  "gs://broad-dsp-spec-ops-public/gatk-package-${VARSTORE_GATK_RELEASE}.jar" \
-  "${GATK_LOCAL_JAR}"
+RUN curl -L -o "${GATK_LOCAL_JAR}" \
+  "https://storage.googleapis.com/storage/v1/b/broad-dsp-spec-ops-public/o/gatk-package-${VARSTORE_GATK_RELEASE}.jar?alt=media"
 
 ENV VARSTORE_TOOLS_VERSION=bdd7f95
 RUN git clone https://github.com/broadinstitute/variantstore.git /tmp/varstore && \


### PR DESCRIPTION
Invoking gsutil from the Docker build process has side-effects: avoid.

As an end user, this resulted in errors such as:

```
!gsutil ls ${WORKSPACE_BUCKET}

Traceback (most recent call last):
  File "/usr/lib/google-cloud-sdk/lib/googlecloudsdk/core/util/files.py", line 1227, in _FileOpener
    return io.open(path, mode, encoding=encoding)
PermissionError: [Errno 13] Permission denied: '/home/jupyter-user/.config/gcloud/active_config'
```