### PR TITLE
Add package 'keychain' to base image to facilitate use of 'ssh-agent' and 'ssh-add'.

### DIFF
--- a/terra-jupyter-base/Dockerfile
+++ b/terra-jupyter-base/Dockerfile
@@ -54,6 +54,9 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
     git \
     jq \
 
+    # for ssh-agent and ssh-add
+    keychain \
+
     # for jupyterlab extensions
     nodejs-dev \
     node-gyp \


### PR DESCRIPTION
Fixes #168.