### PR TITLE
[IA-2235] Bump RStudio version

### DIFF
--- a/config/community_images.json
+++ b/config/community_images.json
@@ -11,10 +11,10 @@
 {
     "id": "RStudio",
     "label": "RStudio (R 4.0.0, Bioconductor 3.11.1, Python 2.7.17)",
-    "version": "0.0.6",
-    "updated": "2020-07-01",
+    "version": "0.0.7",
+    "updated": "2020-10-28",
     "packages": "https://storage.googleapis.com/terra-docker-image-documentation/placeholder.json",
-    "image": "us.gcr.io/anvil-gcr-public/anvil-rstudio-bioconductor:0.0.6",
+    "image": "us.gcr.io/anvil-gcr-public/anvil-rstudio-bioconductor:0.0.7",
     "requiresSpark": false,
     "isRStudio": true
 }]


### PR DESCRIPTION
See: 
https://broadworkbench.atlassian.net/browse/IA-2235
https://github.com/anvilproject/anvil-docker/pull/20
https://github.com/DataBiosphere/leonardo/pull/1674

I'm also bumping it in Leo automation tests and generating new custom GCE/Dataproc images. My plan is to make this live next week after the next Leo release.

@gpcarr how do I generate a new `terra-docker-versions-new.json` after merging this?
