### PR TITLE
Fix base image

### DIFF
--- a/terra-jupyter-base/Dockerfile
+++ b/terra-jupyter-base/Dockerfile
@@ -115,7 +115,7 @@ ENV PATH ${PATH:+$PATH:}$USER_INSTALL_DIR/bin
 RUN apt update \
    && apt install -yq software-properties-common \
    && add-apt-repository ppa:deadsnakes/ppa \
-   && apt install -yq python3.7 \
+   && apt install -yq python3.7-dev \
    && update-alternatives --install /usr/local/bin/python3 python3 /usr/bin/python3.7 1 \
    && apt-get -yq install python3-pip \
    && /usr/local/bin/python3 -m pip install --upgrade pip
@@ -127,7 +127,6 @@ RUN pip3 -V \
  && pip3 install notebook==6.1.1 \
  && pip3 install jupyter==1.0.0 \
  && pip3 install python-datauri \
- && pip3 install terra-notebook-utils==0.7.0 \
  && pip3 install jupyterlab==0.35.4 \
  && pip3 install cookiecutter \
  && pip3 install jupyter_contrib_nbextensions \
@@ -135,7 +134,9 @@ RUN pip3 -V \
  # for jupyter_delocalize.py and jupyter_notebook_config.py
  && pip3 install tornado==5.1.1 \
  && pip3 install requests \
+ && pip3 install six==1.15.0 \
  && pip3 install firecloud==0.16.25 \
+ && pip3 install terra-notebook-utils==0.7.0 \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 

--- a/terra-jupyter-python/Dockerfile
+++ b/terra-jupyter-python/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:gabriela-test
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:0.0.18
 USER root
 #this makes it so pip runs as root, not the user
 ENV PIP_USER=false

--- a/terra-jupyter-python/Dockerfile
+++ b/terra-jupyter-python/Dockerfile
@@ -1,10 +1,9 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:0.0.18
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:gabriela-test
 USER root
 #this makes it so pip runs as root, not the user
 ENV PIP_USER=false
 
 RUN apt-get update && apt-get install -yq --no-install-recommends \
-  python3.7-dev \
   python-tk \
   tk-dev \
   libssl-dev \
@@ -70,7 +69,6 @@ RUN pip3 -V \
  && pip3 install pyvcf==0.6.8 \
  && pip3 install pyyaml==3.12 \
  && pip3 install scipy==1.2 \
- && pip3 install six==1.13.0 \
  && pip3 install tensorflow==2.0.0a0 \
  && pip3 install theano==0.9.0 \
  && pip3 install tqdm==4.19.4 \

--- a/terra-jupyter-r/Dockerfile
+++ b/terra-jupyter-r/Dockerfile
@@ -104,7 +104,7 @@ ENV PIP_USER=false
 
 ## Install python packages needed for a few Bioc packages
 RUN apt-get update \
-    && apt-get install -yq --no-install-recommends python3.7-dev \
+    && apt-get install -yq --no-install-recommends \
     && pip3 -V \
     && pip3 install --upgrade pip \
     && pip3 install cwltool==1.0.20190228155703 \


### PR DESCRIPTION
This PR fixes the base image by adding `pip3 install six==1.15.0` and installing `python3.7-dev` instead of `python3.7` and moving `pip3 install terra-notebook-utils==0.7.0` to after we install `firecloud` because TNU depends on firecloud

Removes `six` and `python3.7-dev` installation from python and r images since now we install them in base image