### PR TITLE
IA-2810 Update Jupyter image stack to Bioconductor 3.13.0

### DIFF
--- a/config/conf.json
+++ b/config/conf.json
@@ -26,7 +26,7 @@
                     "tidyverse"
                 ]
             },
-            "version" : "1.0.14",
+            "version" : "1.0.15",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : true,
@@ -124,7 +124,7 @@
             "packages" : {
                 
             },
-            "version" : "1.1.2",
+            "version" : "1.1.3",
             "automated_flags" : {
                 "include_in_ui" : true,
                 "generate_docs" : true,
@@ -143,7 +143,7 @@
             "packages" : {
                 
             },
-            "version" : "1.1.5",
+            "version" : "1.1.6",
             "automated_flags" : {
                 "include_in_ui" : false,
                 "generate_docs" : false,

--- a/terra-jupyter-aou/CHANGELOG.md
+++ b/terra-jupyter-aou/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.1.6 - 2021-06-07T19:39:56.024375Z
+
+- Update `terra-jupyter-r` to `1.0.16`
+  - Update R to 4.1.0 and Bioconductor version to 3.13.
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:1.1.6`
+
 ## 1.1.5 - 2021-05-24
 
 - Reduce unnecessary package upgrades.

--- a/terra-jupyter-aou/Dockerfile
+++ b/terra-jupyter-aou/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:1.1.2
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:1.1.3
 
 USER root
 

--- a/terra-jupyter-bioconductor/CHANGELOG.md
+++ b/terra-jupyter-bioconductor/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.0.15 - 2021-06-07T19:39:55.978624Z
+
+- Update `terra-jupyter-r` to `1.0.16`
+  - Update R to 4.1.0 and Bioconductor version to 3.13.
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:1.0.15`
+
 ## 1.0.14 - 2021-05-05T16:19:57.470153Z
 
 - Update `terra-jupyter-base` to `0.0.20`

--- a/terra-jupyter-bioconductor/Dockerfile
+++ b/terra-jupyter-bioconductor/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.14
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.15
 
 USER root
 

--- a/terra-jupyter-gatk/CHANGELOG.md
+++ b/terra-jupyter-gatk/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.1.3 - 2021-06-07T19:39:55.994874Z
+
+- Update `terra-jupyter-r` to `1.0.16`
+  - Update R to 4.1.0 and Bioconductor version to 3.13.
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:1.1.3`
+
 ## 1.1.2 - 2021-05-05T16:19:57.539858Z
 
 - Update `terra-jupyter-base` to `0.0.20`

--- a/terra-jupyter-gatk/Dockerfile
+++ b/terra-jupyter-gatk/Dockerfile
@@ -1,6 +1,6 @@
 FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.1.2 AS python
 
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.14
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:1.0.15
 
 # copy everything pip installed from the python image
 COPY --from=python /usr/local/lib/python3.7/dist-packages /usr/local/lib/python3.7/dist-packages


### PR DESCRIPTION
Bumps dependent images with this `terra-jupyter-r` change: https://github.com/DataBiosphere/terra-docker/pull/221

https://broadworkbench.atlassian.net/browse/IA-2810