### PR TITLE
Reduce unnecessary package upgrades.

### DIFF
--- a/config/conf.json
+++ b/config/conf.json
@@ -143,7 +143,7 @@
             "packages" : {
                 
             },
-            "version" : "1.1.4",
+            "version" : "1.1.5",
             "automated_flags" : {
                 "include_in_ui" : false,
                 "generate_docs" : false,

--- a/terra-jupyter-aou/CHANGELOG.md
+++ b/terra-jupyter-aou/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.1.5 - 2021-05-24
+
+- Reduce unnecessary package upgrades.
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:1.1.5`
+
 ## 1.1.4 - 2021-05-24
 
 - Add bcftools

--- a/terra-jupyter-aou/Dockerfile
+++ b/terra-jupyter-aou/Dockerfile
@@ -133,8 +133,8 @@ RUN R -e 'BiocManager::install(c( \
   "SAIGEgds", \
   "GENESIS"))'
 
-RUN pip3 install --upgrade nbstripout \
+RUN pip3 install \
+  nbstripout \
+  "git+git://github.com/all-of-us/workbench-snippets.git#egg=terra_widgets&subdirectory=py" \
   && mkdir -p /home/$USER/.config/git \
-  && nbstripout --install --global \
-  # The base image already contains the needed dependencies for this package.
-  && pip3 install --no-deps "git+git://github.com/all-of-us/workbench-snippets.git#egg=terra_widgets&subdirectory=py"
+  && nbstripout --install --global

--- a/terra-jupyter-aou/Dockerfile
+++ b/terra-jupyter-aou/Dockerfile
@@ -133,8 +133,8 @@ RUN R -e 'BiocManager::install(c( \
   "SAIGEgds", \
   "GENESIS"))'
 
-RUN pip3 install --upgrade \
-  nbstripout \
-  "git+git://github.com/all-of-us/workbench-snippets.git#egg=terra_widgets&subdirectory=py" \
+RUN pip3 install --upgrade nbstripout \
   && mkdir -p /home/$USER/.config/git \
-  && nbstripout --install --global
+  && nbstripout --install --global \
+  # The base image already contains the needed dependencies for this package.
+  && pip3 install --no-deps "git+git://github.com/all-of-us/workbench-snippets.git#egg=terra_widgets&subdirectory=py"


### PR DESCRIPTION
This change is somewhat redundant, but this is the second time terra-widgets dependencies have caused issues with the build for terra-jupyter-aou.

The root cause of the test failures in https://github.com/DataBiosphere/terra-docker/pull/217 will be fixed by https://github.com/all-of-us/workbench-snippets/pull/65 