### PR TITLE
Move terra-notebook-utils to base image and bump all image versions

### DIFF
--- a/config/conf.json
+++ b/config/conf.json
@@ -26,7 +26,7 @@
                     "tidyverse"
                 ]
             },
-            "version" : "1.0.10",
+            "version" : "1.0.11",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : true,
@@ -47,7 +47,7 @@
                     "hail"
                 ]
             },
-            "version" : "0.0.26",
+            "version" : "0.0.27",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : true,
@@ -68,7 +68,7 @@
                     "scikit-learn"
                 ]
             },
-            "version" : "0.0.20",
+            "version" : "0.0.21",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : true,
@@ -86,7 +86,7 @@
             "packages" : {
                 
             },
-            "version" : "0.0.17",
+            "version" : "0.0.18",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : false,
@@ -104,7 +104,7 @@
             "packages" : {
                 
             },
-            "version" : "1.0.10",
+            "version" : "1.0.11",
             "automated_flags" : {
                 "include_in_ui" : false,
                 "generate_docs" : true,
@@ -124,7 +124,7 @@
             "packages" : {
                 
             },
-            "version" : "1.0.11",
+            "version" : "1.0.12",
             "automated_flags" : {
                 "include_in_ui" : true,
                 "generate_docs" : true,
@@ -143,7 +143,7 @@
             "packages" : {
                 
             },
-            "version" : "1.0.18",
+            "version" : "1.0.19",
             "automated_flags" : {
                 "include_in_ui" : false,
                 "generate_docs" : false,

--- a/terra-jupyter-aou/CHANGELOG.md
+++ b/terra-jupyter-aou/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.0.19 - 2020-12-02T17:59:36.458Z
+
+- Update `terra-jupyter-base` to `0.0.18`
+  - bump terra-notebook-utils version to 0.7.0 and move it to base image
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:1.0.19`
+
 ## 1.0.18 - 2020-11-16T18:11:40.848741Z
 
 - Remove dependency on miniconda

--- a/terra-jupyter-aou/Dockerfile
+++ b/terra-jupyter-aou/Dockerfile
@@ -1,6 +1,6 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.20 AS python
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.21 AS python
 
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.10
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.11
 
 # copy everything pip installed from the python image
 COPY --from=python /usr/local/lib/python3.7/dist-packages /usr/local/lib/python3.7/dist-packages

--- a/terra-jupyter-base/CHANGELOG.md
+++ b/terra-jupyter-base/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.0.18 - 2020-12-02T17:59:36.345Z
+
+- bump terra-notebook-utils version to 0.7.0 and move it to base image
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:0.0.18`
+
 ## 0.0.17 - 2020-11-16T18:11:40.717364Z
 
 - remove miniconda

--- a/terra-jupyter-base/Dockerfile
+++ b/terra-jupyter-base/Dockerfile
@@ -127,6 +127,7 @@ RUN pip3 -V \
  && pip3 install notebook==6.1.1 \
  && pip3 install jupyter==1.0.0 \
  && pip3 install python-datauri \
+ && pip3 install terra-notebook-utils==0.7.0 \
  && pip3 install jupyterlab==0.35.4 \
  && pip3 install cookiecutter \
  && pip3 install jupyter_contrib_nbextensions \

--- a/terra-jupyter-base/Dockerfile
+++ b/terra-jupyter-base/Dockerfile
@@ -151,6 +151,9 @@ ENV PIP_USER=true
 # pip docs: https://pip.pypa.io/en/stable/reference/pip_install/#cmdoption-user
 ENV PATH="${PATH}:/home/jupyter-user/.local/bin"
 
+# Default terminal directory should be where PD is mounted
+RUN echo 'cd /home/jupyter-user/notebooks' >> /home/jupyter-user/.bashrc
+
 #######################
 # Utilities
 #######################

--- a/terra-jupyter-bioconductor/CHANGELOG.md
+++ b/terra-jupyter-bioconductor/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.0.11 - 2020-12-02T17:59:36.375Z
+
+- Update `terra-jupyter-base` to `0.0.18`
+  - bump terra-notebook-utils version to 0.7.0 and move it to base image
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:1.0.11`
+
 ## 1.0.10 - 2020-11-16T18:11:40.741594Z
 
 - Update `terra-jupyter-base` to `0.0.17`

--- a/terra-jupyter-bioconductor/Dockerfile
+++ b/terra-jupyter-bioconductor/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.10
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.11
 
 USER root
 

--- a/terra-jupyter-gatk/CHANGELOG.md
+++ b/terra-jupyter-gatk/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.0.12 - 2020-12-02T17:59:36.443Z
+
+- Update `terra-jupyter-base` to `0.0.18`
+  - bump terra-notebook-utils version to 0.7.0 and move it to base image
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:1.0.12`
+
 ## 1.0.11 - 2020-11-16T18:11:40.830329Z
 
 - Update `terra-jupyter-base` to `0.0.17`

--- a/terra-jupyter-gatk/Dockerfile
+++ b/terra-jupyter-gatk/Dockerfile
@@ -1,6 +1,6 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.20 AS python
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.21 AS python
 
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.10
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.11
 
 # copy everything pip installed from the python image
 COPY --from=python /usr/local/lib/python3.7/dist-packages /usr/local/lib/python3.7/dist-packages

--- a/terra-jupyter-hail/CHANGELOG.md
+++ b/terra-jupyter-hail/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.0.27 - 2020-12-02T17:59:36.390Z
+
+- Update `terra-jupyter-base` to `0.0.18`
+  - bump terra-notebook-utils version to 0.7.0 and move it to base image
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-hail:0.0.27`
+
 ## 0.0.26 - 2020-11-16T18:11:40.758876Z
 
 - Update `terra-jupyter-base` to `0.0.17`

--- a/terra-jupyter-hail/Dockerfile
+++ b/terra-jupyter-hail/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.20
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.21
 USER root
 
 COPY scripts $JUPYTER_HOME/scripts

--- a/terra-jupyter-python/CHANGELOG.md
+++ b/terra-jupyter-python/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.0.21 - 2020-12-02T17:59:36.411Z
+
+- Update `terra-jupyter-base` to `0.0.18`
+  - bump terra-notebook-utils version to 0.7.0 and move it to base image
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.21`
+
 ## 0.0.20 - 2020-11-16T18:11:40.785376Z
 
 - Update `terra-jupyter-base` to `0.0.17`

--- a/terra-jupyter-python/Dockerfile
+++ b/terra-jupyter-python/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:0.0.17
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:0.0.18
 USER root
 #this makes it so pip runs as root, not the user
 ENV PIP_USER=false
@@ -30,7 +30,6 @@ RUN pip3 -V \
  && pip3 install pandas-gbq==0.12.0 \
  && pip3 install pandas-profiling==2.4.0 \
  && pip3 install seaborn==0.9.0 \
- && pip3 install terra-notebook-utils==0.2.1 \
  && pip3 install python-lzo==1.12 \
  && pip3 install google-cloud-bigquery==1.23.1 \
  && pip3 install google-api-core==1.6.0 \

--- a/terra-jupyter-r/CHANGELOG.md
+++ b/terra-jupyter-r/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.0.11 - 2020-12-02T17:59:36.434Z
+
+- Update `terra-jupyter-base` to `0.0.18`
+  - bump terra-notebook-utils version to 0.7.0 and move it to base image
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.11`
+
 ## 1.0.10 - 2020-11-16T18:11:40.819538Z
 
 - Update `terra-jupyter-base` to `0.0.17`

--- a/terra-jupyter-r/Dockerfile
+++ b/terra-jupyter-r/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:0.0.17
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:0.0.18
 USER root
 
 COPY scripts $JUPYTER_HOME/scripts
@@ -109,7 +109,6 @@ RUN apt-get update \
     && pip3 install --upgrade pip \
     && pip3 install cwltool==1.0.20190228155703 \
     && pip3 install pandas==0.25.3 \
- 		&& pip3 install terra-notebook-utils==0.7.0 \
     && pip3 install pyyaml \
     && pip3 install scikit-learn==0.21.3 \
     && apt-get clean \

--- a/updateVersions.sc
+++ b/updateVersions.sc
@@ -122,7 +122,10 @@ def main(updatedImage: String, updatedImageReleaseNote: String): Unit = {
               if(s.contains("FROM") && !s.contains("AS")) {
                 val firstSplit = s.split(":")
                 val splited = firstSplit(1).split("\\.")
-                s"${firstSplit(0)}:${splited(0)}.${splited(1)}.${splited(2).toInt + 1}\n"
+                val imageName = firstSplit(0).split("\\/")(2)
+                if(imagesToUpdate.contains(imageName)) {
+                  s"${firstSplit(0)}:${splited(0)}.${splited(1)}.${splited(2).toInt + 1}\n"
+                } else s"${s}\n"
               } else if(s.contains(" AS ") && imagesToUpdate.contains("terra-jupyter-python")) {
                 val firstSplit = s.split(":")
                 val secondSplit = firstSplit(1).split(" ")

--- a/updateVersions.sc
+++ b/updateVersions.sc
@@ -123,7 +123,7 @@ def main(updatedImage: String, updatedImageReleaseNote: String): Unit = {
                 val firstSplit = s.split(":")
                 val splited = firstSplit(1).split("\\.")
                 s"${firstSplit(0)}:${splited(0)}.${splited(1)}.${splited(2).toInt + 1}\n"
-              } else if(s.contains(" AS ")) {
+              } else if(s.contains(" AS ") && imagesToUpdate.contains("terra-jupyter-python")) {
                 val firstSplit = s.split(":")
                 val secondSplit = firstSplit(1).split(" ")
                 val splited = secondSplit(0).split("\\.")


### PR DESCRIPTION
going to be closing this PR: https://github.com/DataBiosphere/terra-docker/pull/184

changes to `updateVersions.sc` were tested using both `amm ./updateVersions.sc terra-jupyter-base "[message]"` and `amm ./updateVersions.sc terra-jupyter-r "[message]"`