### PR TITLE
[IA-2420] Update to a newer version of pymc3

### DIFF
--- a/config/conf.json
+++ b/config/conf.json
@@ -47,7 +47,7 @@
                     "hail"
                 ]
             },
-            "version" : "0.0.28",
+            "version" : "0.0.29",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : true,
@@ -68,7 +68,7 @@
                     "scikit-learn"
                 ]
             },
-            "version" : "0.0.21",
+            "version" : "0.0.22",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : true,
@@ -124,7 +124,7 @@
             "packages" : {
                 
             },
-            "version" : "1.0.12",
+            "version" : "1.0.13",
             "automated_flags" : {
                 "include_in_ui" : true,
                 "generate_docs" : true,
@@ -143,7 +143,7 @@
             "packages" : {
                 
             },
-            "version" : "1.0.19",
+            "version" : "1.0.20",
             "automated_flags" : {
                 "include_in_ui" : false,
                 "generate_docs" : false,

--- a/terra-jupyter-aou/CHANGELOG.md
+++ b/terra-jupyter-aou/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.0.20 - 2020-12-09T18:50:57.334Z
+
+- Update `terra-jupyter-python` to `0.0.22`
+  - [IA-2420] Update to a newer version of pymc3
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:1.0.20`
+
 ## 1.0.19 - 2020-12-02T17:59:36.458Z
 
 - Update `terra-jupyter-base` to `0.0.18`

--- a/terra-jupyter-aou/CHANGELOG.md
+++ b/terra-jupyter-aou/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Update `terra-jupyter-python` to `0.0.22`
   - [IA-2420] Update to a newer version of pymc3
+- Update hail version to `0.2.61`
 
 Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:1.0.20`
 

--- a/terra-jupyter-aou/Dockerfile
+++ b/terra-jupyter-aou/Dockerfile
@@ -108,9 +108,6 @@ RUN pip3 install --upgrade \
   mizani==0.6.0 \
   # Parent image pins tensorflow to an old alpha version. Override here for now.
   tensorflow==2.3.0 \
-  # This version of numpy should already be installed but isn't. See IA-2122.
-  # This line can be removed once that ticket is resolved.
-  numpy==1.19.0 \
   statsmodels==0.10.0rc2 \
   "git+git://github.com/all-of-us/workbench-snippets.git#egg=terra_widgets&subdirectory=py"
 

--- a/terra-jupyter-aou/Dockerfile
+++ b/terra-jupyter-aou/Dockerfile
@@ -108,6 +108,7 @@ RUN pip3 install --upgrade \
   mizani==0.6.0 \
   # Parent image pins tensorflow to an old alpha version. Override here for now.
   tensorflow==2.3.0 \
+  numpy==1.18.5 \
   statsmodels==0.10.0rc2 \
   "git+git://github.com/all-of-us/workbench-snippets.git#egg=terra_widgets&subdirectory=py"
 

--- a/terra-jupyter-aou/Dockerfile
+++ b/terra-jupyter-aou/Dockerfile
@@ -42,7 +42,7 @@ RUN mkdir -p /etc/spark/conf.dist && mkdir -p /etc/hadoop/conf.empty && mkdir -p
     && update-alternatives --install /etc/hadoop/conf hadoop-conf /etc/hadoop/conf.empty 100 \
     && update-alternatives --install /etc/hive/conf hive-conf /etc/hive/conf.dist 100
 
-ENV HAIL_VERSION=0.2.57
+ENV HAIL_VERSION=0.2.61
 ENV PIP_USER=false
 
 # For dataproc clusters, this path with will be automatically mounted. Else,

--- a/terra-jupyter-aou/Dockerfile
+++ b/terra-jupyter-aou/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.21 AS python
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.22 AS python
 
 FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.11
 

--- a/terra-jupyter-gatk/CHANGELOG.md
+++ b/terra-jupyter-gatk/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.0.13 - 2020-12-09T18:50:57.311Z
+
+- Update `terra-jupyter-python` to `0.0.22`
+  - [IA-2420] Update to a newer version of pymc3
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:1.0.13`
+
 ## 1.0.12 - 2020-12-02T17:59:36.443Z
 
 - Update `terra-jupyter-base` to `0.0.18`

--- a/terra-jupyter-gatk/Dockerfile
+++ b/terra-jupyter-gatk/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.21 AS python
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.22 AS python
 
 FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.11
 

--- a/terra-jupyter-hail/CHANGELOG.md
+++ b/terra-jupyter-hail/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.0.29 - 2020-12-09T18:50:57.298Z
+
+- Update `terra-jupyter-python` to `0.0.22`
+  - [IA-2420] Update to a newer version of pymc3
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-hail:0.0.29`
+
 ## 0.0.28 - 2020-12-03
 
 - Update `hail` to `0.2.61`

--- a/terra-jupyter-hail/Dockerfile
+++ b/terra-jupyter-hail/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.21
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.22
 USER root
 
 COPY scripts $JUPYTER_HOME/scripts

--- a/terra-jupyter-python/CHANGELOG.md
+++ b/terra-jupyter-python/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.0.22 - 2020-12-09T18:50:57.262Z
+
+- [IA-2420] Update to a newer version of pymc3
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.22`
+
 ## 0.0.21 - 2020-12-02T17:59:36.411Z
 
 - Update `terra-jupyter-base` to `0.0.18`


### PR DESCRIPTION
Original PR with the actual change: https://github.com/DataBiosphere/terra-docker/pull/188

This PR bumps the versions of python, hail, gatk, and aou images.