### PR TITLE
Bump versions for IA-2472

### DIFF
--- a/config/conf.json
+++ b/config/conf.json
@@ -26,7 +26,7 @@
                     "tidyverse"
                 ]
             },
-            "version" : "1.0.11",
+            "version" : "1.0.12",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : true,
@@ -47,7 +47,7 @@
                     "hail"
                 ]
             },
-            "version" : "0.0.29",
+            "version" : "0.0.30",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : true,
@@ -68,7 +68,7 @@
                     "scikit-learn"
                 ]
             },
-            "version" : "0.0.22",
+            "version" : "0.0.23",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : true,
@@ -86,7 +86,7 @@
             "packages" : {
                 
             },
-            "version" : "0.0.18",
+            "version" : "0.0.19",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : false,
@@ -104,7 +104,7 @@
             "packages" : {
                 
             },
-            "version" : "1.0.11",
+            "version" : "1.0.12",
             "automated_flags" : {
                 "include_in_ui" : false,
                 "generate_docs" : true,
@@ -124,7 +124,7 @@
             "packages" : {
                 
             },
-            "version" : "1.0.13",
+            "version" : "1.0.14",
             "automated_flags" : {
                 "include_in_ui" : true,
                 "generate_docs" : true,
@@ -143,7 +143,7 @@
             "packages" : {
                 
             },
-            "version" : "1.0.20",
+            "version" : "1.0.21",
             "automated_flags" : {
                 "include_in_ui" : false,
                 "generate_docs" : false,

--- a/terra-jupyter-aou/CHANGELOG.md
+++ b/terra-jupyter-aou/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.0.21 - 2021-01-20T16:00:48.370Z
+
+- Update `terra-jupyter-base` to `0.0.19`
+  - [IA-2472] Turn on debug-level logging when JUPYTER_DEBUG_LOGGING env var is true
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:1.0.21`
+
 ## 1.0.20 - 2020-12-09T18:50:57.334Z
 
 - Update `terra-jupyter-python` to `0.0.22`

--- a/terra-jupyter-aou/Dockerfile
+++ b/terra-jupyter-aou/Dockerfile
@@ -1,6 +1,6 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.22 AS python
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.23 AS python
 
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.11
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.12
 
 # copy everything pip installed from the python image
 COPY --from=python /usr/local/lib/python3.7/dist-packages /usr/local/lib/python3.7/dist-packages

--- a/terra-jupyter-base/CHANGELOG.md
+++ b/terra-jupyter-base/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.0.19 - 2021-01-20T16:00:48.255Z
+
+- [IA-2472] Turn on debug-level logging when JUPYTER_DEBUG_LOGGING env var is true
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:0.0.19`
+
 ## 0.0.18 - 2020-12-02T17:59:36.345Z
 
 - bump terra-notebook-utils version to 0.7.0 and move it to base image

--- a/terra-jupyter-bioconductor/CHANGELOG.md
+++ b/terra-jupyter-bioconductor/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.0.12 - 2021-01-20T16:00:48.285Z
+
+- Update `terra-jupyter-base` to `0.0.19`
+  - [IA-2472] Turn on debug-level logging when JUPYTER_DEBUG_LOGGING env var is true
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:1.0.12`
+
 ## 1.0.11 - 2020-12-02T17:59:36.375Z
 
 - Update `terra-jupyter-base` to `0.0.18`

--- a/terra-jupyter-bioconductor/Dockerfile
+++ b/terra-jupyter-bioconductor/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.11
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.12
 
 USER root
 

--- a/terra-jupyter-gatk/CHANGELOG.md
+++ b/terra-jupyter-gatk/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.0.14 - 2021-01-20T16:00:48.352Z
+
+- Update `terra-jupyter-base` to `0.0.19`
+  - [IA-2472] Turn on debug-level logging when JUPYTER_DEBUG_LOGGING env var is true
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:1.0.14`
+
 ## 1.0.13 - 2020-12-09T18:50:57.311Z
 
 - Update `terra-jupyter-python` to `0.0.22`

--- a/terra-jupyter-gatk/Dockerfile
+++ b/terra-jupyter-gatk/Dockerfile
@@ -1,6 +1,6 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.22 AS python
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.23 AS python
 
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.11
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.12
 
 # copy everything pip installed from the python image
 COPY --from=python /usr/local/lib/python3.7/dist-packages /usr/local/lib/python3.7/dist-packages

--- a/terra-jupyter-hail/CHANGELOG.md
+++ b/terra-jupyter-hail/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.0.30 - 2021-01-20T16:00:48.299Z
+
+- Update `terra-jupyter-base` to `0.0.19`
+  - [IA-2472] Turn on debug-level logging when JUPYTER_DEBUG_LOGGING env var is true
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-hail:0.0.30`
+
 ## 0.0.29 - 2020-12-09T18:50:57.298Z
 
 - Update `terra-jupyter-python` to `0.0.22`

--- a/terra-jupyter-hail/Dockerfile
+++ b/terra-jupyter-hail/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.22
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.23
 USER root
 
 COPY scripts $JUPYTER_HOME/scripts

--- a/terra-jupyter-python/CHANGELOG.md
+++ b/terra-jupyter-python/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.0.23 - 2021-01-20T16:00:48.318Z
+
+- Update `terra-jupyter-base` to `0.0.19`
+  - [IA-2472] Turn on debug-level logging when JUPYTER_DEBUG_LOGGING env var is true
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.23`
+
 ## 0.0.22 - 2020-12-09T18:50:57.262Z
 
 - [IA-2420] Update to a newer version of pymc3

--- a/terra-jupyter-python/Dockerfile
+++ b/terra-jupyter-python/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:0.0.18
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:0.0.19
 USER root
 #this makes it so pip runs as root, not the user
 ENV PIP_USER=false

--- a/terra-jupyter-r/CHANGELOG.md
+++ b/terra-jupyter-r/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.0.12 - 2021-01-20T16:00:48.341Z
+
+- Update `terra-jupyter-base` to `0.0.19`
+  - [IA-2472] Turn on debug-level logging when JUPYTER_DEBUG_LOGGING env var is true
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.12`
+
 ## 1.0.11 - 2020-12-02T17:59:36.434Z
 
 - Update `terra-jupyter-base` to `0.0.18`

--- a/terra-jupyter-r/Dockerfile
+++ b/terra-jupyter-r/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:0.0.18
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:0.0.19
 USER root
 
 COPY scripts $JUPYTER_HOME/scripts


### PR DESCRIPTION
Ran:
```
amm ./updateVersions.sc terra-jupyter-base "[IA-2472] Turn on debug-level logging when JUPYTER_DEBUG_LOGGING env var is true"
```

Original PR: https://github.com/DataBiosphere/terra-docker/pull/193

[IA-2472]: https://broadworkbench.atlassian.net/browse/IA-2472