### PR TITLE
[IA-2343] Add AppSec Github Trivy Action

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -21,6 +21,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Cleanup disk space
+        run: |
+          df -h
+
       - uses: broadinstitute/dsp-appsec-trivy-action@v1
         with:
           context: ${{ matrix.context }}

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -21,11 +21,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      # Configure GCR
-      - uses: google-github-actions/setup-gcloud@v0.2.0
-      - run: gcloud auth configure-docker
-
-      # Build and scan the image
       - uses: broadinstitute/dsp-appsec-trivy-action@v1
         with:
           context: ${{ matrix.context }}

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -24,6 +24,13 @@ jobs:
       - name: Cleanup disk space
         run: |
           df -h
+          swapoff -a
+          rm -f /swapfile
+          df -h
+          apt clean
+          df -h
+          docker rmi $(docker image ls -aq)
+          df -h
 
       - uses: broadinstitute/dsp-appsec-trivy-action@v1
         with:

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -21,6 +21,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      # Configure GCR
+      - uses: google-github-actions/setup-gcloud@v0.2.0
+      - run: gcloud auth configure-docker
+
+      # Build and scan the image
       - uses: broadinstitute/dsp-appsec-trivy-action@v1
         with:
           context: ${{ matrix.context }}

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Cleanup disk space
+      - name: Clean up disk space
         run: docker rmi $(docker image ls -aq)
 
       - uses: broadinstitute/dsp-appsec-trivy-action@v1

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        workdir:
+        context:
         - terra-jupyter-aou
         - terra-jupyter-base
         - terra-jupyter-bioconductor
@@ -23,4 +23,4 @@ jobs:
 
       - uses: broadinstitute/dsp-appsec-trivy-action@v1
         with:
-          context: ${{ matrix.workdir }}
+          context: ${{ matrix.context }}

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -24,10 +24,10 @@ jobs:
       - name: Cleanup disk space
         run: |
           df -h
-          swapoff -a
-          rm -f /swapfile
+          sudo swapoff -a
+          sudo rm -f /swapfile
           df -h
-          apt clean
+          sudo apt clean
           df -h
           docker rmi $(docker image ls -aq)
           df -h

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,0 +1,26 @@
+name: dsp-appsec-trivy
+on: [pull_request]
+
+jobs:
+  appsec-trivy:
+    # Parse Dockerfile and build, scan image if a "blessed" base image is not used
+    name: DSP AppSec Trivy check
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        workdir:
+        - terra-jupyter-aou
+        - terra-jupyter-base
+        - terra-jupyter-bioconductor
+        - terra-jupyter-gatk
+        - terra-jupyter-hail
+        - terra-jupyter-python
+        - terra-jupyter-r
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: broadinstitute/dsp-appsec-trivy-action@v1
+        with:
+          context: ${{ matrix.workdir }}

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -22,15 +22,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Cleanup disk space
-        run: |
-          df -h
-          sudo swapoff -a
-          sudo rm -f /swapfile
-          df -h
-          sudo apt clean
-          df -h
-          docker rmi $(docker image ls -aq)
-          df -h
+        run: docker rmi $(docker image ls -aq)
 
       - uses: broadinstitute/dsp-appsec-trivy-action@v1
         with:

--- a/build.sh
+++ b/build.sh
@@ -25,7 +25,7 @@ if [[ $VAULT_LOCATION == *"jenkins"* ]]; then
     VAULT_LOCATION="/etc/vault-token-dsde"
 fi
 
-# will fail if you are not gcloud authed as dspci-wb-gcr-service-account or secret/dsde/firecloud/common/image-build-account.json 
+# will fail if you are not gcloud authed as dspci-wb-gcr-service-account or secret/dsde/firecloud/common/image-build-account.json
 # the below works locally but not on jenkins for some reason, using a different account until a resolution is found
 # docker run --rm  -v $VAULT_LOCATION:/root/.vault-token:ro broadinstitute/dsde-toolbox:latest vault read --format=json secret/dsde/dsp-techops/common/dspci-wb-gcr-service-account.json | jq .data > dspci-wb-gcr-service-account.json
 # gcloud auth activate-service-account --key-file=dspci-wb-gcr-service-account.json
@@ -33,12 +33,9 @@ docker run --rm  -v $VAULT_LOCATION:/root/.vault-token:ro broadinstitute/dsde-to
 gcloud auth activate-service-account --key-file=image-build-account.json
 gcloud auth configure-docker --quiet
 
-docker image build ./$IMAGE_DIR --tag $GCR_IMAGE_REPO/$IMAGE_DIR:$TAG_NAME --tag $GCR_IMAGE_REPO/$IMAGE_DIR:$VERSION 
+docker image build ./$IMAGE_DIR --tag $GCR_IMAGE_REPO/$IMAGE_DIR:$TAG_NAME --tag $GCR_IMAGE_REPO/$IMAGE_DIR:$VERSION
 
-echo "Scanning the docker image for any critical security vulnerabilities..."
-# docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v "$HOME"/.cache:/root/.cache/ aquasec/trivy --exit-code 1 --severity CRITICAL  "$GCR_IMAGE_REPO"/"$IMAGE_DIR":"$TAG_NAME"
-
-docker push $GCR_IMAGE_REPO/$IMAGE_DIR:$TAG_NAME 
+docker push $GCR_IMAGE_REPO/$IMAGE_DIR:$TAG_NAME
 docker push $GCR_IMAGE_REPO/$IMAGE_DIR:$VERSION
 
 rm -f /home/jenkins/.docker/config.json
@@ -51,14 +48,14 @@ if [[ $IMAGE_DIR = "terra-jupyter-aou" ]]; then
   docker push broadinstitute/$IMAGE_DIR:$TAG_NAME
 fi
 
-docker kill $IMAGE_DIR || true 
+docker kill $IMAGE_DIR || true
 docker rm -f $IMAGE_DIR || true
 docker run --rm -itd -u root -e PIP_USER=false --entrypoint='/bin/bash' --name $IMAGE_DIR $GCR_IMAGE_REPO/$IMAGE_DIR:$VERSION
 
 gcloud auth list
 python scripts/generate_package_docs.py "$IMAGE_DIR"
 
-docker kill $IMAGE_DIR || true 
+docker kill $IMAGE_DIR || true
 docker rm -f $IMAGE_DIR || true
 docker image rm -f $GCR_IMAGE_REPO/$IMAGE_DIR:$VERSION
 docker image rm -f $GCR_IMAGE_REPO/$IMAGE_DIR:$TAG_NAME

--- a/terra-jupyter-base/Dockerfile
+++ b/terra-jupyter-base/Dockerfile
@@ -78,7 +78,6 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
  && apt-get update \
  && apt-get install -yq --no-install-recommends \
     google-cloud-sdk \
-
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 

--- a/terra-jupyter-base/Dockerfile
+++ b/terra-jupyter-base/Dockerfile
@@ -78,6 +78,7 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
  && apt-get update \
  && apt-get install -yq --no-install-recommends \
     google-cloud-sdk \
+
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
This change adds Trivy security scan for the Docker image, as discussed in the Workbench Cross-Team meeting.

The action will run on every PR and give you feedback if the Docker image contains critical OS vulnerabilities.

More info:
https://github.com/broadinstitute/dsp-appsec-trivy-action
https://github.com/broadinstitute/dsp-appsec-blessed-images