### PR TITLE
Update to a newer version of pymc3.

### DIFF
--- a/terra-jupyter-python/Dockerfile
+++ b/terra-jupyter-python/Dockerfile
@@ -60,7 +60,7 @@ RUN pip3 -V \
  && pip3 install keras==2.1.6 \
  && pip3 install patsy==0.4.1 \
  && pip3 install protobuf==3.7.1 \
- && pip3 install pymc3==3.1 \
+ && pip3 install pymc3==3.10.0 \
  && pip3 install pyparsing==2.2.0 \
  && pip3 install Cython \
  && pip3 install pysam==0.15.4 --no-binary pysam \


### PR DESCRIPTION
Newer versions of this library no longer depend on the obsolete enum34 library.

Fixes https://github.com/DataBiosphere/terra-docker/issues/175