### PR TITLE
[IA-1644] Install crcmod in base image to support GCS composite objects

### DIFF
--- a/config/conf.json
+++ b/config/conf.json
@@ -26,7 +26,7 @@
                     "tidyverse"
                 ]
             },
-            "version" : "1.0.13",
+            "version" : "1.0.14",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : true,
@@ -47,7 +47,7 @@
                     "hail"
                 ]
             },
-            "version" : "0.1.1",
+            "version" : "0.1.2",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : true,
@@ -68,7 +68,7 @@
                     "scikit-learn"
                 ]
             },
-            "version" : "0.1.1",
+            "version" : "0.1.2",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : true,
@@ -86,7 +86,7 @@
             "packages" : {
                 
             },
-            "version" : "0.0.19",
+            "version" : "0.0.20",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : false,
@@ -104,7 +104,7 @@
             "packages" : {
                 
             },
-            "version" : "1.0.13",
+            "version" : "1.0.14",
             "automated_flags" : {
                 "include_in_ui" : false,
                 "generate_docs" : true,
@@ -124,7 +124,7 @@
             "packages" : {
                 
             },
-            "version" : "1.1.1",
+            "version" : "1.1.2",
             "automated_flags" : {
                 "include_in_ui" : true,
                 "generate_docs" : true,
@@ -143,7 +143,7 @@
             "packages" : {
                 
             },
-            "version" : "1.1.2",
+            "version" : "1.1.3",
             "automated_flags" : {
                 "include_in_ui" : false,
                 "generate_docs" : false,

--- a/config/conf.json
+++ b/config/conf.json
@@ -26,7 +26,7 @@
                     "tidyverse"
                 ]
             },
-            "version" : "1.0.14",
+            "version" : "1.0.13",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : true,
@@ -47,7 +47,7 @@
                     "hail"
                 ]
             },
-            "version" : "0.1.2",
+            "version" : "0.1.1",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : true,
@@ -68,7 +68,7 @@
                     "scikit-learn"
                 ]
             },
-            "version" : "0.1.2",
+            "version" : "0.1.1",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : true,
@@ -86,7 +86,7 @@
             "packages" : {
                 
             },
-            "version" : "0.0.20",
+            "version" : "0.0.19",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : false,
@@ -104,7 +104,7 @@
             "packages" : {
                 
             },
