### PR TITLE
Update to AnVIL Rstudio bioconductor image

### DIFF
--- a/config/community_images.json
+++ b/config/community_images.json
@@ -11,10 +11,10 @@
 {
     "id": "RStudio",
     "label": "RStudio (R 4.1.0, Bioconductor 3.13.0, Python 3.8.5)",
-    "version": "3.13.1",
+    "version": "3.13.2",
     "updated": "2021-06-08",
     "packages": "https://storage.googleapis.com/terra-docker-image-documentation/placeholder.json",
-    "image": "us.gcr.io/anvil-gcr-public/anvil-rstudio-bioconductor:3.13.1",
+    "image": "us.gcr.io/anvil-gcr-public/anvil-rstudio-bioconductor:3.13.2",
     "requiresSpark": false,
     "isRStudio": true
 }]


### PR DESCRIPTION
The bioconductor_docker image was updated. Once the PR to the anvil-rstudio-bioconductor image is added, please merge.