### PR TITLE
[IA-2638] add fix back in to fix ggplot import bug

### DIFF
--- a/config/conf.json
+++ b/config/conf.json
@@ -84,7 +84,7 @@
                 "python"
             ],
             "packages" : {
-
+                
             },
             "version" : "0.0.19",
             "automated_flags" : {
@@ -102,7 +102,7 @@
                 "r"
             ],
             "packages" : {
-
+                
             },
             "version" : "1.0.13",
             "automated_flags" : {

--- a/config/conf.json
+++ b/config/conf.json
@@ -47,7 +47,7 @@
                     "hail"
                 ]
             },
-            "version" : "0.1.0",
+            "version" : "0.1.1",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : true,
@@ -68,7 +68,7 @@
                     "scikit-learn"
                 ]
             },
-            "version" : "0.1.0",
+            "version" : "0.1.1",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : true,
@@ -122,9 +122,9 @@
                 "r"
             ],
             "packages" : {
-
+                
             },
-            "version" : "1.1.0",
+            "version" : "1.1.1",
             "automated_flags" : {
                 "include_in_ui" : true,
                 "generate_docs" : true,
@@ -141,9 +141,9 @@
                 "r"
             ],
             "packages" : {
-
+                
             },
-            "version" : "1.1.0",
+            "version" : "1.1.1",
             "automated_flags" : {
                 "include_in_ui" : false,
                 "generate_docs" : false,

--- a/terra-jupyter-aou/CHANGELOG.md
+++ b/terra-jupyter-aou/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.1.1 - 2021-04-05T17:29:05.447Z
+
+- Update `terra-jupyter-python` to `0.1.1`
+  - fix ggplot import bug
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:1.1.1`
+
 ## 1.1.0 - 2021-03-20
 
 - Update `terra-jupyter-python` to `0.1.0`

--- a/terra-jupyter-aou/Dockerfile
+++ b/terra-jupyter-aou/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.1.0 AS python
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.1.1 AS python
 
 FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.13
 

--- a/terra-jupyter-gatk/CHANGELOG.md
+++ b/terra-jupyter-gatk/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.1.1 - 2021-04-05T17:29:05.428Z
+
+- Update `terra-jupyter-python` to `0.1.1`
+  - fix ggplot import bug
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:1.1.1`
+
 ## 1.1.0 - 2021-03-20
 
 - Update `terra-jupyter-python` to `0.1.0`

--- a/terra-jupyter-gatk/Dockerfile
+++ b/terra-jupyter-gatk/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.1.0 AS python
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.1.1 AS python
 
 FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.13
 

--- a/terra-jupyter-hail/CHANGELOG.md
+++ b/terra-jupyter-hail/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.1.1 - 2021-04-05T17:29:05.415Z
+
+- Update `terra-jupyter-python` to `0.1.1`
+  - fix ggplot import bug
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-hail:0.1.1`
+
 ## 0.1.0 - 2021-03-20
 
 - Update `terra-jupyter-python` to `0.1.0`

--- a/terra-jupyter-hail/Dockerfile
+++ b/terra-jupyter-hail/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.1.0
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.1.1
 USER root
 
 COPY scripts $JUPYTER_HOME/scripts

--- a/terra-jupyter-python/CHANGELOG.md
+++ b/terra-jupyter-python/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 0.1.2 - 2021-04-05T17:29:05.374Z
+
+- fix ggplot import bug
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.1.2`
+
+## 0.1.1 - 2021-04-5
+
+- Add bug fix back in for python package ggplot (see https://github.com/yhat/ggpy/issues/662)
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.1.1`
+
 ## 0.1.0 - 2021-03-20
 
 - Update all Python package versions by unpinning them.

--- a/terra-jupyter-python/CHANGELOG.md
+++ b/terra-jupyter-python/CHANGELOG.md
@@ -1,9 +1,3 @@
-## 0.1.2 - 2021-04-05T17:29:05.374Z
-
-- fix ggplot import bug
-
-Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.1.2`
-
 ## 0.1.1 - 2021-04-5
 
 - Add bug fix back in for python package ggplot (see https://github.com/yhat/ggpy/issues/662)

--- a/terra-jupyter-python/Dockerfile
+++ b/terra-jupyter-python/Dockerfile
@@ -92,7 +92,12 @@ RUN pip3 -V \
  # This currently causes an error on Terra Cloud Runtimes `the user does not have 'bigquery.readsessions.create' permission
  # for '<Terra billing project id>'`. To work-around this uninstall the dependency so that flag `--use_rest_api` can be used
  # with `%%bigquery` to use the older, slower mechanism for data transfer.
- && pip3 uninstall -y google-cloud-bigquery-storage
+ && pip3 uninstall -y google-cloud-bigquery-storage \
+ && sed -i 's/pandas.lib/pandas/g' /usr/local/lib/python3.7/dist-packages/ggplot/stats/smoothers.py \
+ # the next few `sed` lines are workaround for a ggplot bug. See https://github.com/yhat/ggpy/issues/662
+ && sed -i 's/pandas.tslib.Timestamp/pandas.Timestamp/g' /usr/local/lib/python3.7/dist-packages/ggplot/stats/smoothers.py \
+ && sed -i 's/pd.tslib.Timestamp/pd.Timestamp/g' /usr/local/lib/python3.7/dist-packages/ggplot/stats/smoothers.py \
+ && sed -i 's/pd.tslib.Timestamp/pd.Timestamp/g' /usr/local/lib/python3.7/dist-packages/ggplot/utils.py
 
 ENV USER jupyter-user
 USER $USER

--- a/terra-jupyter-python/tests/smoke_test.ipynb
+++ b/terra-jupyter-python/tests/smoke_test.ipynb
@@ -183,6 +183,23 @@
    ]
   },
   {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "## Test ggplot"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "execution_count": null,
+     "metadata": {},
+     "outputs": [],
+     "source": [
+      "from ggplot import *\n",
+      "ggplot"
+     ]
+    },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [


### PR DESCRIPTION
when running `from ggplot import *` we get the following error:
`AttributeError: module 'pandas' has no attribute 'tslib'`
Adding the last three `sed` commands in this PR fixes this error but we then still get error:
`ModuleNotFoundError: No module named 'pandas.lib'`
adding the first `sed` command fixes this second error.
This error was caught by automation tests: https://fc-jenkins.dsp-techops.broadinstitute.org/job/leonardo-fiab-test-runner/34649/testReport/junit/org.broadinstitute.dsde.workbench.leonardo.notebooks/NotebookPyKernelSpec/NotebookPyKernelSpec_should_be_able_to_import_ggplot_for_Python3/

These `sed` commands were present before these [PR](https://github.com/DataBiosphere/terra-docker/pull/207) changes so this PR just adds them back

Tested that running `from ggplot import *` no longer throws any errors and added smoke test to run that line as well