-            "version" : "1.0.14",
+            "version" : "1.0.13",
             "automated_flags" : {
                 "include_in_ui" : false,
                 "generate_docs" : true,
@@ -124,7 +124,7 @@
             "packages" : {
                 
             },
-            "version" : "1.1.2",
+            "version" : "1.1.1",
             "automated_flags" : {
                 "include_in_ui" : true,
                 "generate_docs" : true,
@@ -143,7 +143,7 @@
             "packages" : {
                 
             },
-            "version" : "1.1.3",
+            "version" : "1.1.2",
             "automated_flags" : {
                 "include_in_ui" : false,
                 "generate_docs" : false,

--- a/terra-jupyter-aou/CHANGELOG.md
+++ b/terra-jupyter-aou/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.1.3 - 2021-05-05T16:19:57.558388Z
+
+- Update `terra-jupyter-base` to `0.0.20`
+  - [IA-1644] Install crcmod in base image to support GCS composite objects
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:1.1.3`
+
 ## 1.1.2 - 2021-04-21
 
 - Refactor to terra-jupyter-gatk:1.1.1 as the base image

--- a/terra-jupyter-aou/CHANGELOG.md
+++ b/terra-jupyter-aou/CHANGELOG.md
@@ -1,10 +1,3 @@
-## 1.1.3 - 2021-05-05T16:19:57.558388Z
-
-- Update `terra-jupyter-base` to `0.0.20`
-  - [IA-1644] Install crcmod in base image to support GCS composite objects
-
-Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:1.1.3`
-
 ## 1.1.2 - 2021-04-21
 
 - Refactor to terra-jupyter-gatk:1.1.1 as the base image

--- a/terra-jupyter-aou/Dockerfile
+++ b/terra-jupyter-aou/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:1.1.1
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:1.1.2
 
 USER root
 

--- a/terra-jupyter-aou/Dockerfile
+++ b/terra-jupyter-aou/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:1.1.2
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:1.1.1
 
 USER root
 

--- a/terra-jupyter-base/CHANGELOG.md
+++ b/terra-jupyter-base/CHANGELOG.md
@@ -1,9 +1,3 @@
-## 0.0.20 - 2021-05-05T16:19:57.444846Z
-
-- [IA-1644] Install crcmod in base image to support GCS composite objects
-
-Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:0.0.20`
-
 ## 0.0.19 - 2021-01-20T16:00:48.255Z
 
 - [IA-2472] Turn on debug-level logging when JUPYTER_DEBUG_LOGGING env var is true

--- a/terra-jupyter-base/CHANGELOG.md
+++ b/terra-jupyter-base/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.0.20 - 2021-05-05T16:19:57.444846Z
+
+- [IA-1644] Install crcmod in base image to support GCS composite objects
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:0.0.20`
+
 ## 0.0.19 - 2021-01-20T16:00:48.255Z
 
 - [IA-2472] Turn on debug-level logging when JUPYTER_DEBUG_LOGGING env var is true

--- a/terra-jupyter-base/Dockerfile
+++ b/terra-jupyter-base/Dockerfile
@@ -137,6 +137,7 @@ RUN pip3 -V \
  && pip3 install six==1.15.0 \
  && pip3 install firecloud==0.16.25 \
  && pip3 install terra-notebook-utils==0.7.0 \
+ && pip3 install crcmod \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 

--- a/terra-jupyter-base/Dockerfile
+++ b/terra-jupyter-base/Dockerfile
@@ -137,7 +137,6 @@ RUN pip3 -V \
  && pip3 install six==1.15.0 \
  && pip3 install firecloud==0.16.25 \
  && pip3 install terra-notebook-utils==0.7.0 \
- && pip3 install crcmod \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 

--- a/terra-jupyter-base/Dockerfile
+++ b/terra-jupyter-base/Dockerfile
@@ -175,7 +175,6 @@ RUN chown -R $USER:users $JUPYTER_HOME \
  && cp $JUPYTER_HOME/custom/extension_entry_jupyter.js $HOME/.jupyter/custom/custom.js \
  && cp $JUPYTER_HOME/custom/safe-mode.js $HOME/.jupyter/custom/ \
  && cp $JUPYTER_HOME/custom/edit-mode.js $HOME/.jupyter/custom/ \
- && $JUPYTER_HOME/scripts/extension/jupyter_install_lab_extension.sh $JUPYTER_HOME/custom/extension_entry_jupyterlab.js \
  && mkdir $JUPYTER_HOME/nbconfig \
  && $JUPYTER_HOME/scripts/kernel/kernelspec.sh $JUPYTER_HOME/scripts/kernel /usr/local/share/jupyter/kernels
 

--- a/terra-jupyter-bioconductor/CHANGELOG.md
+++ b/terra-jupyter-bioconductor/CHANGELOG.md
@@ -1,10 +1,3 @@
-## 1.0.14 - 2021-05-05T16:19:57.470153Z
-
-- Update `terra-jupyter-base` to `0.0.20`
-  - [IA-1644] Install crcmod in base image to support GCS composite objects
-
-Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:1.0.14`
-
 ## 1.0.13 - 2021-02-10T00:36:57.149Z
 
 - Update `terra-jupyter-r` to `1.0.13`

--- a/terra-jupyter-bioconductor/CHANGELOG.md
+++ b/terra-jupyter-bioconductor/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.0.14 - 2021-05-05T16:19:57.470153Z
+
+- Update `terra-jupyter-base` to `0.0.20`
+  - [IA-1644] Install crcmod in base image to support GCS composite objects
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:1.0.14`
+
 ## 1.0.13 - 2021-02-10T00:36:57.149Z
 
 - Update `terra-jupyter-r` to `1.0.13`

--- a/terra-jupyter-bioconductor/Dockerfile
+++ b/terra-jupyter-bioconductor/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.14
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.13
 
 USER root
 

--- a/terra-jupyter-bioconductor/Dockerfile
+++ b/terra-jupyter-bioconductor/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.13
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.14
 
 USER root
 

--- a/terra-jupyter-gatk/CHANGELOG.md
+++ b/terra-jupyter-gatk/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.1.2 - 2021-05-05T16:19:57.539858Z
+
+- Update `terra-jupyter-base` to `0.0.20`
+  - [IA-1644] Install crcmod in base image to support GCS composite objects
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:1.1.2`
+
 ## 1.1.1 - 2021-04-05T17:29:05.428Z
 
 - Update `terra-jupyter-python` to `0.1.1`

--- a/terra-jupyter-gatk/CHANGELOG.md
+++ b/terra-jupyter-gatk/CHANGELOG.md
@@ -1,10 +1,3 @@
-## 1.1.2 - 2021-05-05T16:19:57.539858Z
-
-- Update `terra-jupyter-base` to `0.0.20`
-  - [IA-1644] Install crcmod in base image to support GCS composite objects
-
-Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:1.1.2`
-
 ## 1.1.1 - 2021-04-05T17:29:05.428Z
 
 - Update `terra-jupyter-python` to `0.1.1`

--- a/terra-jupyter-gatk/Dockerfile
+++ b/terra-jupyter-gatk/Dockerfile
@@ -1,6 +1,6 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.1.1 AS python
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.1.2 AS python
 
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.13
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.14
 
 # copy everything pip installed from the python image
 COPY --from=python /usr/local/lib/python3.7/dist-packages /usr/local/lib/python3.7/dist-packages

--- a/terra-jupyter-gatk/Dockerfile
+++ b/terra-jupyter-gatk/Dockerfile
@@ -1,6 +1,6 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.1.2 AS python
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.1.1 AS python
 
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.14
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.13
 
 # copy everything pip installed from the python image
 COPY --from=python /usr/local/lib/python3.7/dist-packages /usr/local/lib/python3.7/dist-packages

--- a/terra-jupyter-hail/CHANGELOG.md
+++ b/terra-jupyter-hail/CHANGELOG.md
@@ -1,10 +1,3 @@
-## 0.1.2 - 2021-05-05T16:19:57.485458Z
-
-- Update `terra-jupyter-base` to `0.0.20`
-  - [IA-1644] Install crcmod in base image to support GCS composite objects
-
-Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-hail:0.1.2`
-
 ## 0.1.1 - 2021-04-05T17:29:05.415Z
 
 - Update `terra-jupyter-python` to `0.1.1`

--- a/terra-jupyter-hail/CHANGELOG.md
+++ b/terra-jupyter-hail/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.1.2 - 2021-05-05T16:19:57.485458Z
+
+- Update `terra-jupyter-base` to `0.0.20`
+  - [IA-1644] Install crcmod in base image to support GCS composite objects
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-hail:0.1.2`
+
 ## 0.1.1 - 2021-04-05T17:29:05.415Z
 
 - Update `terra-jupyter-python` to `0.1.1`

--- a/terra-jupyter-hail/Dockerfile
+++ b/terra-jupyter-hail/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.1.2
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.1.1
 USER root
 
 COPY scripts $JUPYTER_HOME/scripts

--- a/terra-jupyter-hail/Dockerfile
+++ b/terra-jupyter-hail/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.1.1
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.1.2
 USER root
 
 COPY scripts $JUPYTER_HOME/scripts

--- a/terra-jupyter-python/CHANGELOG.md
+++ b/terra-jupyter-python/CHANGELOG.md
@@ -1,10 +1,3 @@
-## 0.1.2 - 2021-05-05T16:19:57.509127Z
-
-- Update `terra-jupyter-base` to `0.0.20`
-  - [IA-1644] Install crcmod in base image to support GCS composite objects
-
-Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.1.2`
-
 ## 0.1.1 - 2021-04-5
 
 - Add bug fix back in for python package ggplot (see https://github.com/yhat/ggpy/issues/662)

--- a/terra-jupyter-python/CHANGELOG.md
+++ b/terra-jupyter-python/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.1.2 - 2021-05-05T16:19:57.509127Z
+
+- Update `terra-jupyter-base` to `0.0.20`
+  - [IA-1644] Install crcmod in base image to support GCS composite objects
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.1.2`
+
 ## 0.1.1 - 2021-04-5
 
 - Add bug fix back in for python package ggplot (see https://github.com/yhat/ggpy/issues/662)

--- a/terra-jupyter-python/Dockerfile
+++ b/terra-jupyter-python/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:0.0.20
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:0.0.19
 USER root
 # This makes it so pip runs as root, not the user.
 ENV PIP_USER=false

--- a/terra-jupyter-python/Dockerfile
+++ b/terra-jupyter-python/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:0.0.19
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:0.0.20
 USER root
 # This makes it so pip runs as root, not the user.
 ENV PIP_USER=false

--- a/terra-jupyter-python/tests/smoke_test.ipynb
+++ b/terra-jupyter-python/tests/smoke_test.ipynb
@@ -183,22 +183,22 @@
    ]
   },
   {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "## Test ggplot"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "execution_count": null,
-     "metadata": {},
-     "outputs": [],
-     "source": [
-      "from ggplot import *\n",
-      "ggplot"
-     ]
-    },
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Test ggplot"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ggplot import *\n",
+    "ggplot"
+   ]
+  },
   {
    "cell_type": "markdown",
    "metadata": {},
@@ -268,6 +268,18 @@
     "%%bash\n",
     "\n",
     "bq --project_id bigquery-public-data ls gnomAD"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "\n",
+    "# test composite object, requires python crcmod to be installed\n",
+    "gsutil cp gs://terra-docker-image-documentation/test-composite.cram ."
    ]
   }
  ],

