### PR TITLE
Updates to jupyter-r image to R 4.1.0 and Bioconductor 3.13

### DIFF
--- a/config/conf.json
+++ b/config/conf.json
@@ -104,7 +104,7 @@
             "packages" : {
                 
             },
-            "version" : "1.0.14",
+            "version" : "1.0.15",
             "automated_flags" : {
                 "include_in_ui" : false,
                 "generate_docs" : true,

--- a/terra-jupyter-r/CHANGELOG.md
+++ b/terra-jupyter-r/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.0.15 - 2021-06-07
+
+- Update R to 4.1.0 and Bioconductor version to 3.13.
+- Update terra-jupyter-r image to `1.0.15`
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.15`
+
 ## 1.0.14 - 2021-05-05T16:19:57.531117Z
 
 - Update `terra-jupyter-base` to `0.0.20`

--- a/terra-jupyter-r/Dockerfile
+++ b/terra-jupyter-r/Dockerfile
@@ -5,7 +5,7 @@ COPY scripts $JUPYTER_HOME/scripts
 
 # Add env vars to identify binary package installation
 ENV TERRA_R_PLATFORM="terra-jupyter-r"
-ENV TERRA_R_PLATFORM_BINARY_VERSION=0.99.1
+ENV TERRA_R_PLATFORM_BINARY_VERSION=3.13.0
 
 
 RUN find $JUPYTER_HOME/scripts -name '*.sh' -type f | xargs chmod +x \
@@ -83,7 +83,8 @@ RUN apt-get update \
 	xfonts-100dpi \
 	xfonts-75dpi \
 	biber \
-	libsbml5-dev \
+        libsbml5-dev \
+        libzmq3-dev \
     && ln -s /usr/lib/gcc/x86_64-linux-gnu/7/libgfortran.so /usr/lib/x86_64-linux-gnu/libgfortran.so \
     && ln -s /usr/lib/gcc/x86_64-linux-gnu/7/libstdc++.so /usr/lib/x86_64-linux-gnu/libstdc++.so \
     && apt-get clean \
@@ -111,7 +112,7 @@ RUN apt-get update \
 
 RUN R -e 'install.packages("BiocManager")' \
     ## check version
-    && R -e 'BiocManager::install(version="3.12", ask=FALSE)' \
+    && R -e 'BiocManager::install(version="3.13", ask=FALSE)' \
     && R -e 'BiocManager::install(c( \
     "boot", \
     "class", \


### PR DESCRIPTION
- Update R to 4.1.0 (latest stable release)
- Update Bioconductor to 3.13 (latest stable release)
- Add a library needed for installing a Bioconductor package (RCy3) -- libzmq3-dev

General changes:

- Update CHANGELOG.md (this seems to be an auto-update, not sure I needed to do it)
- Update config. 