### PR TITLE
IA-2345: Update anvil-rstudio-bioconductor to 0.0.8

### DIFF
--- a/config/community_images.json
+++ b/config/community_images.json
@@ -10,11 +10,11 @@
 },
 {
     "id": "RStudio",
-    "label": "RStudio (R 4.0.0, Bioconductor 3.11.1, Python 2.7.17)",
-    "version": "0.0.7",
-    "updated": "2020-10-28",
+    "label": "RStudio (R 4.0.3, Bioconductor 3.12.0, Python 3.8.5)",
+    "version": "0.0.8",
+    "updated": "2020-11-09",
     "packages": "https://storage.googleapis.com/terra-docker-image-documentation/placeholder.json",
-    "image": "us.gcr.io/anvil-gcr-public/anvil-rstudio-bioconductor:0.0.7",
+    "image": "us.gcr.io/anvil-gcr-public/anvil-rstudio-bioconductor:0.0.8",
     "requiresSpark": false,
     "isRStudio": true
 }]


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-2345

anvil-docker PR: https://github.com/anvilproject/anvil-docker/pull/21

Leo PR: https://github.com/DataBiosphere/leonardo/pull/1692