### PR TITLE
[SUP-503] Update Rstudio version for ggplot2 fix

### DIFF
--- a/config/community_images.json
+++ b/config/community_images.json
@@ -11,10 +11,10 @@
 {
     "id": "RStudio",
     "label": "RStudio (R 4.1.0, Bioconductor 3.13.0, Python 3.8.5)",
-    "version": "3.13.1",
-    "updated": "2021-06-08",
+    "version": "3.13.2",
+    "updated": "2021-06-24",
     "packages": "https://storage.googleapis.com/terra-docker-image-documentation/placeholder.json",
-    "image": "us.gcr.io/anvil-gcr-public/anvil-rstudio-bioconductor:3.13.1",
+    "image": "us.gcr.io/anvil-gcr-public/anvil-rstudio-bioconductor:3.13.2",
     "requiresSpark": false,
     "isRStudio": true
 }]


### PR DESCRIPTION
See https://github.com/anvilproject/anvil-docker/pull/32 and https://broadworkbench.atlassian.net/browse/SUP-503

This image is already pushed to GCR and tested in Terra.