### PR TITLE
[no ticket] Update pyyaml versions to be consistent across python and r images

### DIFF
--- a/terra-jupyter-python/Dockerfile
+++ b/terra-jupyter-python/Dockerfile
@@ -67,7 +67,7 @@ RUN pip3 -V \
  && pip3 install python-dateutil==2.6.1 \
  && pip3 install pytz==2017.3 \
  && pip3 install pyvcf==0.6.8 \
- && pip3 install pyyaml==3.12 \
+ && pip3 install pyyaml==5.3.1 \
  && pip3 install scipy==1.2 \
  && pip3 install tensorflow==2.0.0a0 \
  && pip3 install theano==0.9.0 \

--- a/terra-jupyter-r/Dockerfile
+++ b/terra-jupyter-r/Dockerfile
@@ -109,7 +109,7 @@ RUN apt-get update \
     && pip3 install --upgrade pip \
     && pip3 install cwltool==1.0.20190228155703 \
     && pip3 install pandas==0.25.3 \
-    && pip3 install pyyaml \
+    && pip3 install pyyaml==5.3.1 \
     && pip3 install scikit-learn==0.21.3 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
I think this was causing issues starting up Jupyter in the latest terra-docker build. Example error from AoU image (which extends from both python and r images):
```
$ docker run --rm -it -p 8000:8000 us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:1.0.21
[I 00:49:37.496 NotebookApp] initializing DelocalizingContentsManager
[I 00:49:37.503 NotebookApp] Writing notebook server cookie secret to /home/jupyter-user/.local/share/jupyter/runtime/notebook_cookie_secret
[W 00:49:37.731 NotebookApp] All authentication is disabled.  Anyone who can connect to this server will be able to run code.
[W 00:49:37.751 NotebookApp] Error loading server extension jupyter_nbextensions_configurator
    Traceback (most recent call last):
      File "/usr/local/lib/python3.7/dist-packages/notebook/notebookapp.py", line 1934, in init_server_extensions
        mod = importlib.import_module(modulename)
      File "/usr/lib/python3.7/importlib/__init__.py", line 127, in import_module
        return _bootstrap._gcd_import(name[level:], package, level)
      File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
      File "<frozen importlib._bootstrap>", line 983, in _find_and_load
      File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
      File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
      File "<frozen importlib._bootstrap_external>", line 728, in exec_module
      File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
      File "/usr/local/lib/python3.7/dist-packages/jupyter_nbextensions_configurator/__init__.py", line 16, in <module>
        import yaml
      File "/usr/local/lib/python3.7/dist-packages/yaml/__init__.py", line 13, in <module>
        from .cyaml import *
      File "/usr/local/lib/python3.7/dist-packages/yaml/cyaml.py", line 5, in <module>
        from _yaml import CParser, CEmitter
      File "/usr/local/lib/python3.7/dist-packages/_yaml/__init__.py", line 8, in <module>
        if not yaml.__with_libyaml__:
    AttributeError: module 'yaml' has no attribute '__with_libyaml__'
```

And with the fix:
```
$ docker run --rm -it -p 8000:8000 terra-jupyter-aou:pyyaml-fix
[I 00:50:07.045 NotebookApp] initializing DelocalizingContentsManager
[I 00:50:07.056 NotebookApp] Writing notebook server cookie secret to /home/jupyter-user/.local/share/jupyter/runtime/notebook_cookie_secret
[W 00:50:07.780 NotebookApp] All authentication is disabled.  Anyone who can connect to this server will be able to run code.
[I 00:50:07.871 NotebookApp] [jupyter_nbextensions_configurator] enabled 0.4.1
[I 00:50:08.016 NotebookApp] JupyterLab extension loaded from /usr/local/lib/python3.7/dist-packages/jupyterlab
[I 00:50:08.016 NotebookApp] JupyterLab application directory is /usr/local/share/jupyter/lab
[I 00:50:08.020 NotebookApp] Serving notebooks from local directory: /home/jupyter-user
[I 00:50:08.021 NotebookApp] Jupyter Notebook 6.1.1 is running at:
[I 00:50:08.021 NotebookApp] http://9fed1b53b504:8000/notebooks/
[I 00:50:08.022 NotebookApp] Use Control-C to stop this server and shut down all kernels (twice to skip confirmation).
```

I think what happened is a new `pyyaml` version released in Jan 2021 which was not backwards compatible with some Jupyter libraries. See: https://pypi.org/project/PyYAML/#history. I pegged our images to the previous working version (from Mar 2020).

I still want to do some testing with Leo, but assuming it works, I think I will merge this with no version bumps and regenerate the latest versions of all images. Then hopefully tests will pass in https://github.com/DataBiosphere/leonardo/pull/1840/.