### PR TITLE
Update hail to 0.2.62

### DIFF
--- a/config/conf.json
+++ b/config/conf.json
@@ -47,7 +47,7 @@
                     "hail"
                 ]
             },
-            "version" : "0.0.30",
+            "version" : "0.0.31",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : true,

--- a/terra-jupyter-hail/CHANGELOG.md
+++ b/terra-jupyter-hail/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.0.31 - 2021-02-05
+
+- Update `hail` to `0.2.62`
+  - See https://hail.is/docs/0.2/change_log.html#version-0-2-61 for details.
+- Update `pandas` to `1.1.x`
+
 ## 0.0.30 - 2021-01-20T16:00:48.299Z
 
 - Update `terra-jupyter-base` to `0.0.19`

--- a/terra-jupyter-hail/Dockerfile
+++ b/terra-jupyter-hail/Dockerfile
@@ -5,7 +5,7 @@ COPY scripts $JUPYTER_HOME/scripts
 
 ENV PIP_USER=false
 ENV PYTHONPATH $PYTHONPATH:/usr/lib/spark/python
-ENV HAIL_VERSION=0.2.61
+ENV HAIL_VERSION=0.2.62
 
 RUN find $JUPYTER_HOME/scripts -name '*.sh' -type f | xargs chmod +x \
     && $JUPYTER_HOME/scripts/kernel/kernelspec.sh $JUPYTER_HOME/scripts/kernel /usr/local/share/jupyter/kernels \


### PR DESCRIPTION
This PR updates `terra-jupyter-hail` to use hail version 0.2.62. 

@Qi77Qi  asked if we could update hail to depend on a newer version of pandas. Hail version 0.2.62 makes this change, allowing pandas versions: pandas>=1.1.0,<1.1.5