### PR TITLE
IA-2346 terra-docker: Remove Python package enum34

### DIFF
--- a/config/conf.json
+++ b/config/conf.json
@@ -47,7 +47,7 @@
                     "hail"
                 ]
             },
-            "version" : "0.0.24",
+            "version" : "0.0.25",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : true,
@@ -68,7 +68,7 @@
                     "scikit-learn"
                 ]
             },
-            "version" : "0.0.18",
+            "version" : "0.0.19",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : true,
@@ -124,7 +124,7 @@
             "packages" : {
                 
             },
-            "version" : "1.0.9",
+            "version" : "1.0.10",
             "automated_flags" : {
                 "include_in_ui" : true,
                 "generate_docs" : true,
@@ -143,7 +143,7 @@
             "packages" : {
                 
             },
-            "version" : "1.0.16",
+            "version" : "1.0.17",
             "automated_flags" : {
                 "include_in_ui" : false,
                 "generate_docs" : false,

--- a/terra-jupyter-aou/CHANGELOG.md
+++ b/terra-jupyter-aou/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.0.17 - 2020-11-10T13:26:19.148Z
+
+- Update `terra-jupyter-python` to `0.0.19`
+  - Remove Python package enum34. Fixes https://github.com/DataBiosphere/terra-docker/issues/175
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:1.0.17`
+
 ## 1.0.16 - 2020-11-04T21:43:54.919Z
 
 - Update `terra-jupyter-r` to `1.0.9`

--- a/terra-jupyter-aou/Dockerfile
+++ b/terra-jupyter-aou/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.18 AS python
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.19 AS python
 
 FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.9
 

--- a/terra-jupyter-gatk/CHANGELOG.md
+++ b/terra-jupyter-gatk/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.0.10 - 2020-11-10T13:26:19.126Z
+
+- Update `terra-jupyter-python` to `0.0.19`
+  - Remove Python package enum34. Fixes https://github.com/DataBiosphere/terra-docker/issues/175
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:1.0.10`
+
 ## 1.0.9 - 2020-11-04T21:43:54.895Z
 
 - Update `terra-jupyter-r` to `1.0.9`

--- a/terra-jupyter-gatk/Dockerfile
+++ b/terra-jupyter-gatk/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.18 AS python
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.19 AS python
 
 FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.9
 

--- a/terra-jupyter-hail/CHANGELOG.md
+++ b/terra-jupyter-hail/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.0.25 - 2020-11-10T13:26:19.112Z
+
+- Update `terra-jupyter-python` to `0.0.19`
+  - Remove Python package enum34. Fixes https://github.com/DataBiosphere/terra-docker/issues/175
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-hail:0.0.25`
+
 ## 0.0.24 - 2020-10-26T20:13:57.675Z
 
 - Update `terra-jupyter-base` to `0.0.16`

--- a/terra-jupyter-hail/Dockerfile
+++ b/terra-jupyter-hail/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.18
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.19
 USER root
 
 COPY scripts $JUPYTER_HOME/scripts

--- a/terra-jupyter-python/CHANGELOG.md
+++ b/terra-jupyter-python/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.0.19 - 2020-11-10T13:26:19.077Z
+
+- Remove Python package enum34. Fixes https://github.com/DataBiosphere/terra-docker/issues/175
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.19`
+
 ## 0.0.18 - 2020-10-26T20:13:57.706Z
 
 - Update `terra-jupyter-base` to `0.0.16`

--- a/terra-jupyter-python/Dockerfile
+++ b/terra-jupyter-python/Dockerfile
@@ -56,7 +56,6 @@ RUN pip3 -V \
  && pip3 install matplotlib-venn==0.11.5 \
  && pip3 install bleach==1.5.0 \
  && pip3 install cycler==0.10.0 \
- && pip3 install enum34==1.1.6 \
  && pip3 install h5py==2.7.1 \
  && pip3 install html5lib==0.9999999 \
  && pip3 install joblib==0.11 \

--- a/updateVersions.sc
+++ b/updateVersions.sc
@@ -79,6 +79,12 @@ def main(updatedImage: String, updatedImageReleaseNote: String): Unit = {
       "terra-jupyter-gatk",
       "terra-jupyter-aou"
     )
+    case "terra-jupyter-python" => List(
+      "terra-jupyter-python",
+      "terra-jupyter-hail",
+      "terra-jupyter-gatk",
+      "terra-jupyter-aou"
+    )
     case updatedImage =>
       throw new Exception(s"${updatedImage} is not supported yet. Please update the script to support the image")
   }


### PR DESCRIPTION
Merged from https://github.com/DataBiosphere/terra-docker/issues/175, also updates versions.

JIRA to track: https://broadworkbench.atlassian.net/browse/IA-2346