### PR TITLE
Update all Python package versions by unpinning them.

### DIFF
--- a/config/conf.json
+++ b/config/conf.json
@@ -47,7 +47,7 @@
                     "hail"
                 ]
             },
-            "version" : "0.0.32",
+            "version" : "0.1.0",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : true,
@@ -68,7 +68,7 @@
                     "scikit-learn"
                 ]
             },
-            "version" : "0.0.24",
+            "version" : "0.1.0",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : true,
@@ -124,7 +124,7 @@
             "packages" : {
 
             },
-            "version" : "1.0.16",
+            "version" : "1.1.0",
             "automated_flags" : {
                 "include_in_ui" : true,
                 "generate_docs" : true,
@@ -143,7 +143,7 @@
             "packages" : {
 
             },
-            "version" : "1.0.24",
+            "version" : "1.1.0",
             "automated_flags" : {
                 "include_in_ui" : false,
                 "generate_docs" : false,

--- a/config/conf.json
+++ b/config/conf.json
@@ -68,7 +68,7 @@
                     "scikit-learn"
                 ]
             },
-            "version" : "0.0.23",
+            "version" : "0.0.24",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : true,
@@ -84,7 +84,7 @@
                 "python"
             ],
             "packages" : {
-                
+
             },
             "version" : "0.0.19",
             "automated_flags" : {
@@ -102,7 +102,7 @@
                 "r"
             ],
             "packages" : {
-                
+
             },
             "version" : "1.0.13",
             "automated_flags" : {
@@ -122,7 +122,7 @@
                 "r"
             ],
             "packages" : {
-                
+
             },
             "version" : "1.0.15",
             "automated_flags" : {
@@ -141,9 +141,9 @@
                 "r"
             ],
             "packages" : {
-                
+
             },
-            "version" : "1.0.23",
+            "version" : "1.0.24",
             "automated_flags" : {
                 "include_in_ui" : false,
                 "generate_docs" : false,

--- a/config/conf.json
+++ b/config/conf.json
@@ -47,7 +47,7 @@
                     "hail"
                 ]
             },
-            "version" : "0.0.31",
+            "version" : "0.0.32",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : true,
@@ -124,7 +124,7 @@
             "packages" : {
 
             },