--- a/terra-jupyter-r/CHANGELOG.md
+++ b/terra-jupyter-r/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Update `terra-jupyter-base` to `0.0.20`
   - [IA-1644] Install crcmod in base image to support GCS composite objects
+- Fix `libsbml5` installation
 
 Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.14`
 

--- a/terra-jupyter-r/CHANGELOG.md
+++ b/terra-jupyter-r/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.0.14 - 2021-05-05T16:19:57.531117Z
+
+- Update `terra-jupyter-base` to `0.0.20`
+  - [IA-1644] Install crcmod in base image to support GCS composite objects
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.14`
+
 ## 1.0.13 - 2021-02-10T00:36:57.099Z
 
 - [IA-2511] Install Seurat R package in terra-jupyter-r image

--- a/terra-jupyter-r/CHANGELOG.md
+++ b/terra-jupyter-r/CHANGELOG.md
@@ -1,10 +1,3 @@
-## 1.0.14 - 2021-05-05T16:19:57.531117Z
-
-- Update `terra-jupyter-base` to `0.0.20`
-  - [IA-1644] Install crcmod in base image to support GCS composite objects
-
-Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.14`
-
 ## 1.0.13 - 2021-02-10T00:36:57.099Z
 
 - [IA-2511] Install Seurat R package in terra-jupyter-r image

--- a/terra-jupyter-r/Dockerfile
+++ b/terra-jupyter-r/Dockerfile
@@ -83,22 +83,16 @@ RUN apt-get update \
 	xfonts-100dpi \
 	xfonts-75dpi \
 	biber \
+	libsbml5-dev \
     && ln -s /usr/lib/gcc/x86_64-linux-gnu/7/libgfortran.so /usr/lib/x86_64-linux-gnu/libgfortran.so \
     && ln -s /usr/lib/gcc/x86_64-linux-gnu/7/libstdc++.so /usr/lib/x86_64-linux-gnu/libstdc++.so \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-# Install libsbml
-RUN cd /tmp \
-    && curl -O https://s3.amazonaws.com/linux-provisioning/libSBML-5.10.2-core-src.tar.gz \
-    && tar zxf libSBML-5.10.2-core-src.tar.gz \
-    && cd libsbml-5.10.2 \
-    && ./configure --enable-layout \
-    && make \
-    && make install \
-    && ldconfig \
-    && rm -rf /tmp/libsbml-5.10.2 \
-    && rm -rf /tmp/libSBML-5.10.2-core-src.tar.gz
+ENV LIBSBML_CFLAGS="-I/usr/include"
+ENV LIBSBML_LIBS="-lsbml"
+RUN echo 'export LIBSBML_CFLAGS="-I/usr/include"' >> /etc/profile \
+    && echo 'export LIBSBML_LIBS="-lsbml"' >> /etc/profile
 
 ## set pip3 to run as root, not as jupyter-user
 ENV PIP_USER=false

--- a/terra-jupyter-r/Dockerfile
+++ b/terra-jupyter-r/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:0.0.20
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:0.0.19
 USER root
 
 COPY scripts $JUPYTER_HOME/scripts

--- a/terra-jupyter-r/Dockerfile
+++ b/terra-jupyter-r/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:0.0.19
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:0.0.20
 USER root
 
 COPY scripts $JUPYTER_HOME/scripts


### PR DESCRIPTION
JIRA: https://broadworkbench.atlassian.net/browse/IA-1644

Details about composite objects: https://cloud.google.com/storage/docs/composite-objects

The new test failed before the fix: https://github.com/DataBiosphere/terra-docker/runs/2511051906?check_suite_focus=true

...and passed after the fix 🎉 : https://github.com/DataBiosphere/terra-docker/runs/2511404254?check_suite_focus=true

To get things to work I had to fix a couple unrelated things, noted inline in the comments.

@mikebaumann fyi