### PR TITLE
[IA-2472] Turn on debug-level logging when JUPYTER_DEBUG_LOGGING env var is true

### DIFF
--- a/terra-jupyter-base/jupyter_notebook_config.py
+++ b/terra-jupyter-base/jupyter_notebook_config.py
@@ -6,6 +6,10 @@
 import os
 
 c = get_config()
+
+if os.environ.get('JUPYTER_DEBUG_LOGGING') == 'true':
+  c.Application.log_level = 'DEBUG'
+
 c.NotebookApp.ip = '0.0.0.0'
 c.NotebookApp.port = 8000
 c.NotebookApp.open_browser = False


### PR DESCRIPTION
(Note: see https://github.com/DataBiosphere/leonardo/pull/1833 for related Leo PR keeping both files in sync.)

Turns on conditional debug-level logging for the Jupyter application, controlled by an environment variable.