-            "version" : "1.0.15",
+            "version" : "1.0.16",
             "automated_flags" : {
                 "include_in_ui" : true,
                 "generate_docs" : true,

--- a/terra-jupyter-aou/CHANGELOG.md
+++ b/terra-jupyter-aou/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.0.24 - 2021-03-10
+## 1.0.24 - 2021-03-15
 
 - Update `terra-jupyter-python` to `0.0.24`
 - Remove more Python package overrides which are no longer needed due to updates in the base Python image.

--- a/terra-jupyter-aou/CHANGELOG.md
+++ b/terra-jupyter-aou/CHANGELOG.md
@@ -1,8 +1,10 @@
-## 1.0.24 - 2021-03-15
+## 1.1.0 - 2021-03-20
 
-- Update `terra-jupyter-python` to `0.0.24`
+- Update `terra-jupyter-python` to `0.1.0`
 - Remove more Python package overrides which are no longer needed due to updates in the base Python image.
 - Add nbstripout and enable it globally so that its in effect for any git repository cloned to the VM.
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:1.1.0`
 
 ## 1.0.23 - 2021-02-22
 

--- a/terra-jupyter-aou/CHANGELOG.md
+++ b/terra-jupyter-aou/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.0.24 - 2021-03-10
+
+- Update `terra-jupyter-python` to `0.0.24`
+- Remove more Python package overrides which are no longer needed due to updates in the base Python image.
+- Add nbstripout and enable it globally so that its in effect for any git repository cloned to the VM.
+
 ## 1.0.23 - 2021-02-22
 
 - Remove varstore scripts / GATK jar

--- a/terra-jupyter-aou/Dockerfile
+++ b/terra-jupyter-aou/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.23 AS python
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.24 AS python
 
 FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.13
 
@@ -85,9 +85,7 @@ ENV USER jupyter-user
 USER $USER
 
 RUN pip3 install --upgrade \
-  pandas-profiling==2.10.1 \
-  plotnine==0.7.1 \
-  # Parent image pins tensorflow to an old alpha version. Override here for now.
-  tensorflow==2.3.0 \
-  numpy==1.18.5 \
-  "git+git://github.com/all-of-us/workbench-snippets.git#egg=terra_widgets&subdirectory=py"
+  nbstripout \
+  "git+git://github.com/all-of-us/workbench-snippets.git#egg=terra_widgets&subdirectory=py" \
+  && mkdir -p /home/$USER/.config/git \
+  && nbstripout --install --global

--- a/terra-jupyter-aou/Dockerfile
+++ b/terra-jupyter-aou/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.24 AS python
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.1.0 AS python
 
 FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.13
 

--- a/terra-jupyter-gatk/CHANGELOG.md
+++ b/terra-jupyter-gatk/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.0.16 - 2021-03-15
+
+- Update `terra-jupyter-python` to `0.0.24`
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:1.0.16`
+
 ## 1.0.15 - 2021-02-10T00:36:57.172Z
 
 - Update `terra-jupyter-r` to `1.0.13`

--- a/terra-jupyter-gatk/CHANGELOG.md
+++ b/terra-jupyter-gatk/CHANGELOG.md
@@ -1,8 +1,8 @@
-## 1.0.16 - 2021-03-15
+## 1.1.0 - 2021-03-20
 
-- Update `terra-jupyter-python` to `0.0.24`
+- Update `terra-jupyter-python` to `0.1.0`
 
-Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:1.0.16`
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:1.1.0`
 
 ## 1.0.15 - 2021-02-10T00:36:57.172Z
 

--- a/terra-jupyter-gatk/Dockerfile
+++ b/terra-jupyter-gatk/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.23 AS python
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.24 AS python
 
 FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.13
 

--- a/terra-jupyter-gatk/Dockerfile
+++ b/terra-jupyter-gatk/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.24 AS python
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.1.0 AS python
 
 FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.13
 

--- a/terra-jupyter-hail/CHANGELOG.md
+++ b/terra-jupyter-hail/CHANGELOG.md
@@ -1,8 +1,8 @@
-## 0.0.32 - 2021-03-15
+## 0.1.0 - 2021-03-20
 
-- Update `terra-jupyter-python` to `0.0.24`
+- Update `terra-jupyter-python` to `0.1.0`
 
-Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-hail:0.0.31`
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-hail:0.1.0`
 
 ## 0.0.31 - 2021-02-05
 

--- a/terra-jupyter-hail/CHANGELOG.md
+++ b/terra-jupyter-hail/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.0.32 - 2021-03-15
+
+- Update `terra-jupyter-python` to `0.0.24`
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-hail:0.0.31`
+
 ## 0.0.31 - 2021-02-05
 
 - Update `hail` to `0.2.62`

--- a/terra-jupyter-hail/Dockerfile
+++ b/terra-jupyter-hail/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.24
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.1.0
 USER root
 
 COPY scripts $JUPYTER_HOME/scripts

--- a/terra-jupyter-hail/Dockerfile
+++ b/terra-jupyter-hail/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.23
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.24
 USER root
 
 COPY scripts $JUPYTER_HOME/scripts

--- a/terra-jupyter-python/CHANGELOG.md
+++ b/terra-jupyter-python/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.0.24 - 2021-03-15
+## 0.1.0 - 2021-03-20
 
 - Update all Python package versions by unpinning them.
 - Add package `plotnine`. Fixes https://github.com/DataBiosphere/terra-docker/issues/126
@@ -6,7 +6,7 @@
 - Add package `google-resumable-media` as an explicit dependency to ensure a more recent version of it is used. `pandas-gbq` depends on it for table uploads.
 - Work around lack of 'bigquery.readsessions.create' permission [CA-1179] by uninstalling the dependency `google-cloud-bigquery-storage` so that flag `--use_rest_api` can be used with `%%bigquery` to use the older mechanism for data transfer.
 
-Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.24`
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.1.0`
 
 ## 0.0.23 - 2021-01-20T16:00:48.318Z
 

--- a/terra-jupyter-python/CHANGELOG.md
+++ b/terra-jupyter-python/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.0.24 - 2021-03-10
+
+- Update all Python package versions by unpinning them.
+- Add package `plotnine`. Fixes https://github.com/DataBiosphere/terra-docker/issues/126
+- Replace package `tensorflow` with `tensorflow_cpu` to get rid of the warnings about GPUs being unavailable for Terra Cloud Runtimes.
+- Add package `google-resumable-media` as an explicit dependency to ensure a more recent version of it is used. `pandas-gbq` depends on it for table uploads.
+- Work around lack of 'bigquery.readsessions.create' permission [CA-1179] by uninstalling the dependency `google-cloud-bigquery-storage` so that flag `--use_rest_api` can be used with `%%bigquery` to use the older mechanism for data transfer.
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.24`
+
 ## 0.0.23 - 2021-01-20T16:00:48.318Z
 
 - Update `terra-jupyter-base` to `0.0.19`

--- a/terra-jupyter-python/CHANGELOG.md
+++ b/terra-jupyter-python/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.0.24 - 2021-03-10
+## 0.0.24 - 2021-03-15
 
 - Update all Python package versions by unpinning them.
 - Add package `plotnine`. Fixes https://github.com/DataBiosphere/terra-docker/issues/126

--- a/terra-jupyter-python/Dockerfile
+++ b/terra-jupyter-python/Dockerfile
@@ -30,61 +30,62 @@ ENV HTSLIB_CONFIGURE_OPTIONS="--enable-gcs"
 #    test coverage for the identified problem.
 RUN pip3 -V \
  && pip3 install --upgrade pip \
- && pip3 install numpy \
- && pip3 install py4j \
- && python3 -mpip install matplotlib \
- && pip3 install pandas \
- && pip3 install pandas-gbq \
- && pip3 install pandas-profiling \
- && pip3 install seaborn \
- && pip3 install python-lzo \
- && pip3 install google-cloud-bigquery \
- && pip3 install google-api-core \
- && pip3 install google-cloud-bigquery-datatransfer \
- && pip3 install google-cloud-datastore \
- && pip3 install google-cloud-resource-manager \
- && pip3 install google-cloud-storage \
- && pip3 install scikit-learn \
- && pip3 install statsmodels \
- && pip3 install ggplot \
- && pip3 install bokeh \
- && pip3 install pyfasta \
- && pip3 install markdown \
- && pip3 install pdoc3 \
- && pip3 install biopython \
- && pip3 install bx-python \
- && pip3 install fastinterval \
- && pip3 install matplotlib-venn \
- && pip3 install bleach \
- && pip3 install cycler \
- && pip3 install h5py \
- && pip3 install html5lib \
- && pip3 install joblib \
- && pip3 install keras \
- && pip3 install patsy \
- && pip3 install protobuf \
- && pip3 install pymc3 \
- && pip3 install pyparsing \
- && pip3 install Cython \
- && pip3 install pysam --no-binary pysam \
- && pip3 install python-dateutil \
- && pip3 install pytz \
- && pip3 install pyvcf \
- && pip3 install pyyaml \
- && pip3 install scipy \
- # Use the cpu version of Tensorflow to eliminate the warnings about absent gpus on the Cloud Runtime.
- && pip3 install tensorflow_cpu \
- && pip3 install theano \
- && pip3 install tqdm \
- && pip3 install werkzeug \
- && pip3 install certifi \
- && pip3 install intel-openmp \
- && pip3 install mkl \
- && pip3 install readline \
- && pip3 install setuptools \
- && pip3 install wheel \
- && pip3 install plotnine \
- && pip3 install google-resumable-media \
+ && pip3 install --upgrade \
+   numpy \
+   py4j \
+   matplotlib \
+   pandas \
+   pandas-gbq \
+   pandas-profiling \
+   seaborn \
+   python-lzo \
+   google-cloud-bigquery \
+   google-api-core \
+   google-cloud-bigquery-datatransfer \
+   google-cloud-datastore \
+   google-cloud-resource-manager \
+   google-cloud-storage \
+   scikit-learn \
+   statsmodels \
+   ggplot \
+   bokeh \
+   pyfasta \
+   markdown \
+   pdoc3 \
+   biopython \
+   bx-python \
+   fastinterval \
+   matplotlib-venn \
+   bleach \
+   cycler \
+   h5py \
+   html5lib \
+   joblib \
+   keras \
+   patsy \
+   protobuf \
+   pymc3 \
+   pyparsing \
+   Cython \
+   pysam --no-binary pysam \
+   python-dateutil \
+   pytz \
+   pyvcf \
+   pyyaml \
+   scipy \
+   # Use the cpu version of Tensorflow to eliminate the warnings about absent GPUs on the Cloud Runtime.
+   tensorflow_cpu \
+   theano \
+   tqdm \
+   werkzeug \
+   certifi \
+   intel-openmp \
+   mkl \
+   readline \
+   setuptools \
+   wheel \
+   plotnine \
+   google-resumable-media \
  # Remove this after https://broadworkbench.atlassian.net/browse/CA-1179
  # As of release [google-cloud-bigquery 1.26.0 (2020-07-20)](https://github.com/googleapis/python-bigquery/blob/master/CHANGELOG.md#1260-2020-07-20)
  # the BigQuery Python client uses the BigQuery Storage client by default.

--- a/terra-jupyter-python/Dockerfile
+++ b/terra-jupyter-python/Dockerfile
@@ -1,6 +1,6 @@
 FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:0.0.19
 USER root
-#this makes it so pip runs as root, not the user
+# This makes it so pip runs as root, not the user.
 ENV PIP_USER=false
 
 RUN apt-get update && apt-get install -yq --no-install-recommends \
@@ -20,69 +20,82 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
 
 ENV HTSLIB_CONFIGURE_OPTIONS="--enable-gcs"
 
+# Dev note: in general, do not pin Python packages to any particular version.
+# Depend on the smoke tests to help us identify any package incompatibilties.
+#
+# If we find that we do need to pin a package version, be sure to:
+# 1) Add a comment saying what needs to be true for us to remove the pin.
+#    (e.g. link to an issue and put the details there)
+# 2) If the smoke tests did not show the problem, add a new test case to improve
+#    test coverage for the identified problem.
 RUN pip3 -V \
  && pip3 install --upgrade pip \
- && pip3 install numpy==1.15.2 \
- && pip3 install py4j==0.10.7 \
- && python3 -mpip install matplotlib==3.0.0 \
- && pip3 install pandas==0.25.3 \
- && pip3 install pandas-gbq==0.12.0 \
- && pip3 install pandas-profiling==2.4.0 \
- && pip3 install seaborn==0.9.0 \
- && pip3 install python-lzo==1.12 \
- && pip3 install google-cloud-bigquery==1.23.1 \
- && pip3 install google-api-core==1.6.0 \
- && pip3 install google-cloud-bigquery-datatransfer==0.4.1 \
- && pip3 install google-cloud-datastore==1.10.0 \
- && pip3 install google-cloud-resource-manager==0.30.0 \
- && pip3 install google-cloud-storage==1.23.0 \
- && pip3 install scikit-learn==0.20.0 \
- && pip3 install statsmodels==0.9.0 \
- && pip3 install ggplot==0.11.5 \
- && sed -i 's/pandas.lib/pandas/g' /usr/local/lib/python3.7/dist-packages/ggplot/stats/smoothers.py \
- # the next few `sed` lines are workaround for a ggplot bug. See https://github.com/yhat/ggpy/issues/662
- && sed -i 's/pandas.tslib.Timestamp/pandas.Timestamp/g' /usr/local/lib/python3.7/dist-packages/ggplot/stats/smoothers.py \
- && sed -i 's/pd.tslib.Timestamp/pd.Timestamp/g' /usr/local/lib/python3.7/dist-packages/ggplot/stats/smoothers.py \
- && sed -i 's/pd.tslib.Timestamp/pd.Timestamp/g' /usr/local/lib/python3.7/dist-packages/ggplot/utils.py \
- && pip3 install bokeh==1.0.0 \
- && pip3 install pyfasta==0.5.2 \
- && pip3 install markdown==2.4.1 \
- && pip3 install pdoc3==0.7.2 \
- && pip3 install biopython==1.72 \
- && pip3 install bx-python==0.8.2 \
- && pip3 install fastinterval==0.1.1 \
- && pip3 install matplotlib-venn==0.11.5 \
- && pip3 install bleach==1.5.0 \
- && pip3 install cycler==0.10.0 \
- && pip3 install h5py==2.7.1 \
- && pip3 install html5lib==0.9999999 \
- && pip3 install joblib==0.11 \
- && pip3 install keras==2.1.6 \
- && pip3 install patsy==0.4.1 \
- && pip3 install protobuf==3.7.1 \
- && pip3 install pymc3==3.10.0 \
- && pip3 install pyparsing==2.2.0 \
+ && pip3 install numpy \
+ && pip3 install py4j \
+ && python3 -mpip install matplotlib \
+ && pip3 install pandas \
+ && pip3 install pandas-gbq \
+ && pip3 install pandas-profiling \
+ && pip3 install seaborn \
+ && pip3 install python-lzo \
+ && pip3 install google-cloud-bigquery \
+ && pip3 install google-api-core \
+ && pip3 install google-cloud-bigquery-datatransfer \
+ && pip3 install google-cloud-datastore \
+ && pip3 install google-cloud-resource-manager \
+ && pip3 install google-cloud-storage \
+ && pip3 install scikit-learn \
+ && pip3 install statsmodels \
+ && pip3 install ggplot \
+ && pip3 install bokeh \
+ && pip3 install pyfasta \
+ && pip3 install markdown \
+ && pip3 install pdoc3 \
+ && pip3 install biopython \
+ && pip3 install bx-python \
+ && pip3 install fastinterval \
+ && pip3 install matplotlib-venn \
+ && pip3 install bleach \
+ && pip3 install cycler \
+ && pip3 install h5py \
+ && pip3 install html5lib \
+ && pip3 install joblib \
+ && pip3 install keras \
+ && pip3 install patsy \
+ && pip3 install protobuf \
+ && pip3 install pymc3 \
+ && pip3 install pyparsing \
  && pip3 install Cython \
- && pip3 install pysam==0.15.4 --no-binary pysam \
- && pip3 install python-dateutil==2.6.1 \
- && pip3 install pytz==2017.3 \
- && pip3 install pyvcf==0.6.8 \
- && pip3 install pyyaml==5.3.1 \
- && pip3 install scipy==1.2 \
- && pip3 install tensorflow==2.0.0a0 \
- && pip3 install theano==0.9.0 \
- && pip3 install tqdm==4.19.4 \
- && pip3 install werkzeug==0.12.2 \
- && pip3 install certifi==2017.4.17 \
- && pip3 install intel-openmp==2018.0.0 \
- && pip3 install mkl==2018.0.3 \
- && pip3 install readline==6.2 \
- && pip3 install setuptools==42.0.2 \
- && pip3 install wheel
+ && pip3 install pysam --no-binary pysam \
+ && pip3 install python-dateutil \
+ && pip3 install pytz \
+ && pip3 install pyvcf \
+ && pip3 install pyyaml \
+ && pip3 install scipy \
+ # Use the cpu version of Tensorflow to eliminate the warnings about absent gpus on the Cloud Runtime.
+ && pip3 install tensorflow_cpu \
+ && pip3 install theano \
+ && pip3 install tqdm \
+ && pip3 install werkzeug \
+ && pip3 install certifi \
+ && pip3 install intel-openmp \
+ && pip3 install mkl \
+ && pip3 install readline \
+ && pip3 install setuptools \
+ && pip3 install wheel \
+ && pip3 install plotnine \
+ && pip3 install google-resumable-media \
+ # Remove this after https://broadworkbench.atlassian.net/browse/CA-1179
+ # As of release [google-cloud-bigquery 1.26.0 (2020-07-20)](https://github.com/googleapis/python-bigquery/blob/master/CHANGELOG.md#1260-2020-07-20)
+ # the BigQuery Python client uses the BigQuery Storage client by default.
+ # This currently causes an error on Terra Cloud Runtimes `the user does not have 'bigquery.readsessions.create' permission
+ # for '<Terra billing project id>'`. To work-around this uninstall the dependency so that flag `--use_rest_api` can be used
+ # with `%%bigquery` to use the older, slower mechanism for data transfer.
+ && pip3 uninstall -y google-cloud-bigquery-storage
 
 ENV USER jupyter-user
 USER $USER
-#we want pip to install into the user's dir when the notebook is running
+# We want pip to install into the user's dir when the notebook is running.
 ENV PIP_USER=true
 
 # Note: this entrypoint is provided for running Jupyter independently of Leonardo.

--- a/terra-jupyter-python/tests/smoke_test.ipynb
+++ b/terra-jupyter-python/tests/smoke_test.ipynb
@@ -228,6 +228,17 @@
    "source": [
     "%%bash\n",
     "\n",
+    "gcloud auth activate-service-account --key-file $GOOGLE_APPLICATION_CREDENTIALS"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "\n",
     "gsutil ls gs://gcp-public-data--gnomad"
    ]
   },

