### PR TITLE
Bump versions + changelog for https://github.com/DataBiosphere/terra-docker/pull/183

### DIFF
--- a/config/conf.json
+++ b/config/conf.json
@@ -26,7 +26,7 @@
                     "tidyverse"
                 ]
             },
-            "version" : "1.0.10",
+            "version" : "1.0.11",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : true,
@@ -104,7 +104,7 @@
             "packages" : {
                 
             },
-            "version" : "1.0.10",
+            "version" : "1.0.11",
             "automated_flags" : {
                 "include_in_ui" : false,
                 "generate_docs" : true,
@@ -124,7 +124,7 @@
             "packages" : {
                 
             },
-            "version" : "1.0.11",
+            "version" : "1.0.12",
             "automated_flags" : {
                 "include_in_ui" : true,
                 "generate_docs" : true,
@@ -143,7 +143,7 @@
             "packages" : {
                 
             },
-            "version" : "1.0.18",
+            "version" : "1.0.19",
             "automated_flags" : {
                 "include_in_ui" : false,
                 "generate_docs" : false,

--- a/terra-jupyter-aou/CHANGELOG.md
+++ b/terra-jupyter-aou/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.0.19 - 2020-12-02T16:56:10.147Z
+
+- Update `terra-jupyter-r` to `1.0.11`
+  - bump terra-notebook-utils version to 0.7.0
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:1.0.19`
+
 ## 1.0.18 - 2020-11-16T18:11:40.848741Z
 
 - Remove dependency on miniconda

--- a/terra-jupyter-aou/Dockerfile
+++ b/terra-jupyter-aou/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.21 AS python
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.20 AS python
 
 FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.11
 

--- a/terra-jupyter-aou/Dockerfile
+++ b/terra-jupyter-aou/Dockerfile
@@ -1,6 +1,6 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.20 AS python
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.21 AS python
 
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.10
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.11
 
 # copy everything pip installed from the python image
 COPY --from=python /usr/local/lib/python3.7/dist-packages /usr/local/lib/python3.7/dist-packages

--- a/terra-jupyter-bioconductor/CHANGELOG.md
+++ b/terra-jupyter-bioconductor/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.0.11 - 2020-12-02T16:56:10.112Z
+
+- Update `terra-jupyter-r` to `1.0.11`
+  - bump terra-notebook-utils version to 0.7.0
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:1.0.11`
+
 ## 1.0.10 - 2020-11-16T18:11:40.741594Z
 
 - Update `terra-jupyter-base` to `0.0.17`

--- a/terra-jupyter-bioconductor/Dockerfile
+++ b/terra-jupyter-bioconductor/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.10
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.11
 
 USER root
 

--- a/terra-jupyter-gatk/CHANGELOG.md
+++ b/terra-jupyter-gatk/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.0.12 - 2020-12-02T16:56:10.126Z
+
+- Update `terra-jupyter-r` to `1.0.11`
+  - bump terra-notebook-utils version to 0.7.0
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:1.0.12`
+
 ## 1.0.11 - 2020-11-16T18:11:40.830329Z
 
 - Update `terra-jupyter-base` to `0.0.17`

--- a/terra-jupyter-gatk/Dockerfile
+++ b/terra-jupyter-gatk/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.21 AS python
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.20 AS python
 
 FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.11
 

--- a/terra-jupyter-gatk/Dockerfile
+++ b/terra-jupyter-gatk/Dockerfile
@@ -1,6 +1,6 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.20 AS python
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.21 AS python
 
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.10
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.11
 
 # copy everything pip installed from the python image
 COPY --from=python /usr/local/lib/python3.7/dist-packages /usr/local/lib/python3.7/dist-packages

--- a/terra-jupyter-r/CHANGELOG.md
+++ b/terra-jupyter-r/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.0.11 - 2020-12-02T16:56:10.085Z
+
+- bump terra-notebook-utils version to 0.7.0
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.11`
+
 ## 1.0.10 - 2020-11-16T18:11:40.819538Z
 
 - Update `terra-jupyter-base` to `0.0.17`

--- a/updateVersions.sc
+++ b/updateVersions.sc
@@ -123,7 +123,7 @@ def main(updatedImage: String, updatedImageReleaseNote: String): Unit = {
                 val firstSplit = s.split(":")
                 val splited = firstSplit(1).split("\\.")
                 s"${firstSplit(0)}:${splited(0)}.${splited(1)}.${splited(2).toInt + 1}\n"
-              } else if(s.contains(" AS ")) {
+              } else if(s.contains(" AS ") && imagesToUpdate.contains("terra-jupyter-python")) {
                 val firstSplit = s.split(":")
                 val secondSplit = firstSplit(1).split(" ")
                 val splited = secondSplit(0).split("\\.")


### PR DESCRIPTION
tested changes to `updateVersions.sc` in a separate branch, ran `amm ./updateVersions.sc terra-jupyter-r "bump terra-notebook-utils version to 0.7.0"` and verified that we don't bump the version for `terra-jupyter-python` in any Dockerfile in the `FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.20 AS python` section

bumping versions for https://github.com/DataBiosphere/terra-docker/pull/183