--- a/terra-jupyter-python/tests/smoke_test.ipynb
+++ b/terra-jupyter-python/tests/smoke_test.ipynb
@@ -201,6 +201,46 @@
     "which ssh-agent\n",
     "which ssh-add"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Test gcloud tools"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "\n",
+    "gcloud version "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "\n",
+    "gsutil ls gs://gcp-public-data--gnomad"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "\n",
+    "bq --project_id bigquery-public-data ls gnomAD"
+   ]
   }
  ],
  "metadata": {
@@ -223,8 +263,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.7.8"
+   "pygments_lexer": "ipython3"
   },
   "toc": {
    "base_numbering": 1,

--- a/terra-jupyter-python/tests/smoke_test.ipynb
+++ b/terra-jupyter-python/tests/smoke_test.ipynb
@@ -60,9 +60,11 @@
    "source": [
     "## Test BigQuery magic\n",
     "\n",
-    "TODO(deflaux) after we update the BigQuery Python client package, be sure to explicitly use flag `--use_rest_api` with `%%bigquery`\n",
     "* As of release [google-cloud-bigquery 1.26.0 (2020-07-20)](https://github.com/googleapis/python-bigquery/blob/master/CHANGELOG.md#1260-2020-07-20) the BigQuery Python client uses the BigQuery Storage client by default.\n",
-    "* This currently causes an error on Terra Cloud Runtimes `the user does not have 'bigquery.readsessions.create' permission for '<Terra billing project id>'`."
+    "* This currently causes an error on Terra Cloud Runtimes `the user does not have 'bigquery.readsessions.create' permission for '<Terra billing project id>'`.\n",
+    "* To work around this, we do two things:\n",
+    "  1. remove the dependency `google-cloud-bigquery-storage` from the `terra-jupyter-python` image\n",
+    "  1. use flag `--use_rest_api` with `%%bigquery`"
    ]
   },
   {
@@ -80,7 +82,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%bigquery\n",
+    "%%bigquery --use_rest_api\n",
     "\n",
     "SELECT country_name, alpha_2_code\n",
     "FROM `bigquery-public-data.utility_us.country_code_iso`\n",
@@ -92,14 +94,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Test pandas profiling\n",
-    "\n",
-    "TODO(deflaux) its a known issue that pandas-profiler is broken in the current image. Enable this test after we update the package version."
+    "## Test pandas profiling"
    ]
   },
   {
-   "cell_type": "raw",
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "import numpy as np\n",
     "import pandas as pd\n",
@@ -162,14 +164,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Test plotnine\n",
-    "\n",
-    "TODO(deflaux) enable this as part of https://github.com/DataBiosphere/terra-docker/issues/126"
+    "## Test plotnine"
    ]
   },
   {
-   "cell_type": "raw",
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "from plotnine import ggplot, geom_point, aes, stat_smooth, facet_wrap\n",
     "from plotnine.data import mtcars\n",

--- a/terra-jupyter-python/tests/smoke_test.py
+++ b/terra-jupyter-python/tests/smoke_test.py
@@ -16,13 +16,12 @@ def test_pandas():
   
   pd.DataFrame(
     {
-# TODO(deflaux) uncomment "A" and "F" after the pandas version upgrade.
-#      "A": 1.0,
+      "A": 1.0,
       "B": pd.Timestamp("20130102"),
       "C": pd.Series(1, index=list(range(4)), dtype="float32"),
       "D": np.array([3] * 4, dtype="int32"),
       "E": pd.Categorical(["test", "train", "test", "train"]),
-#      "F": "foo",
+      "F": "foo",
     }
   )
   


### PR DESCRIPTION
Also:
* added package `plotnine` per #126
* replaced package `tensorflow` with `tensorflow_cpu` to get rid of the warnings about GPUs being unavailable for Terra Cloud Runtimes
* added package `google-resumable-media` as an explicit dependency to ensure a more recent version of it is used, pandas-gbq depends on it for table uploads
* `--use_rest_api` flag is now needed for `%%bigquery magic`
  * As of release [google-cloud-bigquery 1.26.0 (2020-07-20)](https://github.com/googleapis/python-bigquery/blob/master/CHANGELOG.md#1260-2020-07-20) the BigQuery Python client uses the BigQuery Storage client by default.
  * This currently causes an error on Terra Cloud Runtimes `the user does not have 'bigquery.readsessions.create' permission for '<Terra billing project id>'`.
  * To work-around this we uninstall the dependency `google-cloud-bigquery-storage` so that flag `--use_rest_api` can be used with `%%bigquery` to use the older, slower mechanism for data transfer.
* add `nbstripout` to `terra-jupyter-aou` and enable it globally
* improve test coverage by enabling tests that were intentionally commented out for the prior image


Smoke test pass for the images that were modified:
* [terra-jupyter-python](https://github.com/deflaux/terra-docker/actions/runs/625147084) smoke test results
* [terra-jupyter-aou](https://github.com/deflaux/terra-docker/actions/runs/625146524) smoke test results

The Hail and GATK images are unchanged by this PR, but just to demonstrate that this change will causes no future issues for them, in a test branch I bumped the version of `terra-jupyter-python` and those smoke tests pass too:
* [terra-jupyter-hail](https://github.com/deflaux/terra-docker/actions/runs/625153667) smoke test results
* [terra-jupyter-gatk](https://github.com/deflaux/terra-docker/actions/runs/625153665) smoke test results