### PR TITLE
Add global gitignore to terra-jupyter-aou

### DIFF
--- a/.github/workflows/test-terra-jupyter-aou.yml
+++ b/.github/workflows/test-terra-jupyter-aou.yml
@@ -64,56 +64,55 @@ jobs:
         gcloud auth configure-docker
         ./build_smoke_test_image.sh terra-jupyter-aou
 
-    # - name: Run Python code specific to notebooks with nbconvert
-    #   # Run all notebooks from start to finish, regardles of error, so that we can capture the
-    #   # result as a workflow artifact.
-    #   # See also https://github.com/marketplace/actions/run-notebook if a more complicated
-    #   # workflow for notebooks is needed in the future.
-    #   run: |
-    #     chmod a+w -R $GITHUB_WORKSPACE
-    #     docker run \
-    #       --env GOOGLE_PROJECT \
-    #       --volume "${{ env.GOOGLE_APPLICATION_CREDENTIALS }}:/tmp/credentials.json:ro" \
-    #       --env GOOGLE_APPLICATION_CREDENTIALS="/tmp/credentials.json" \
-    #       --volume $GITHUB_WORKSPACE:/tests \
-    #       --workdir=/tests \
-    #       --entrypoint="" \
-    #       terra-jupyter-aou:smoke-test \
-    #       /bin/bash -c 'for nb in {terra-jupyter-python/tests,terra-jupyter-aou/tests}/*ipynb ; do jupyter nbconvert --to html --ExecutePreprocessor.allow_errors=True --execute "${nb}" ; done'
+    - name: Run Python code specific to notebooks with nbconvert
+      # Run all notebooks from start to finish, regardles of error, so that we can capture the
+      # result as a workflow artifact.
+      # See also https://github.com/marketplace/actions/run-notebook if a more complicated
+      # workflow for notebooks is needed in the future.
+      run: |
+        chmod a+w -R $GITHUB_WORKSPACE
+        docker run \
+          --env GOOGLE_PROJECT \
+          --volume "${{ env.GOOGLE_APPLICATION_CREDENTIALS }}:/tmp/credentials.json:ro" \
+          --env GOOGLE_APPLICATION_CREDENTIALS="/tmp/credentials.json" \
+          --volume $GITHUB_WORKSPACE:/tests \
+          --workdir=/tests \
+          --entrypoint="" \
+          terra-jupyter-aou:smoke-test \
+          /bin/bash -c 'for nb in {terra-jupyter-python/tests,terra-jupyter-aou/tests}/*ipynb ; do jupyter nbconvert --to html --ExecutePreprocessor.allow_errors=True --execute "${nb}" ; done'
 
-    # - name: Upload workflow artifacts
-    #   uses: actions/upload-artifact@v2
-    #   with:
-    #     name: notebook-execution-results
-    #     path: |
-    #       terra-jupyter-python/tests/*.html
-    #       terra-jupyter-aou/tests/*.html
-    #     retention-days: 30
+    - name: Upload workflow artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: notebook-execution-results
+        path: |
+          terra-jupyter-python/tests/*.html
+          terra-jupyter-aou/tests/*.html
+        retention-days: 30
 
-    # - name: Test Python code with pytest
-    #   run: |
-    #     docker run \
-    #       --env GOOGLE_PROJECT \
-    #       --volume "${{ env.GOOGLE_APPLICATION_CREDENTIALS }}:/tmp/credentials.json:ro" \
-    #       --env GOOGLE_APPLICATION_CREDENTIALS="/tmp/credentials.json" \
-    #       --volume $GITHUB_WORKSPACE:/tests \
-    #       --workdir=/tests \
-    #       --entrypoint="" \
-    #       terra-jupyter-aou:smoke-test \
-    #       /bin/bash -c 'pip3 install pytest ; pytest terra-jupyter-python/tests/ terra-jupyter-aou/tests/'
+    - name: Test Python code with pytest
+      run: |
+        docker run \
+          --env GOOGLE_PROJECT \
+          --volume "${{ env.GOOGLE_APPLICATION_CREDENTIALS }}:/tmp/credentials.json:ro" \
+          --env GOOGLE_APPLICATION_CREDENTIALS="/tmp/credentials.json" \
+          --volume $GITHUB_WORKSPACE:/tests \
+          --workdir=/tests \
+          --entrypoint="" \
+          terra-jupyter-aou:smoke-test \
+          /bin/bash -c 'pip3 install pytest ; pytest terra-jupyter-python/tests/ terra-jupyter-aou/tests/'
 
-    # - name: Test Python code specific to notebooks with nbconvert
-    #   # Simply 'Cell -> Run All` these notebooks and expect no errors in the case of a successful run of the test suite.
-    #   # If the tests throw any exceptions, execution of the notebooks will halt at that point. Look at the workflow
-    #   # artifacts to understand if there are more failures than just the one that caused this task to halt.
-    #   run: |
-    #     docker run \
-    #       --env GOOGLE_PROJECT \
-    #       --volume "${{ env.GOOGLE_APPLICATION_CREDENTIALS }}:/tmp/credentials.json:ro" \
-    #       --env GOOGLE_APPLICATION_CREDENTIALS="/tmp/credentials.json" \
-    #       --volume $GITHUB_WORKSPACE:/tests \
-    #       --workdir=/tests \
-    #       --entrypoint="" \
-    #       terra-jupyter-aou:smoke-test \
-    #       /bin/bash -c 'for nb in {terra-jupyter-python/tests,terra-jupyter-aou/tests}/*ipynb ; do jupyter nbconvert --to html --execute "${nb}" ; done'
-
+    - name: Test Python code specific to notebooks with nbconvert
+      # Simply 'Cell -> Run All` these notebooks and expect no errors in the case of a successful run of the test suite.
+      # If the tests throw any exceptions, execution of the notebooks will halt at that point. Look at the workflow
+      # artifacts to understand if there are more failures than just the one that caused this task to halt.
+      run: |
+        docker run \
+          --env GOOGLE_PROJECT \
+          --volume "${{ env.GOOGLE_APPLICATION_CREDENTIALS }}:/tmp/credentials.json:ro" \
+          --env GOOGLE_APPLICATION_CREDENTIALS="/tmp/credentials.json" \
+          --volume $GITHUB_WORKSPACE:/tests \
+          --workdir=/tests \
+          --entrypoint="" \
+          terra-jupyter-aou:smoke-test \
+          /bin/bash -c 'for nb in {terra-jupyter-python/tests,terra-jupyter-aou/tests}/*ipynb ; do jupyter nbconvert --to html --execute "${nb}" ; done'

--- a/config/conf.json
+++ b/config/conf.json
@@ -143,7 +143,7 @@
             "packages" : {
                 
             },
-            "version" : "1.1.6",
+            "version" : "1.1.7",
             "automated_flags" : {
                 "include_in_ui" : false,
                 "generate_docs" : false,

--- a/terra-jupyter-aou/CHANGELOG.md
+++ b/terra-jupyter-aou/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.1.7 - 2021-06-30
+
+- Add less
+- Add papermill
+- Install a global gitignore to ensure that by default only code files and documentation are commited to source control.
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:1.1.7`
+
 ## 1.1.6 - 2021-06-07T19:39:56.024375Z
 
 - Update `terra-jupyter-r` to `1.0.16`

--- a/terra-jupyter-aou/Dockerfile
+++ b/terra-jupyter-aou/Dockerfile
@@ -137,7 +137,7 @@ RUN R -e 'BiocManager::install(c( \
 # Install a global gitignore file that denies all by default and then specifcally allows
 # code and documentation files.
 # https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files#configuring-ignored-files-for-all-repositories-on-your-computer
-COPY --chown=jupyter-user:users gitignore_global /home/jupyter-user/gitignore_global
+COPY --chown=$USER:users gitignore_global /home/$USER/gitignore_global
 
 RUN pip3 install \
   nbstripout \
@@ -145,4 +145,4 @@ RUN pip3 install \
   "git+git://github.com/all-of-us/workbench-snippets.git#egg=terra_widgets&subdirectory=py" \
   && mkdir -p /home/$USER/.config/git \
   && nbstripout --install --global \
-  && git config --global core.excludesfile /home/jupyter-user/gitignore_global
+  && git config --global core.excludesfile /home/$USER/gitignore_global

--- a/terra-jupyter-aou/Dockerfile
+++ b/terra-jupyter-aou/Dockerfile
@@ -6,6 +6,7 @@ USER root
 RUN apt-get update && apt-get install -yq --no-install-recommends \
   jq \
   g++ \
+  less \
   liblz4-dev \
   libmagick++-dev \
   iproute2 \
@@ -133,8 +134,15 @@ RUN R -e 'BiocManager::install(c( \
   "SAIGEgds", \
   "GENESIS"))'
 
+# Install a global gitignore file that denies all by default and then specifcally allows
+# code and documentation files.
+# https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files#configuring-ignored-files-for-all-repositories-on-your-computer
+COPY gitignore_global /home/jupyter-user/gitignore_global
+
 RUN pip3 install \
   nbstripout \
+  papermill \
   "git+git://github.com/all-of-us/workbench-snippets.git#egg=terra_widgets&subdirectory=py" \
   && mkdir -p /home/$USER/.config/git \
-  && nbstripout --install --global
+  && nbstripout --install --global \
+  && git config --global core.excludesfile /home/jupyter-user/gitignore_global

--- a/terra-jupyter-aou/Dockerfile
+++ b/terra-jupyter-aou/Dockerfile
@@ -137,7 +137,7 @@ RUN R -e 'BiocManager::install(c( \
 # Install a global gitignore file that denies all by default and then specifcally allows
 # code and documentation files.
 # https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files#configuring-ignored-files-for-all-repositories-on-your-computer
-COPY --chown=jupyter-user gitignore_global /home/jupyter-user/gitignore_global
+COPY --chown=jupyter-user:users gitignore_global /home/jupyter-user/gitignore_global
 
 RUN pip3 install \
   nbstripout \

--- a/terra-jupyter-aou/Dockerfile
+++ b/terra-jupyter-aou/Dockerfile
@@ -137,7 +137,7 @@ RUN R -e 'BiocManager::install(c( \
 # Install a global gitignore file that denies all by default and then specifcally allows
 # code and documentation files.
 # https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files#configuring-ignored-files-for-all-repositories-on-your-computer
-COPY gitignore_global /home/jupyter-user/gitignore_global
+COPY --chown=jupyter-user gitignore_global /home/jupyter-user/gitignore_global
 
 RUN pip3 install \
   nbstripout \

--- a/terra-jupyter-aou/gitignore_global
+++ b/terra-jupyter-aou/gitignore_global
@@ -12,6 +12,4 @@
 !*.md
 !*.rst
 !LICENSE*
-# Also allow some particular source control metadata files.
-!.git*
-!.github/workflows/*.*
+

--- a/terra-jupyter-aou/gitignore_global
+++ b/terra-jupyter-aou/gitignore_global
@@ -1,0 +1,17 @@
+# By default, all files should be ignored by git.
+# We want to be sure to exclude files containing data such as CSVs and images such as PNGs.
+*.*
+# Now, allow the file types that we do want to track via source control.
+!*.ipynb
+!*.py
+!*.r
+!*.R
+!*.wdl
+!*.sh
+# Allow documentation files.
+!*.md
+!*.rst
+!LICENSE*
+# Also allow some particular source control metadata files.
+!.git*
+!.github/workflows/*.*

--- a/terra-jupyter-aou/tests/aou_smoke_test.ipynb
+++ b/terra-jupyter-aou/tests/aou_smoke_test.ipynb
@@ -126,6 +126,161 @@
     "export WORKSPACE_CDR=placeholder_string\n",
     "python3 /tmp/workbench-snippets/storage-snippets/snippets_setup.py"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Test that our source control protections are working."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### global gitignore omit images and data from source control"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Make some new files of various types in the git repo clone."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "\n",
+    "touch /tmp/workbench-snippets/should_be_ignored.png\n",
+    "touch /tmp/workbench-snippets/should_be_ignored.csv\n",
+    "touch /tmp/workbench-snippets/should_be_ignored.tsv\n",
+    "touch /tmp/workbench-snippets/should_be_ignored.CSV\n",
+    "touch /tmp/workbench-snippets/should_be_ignored.TSV\n",
+    "touch /tmp/workbench-snippets/should_be_visible.r\n",
+    "touch /tmp/workbench-snippets/should_be_visible.R\n",
+    "touch /tmp/workbench-snippets/should_be_visible.py\n",
+    "touch /tmp/workbench-snippets/should_be_visible.wdl\n",
+    "touch /tmp/workbench-snippets/should_be_visible.sh\n",
+    "touch /tmp/workbench-snippets/should_be_visible.md"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The git status should only show code and documentation files (no data)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "actual = !cd /tmp/workbench-snippets/; git status\n",
+    "\n",
+    "actual"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert(not any('should_be_ignored' in s for s in actual))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Ensure that notebook outputs are removed"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Make a notebook file containing outputs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "\n",
+    "cat << 'EOF' > /tmp/workbench-snippets/should_be_visible.ipynb\n",
+    "\n",
+    "{\n",
+    " \"cells\": [\n",
+    "  {\n",
+    "   \"cell_type\": \"code\",\n",
+    "   \"execution_count\": 2,\n",
+    "   \"id\": \"pacific-album\",\n",
+    "   \"metadata\": {},\n",
+    "   \"outputs\": [\n",
+    "    {\n",
+    "     \"data\": {\n",
+    "      \"text/plain\": [\n",
+    "       \"'this is an output'\"\n",
+    "      ]\n",
+    "     },\n",
+    "     \"execution_count\": 2,\n",
+    "     \"metadata\": {},\n",
+    "     \"output_type\": \"execute_result\"\n",
+    "    }\n",
+    "   ],\n",
+    "   \"source\": [\n",
+    "    \"\\\" \\\".join(['this', 'is', 'an', 'output'])\"\n",
+    "   ]\n",
+    "  }\n",
+    " ],\n",
+    " \"metadata\": {},\n",
+    " \"nbformat\": 4,\n",
+    " \"nbformat_minor\": 5\n",
+    "}\n",
+    "\n",
+    "EOF"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The git diff should show that the outputs have been removed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "expected = ['+   \"outputs\": [],']\n",
+    "\n",
+    "!cd /tmp/workbench-snippets/ ; git add should_be_visible.ipynb\n",
+    "actual = !cd /tmp/workbench-snippets/ ; git diff --staged should_be_visible.ipynb | grep outputs\n",
+    "\n",
+    "actual"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert(expected == actual)"
+   ]
   }
  ],
  "metadata": {

--- a/terra-jupyter-aou/tests/aou_smoke_test.ipynb
+++ b/terra-jupyter-aou/tests/aou_smoke_test.ipynb
@@ -193,6 +193,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "assert(any('should_be_visible' in s for s in actual))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "assert(not any('should_be_ignored' in s for s in actual))"
    ]
   },
@@ -265,10 +274,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "expected = ['+   \"outputs\": [],']\n",
-    "\n",
-    "!cd /tmp/workbench-snippets/ ; git add should_be_visible.ipynb\n",
-    "actual = !cd /tmp/workbench-snippets/ ; git diff --staged should_be_visible.ipynb | grep outputs\n",
+    "actual = !cd /tmp/workbench-snippets/ ; git add should_be_visible.ipynb ; git diff --staged should_be_visible.ipynb\n",
     "\n",
     "actual"
    ]
@@ -279,7 +285,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "assert(expected == actual)"
+    "assert(any('\"outputs\": [],' in s for s in actual))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert(not any('this is an output' in s for s in actual))"
    ]
   }
  ],

--- a/terra-jupyter-aou/tests/aou_smoke_test.ipynb
+++ b/terra-jupyter-aou/tests/aou_smoke_test.ipynb
@@ -166,7 +166,10 @@
     "touch /tmp/workbench-snippets/should_be_visible.py\n",
     "touch /tmp/workbench-snippets/should_be_visible.wdl\n",
     "touch /tmp/workbench-snippets/should_be_visible.sh\n",
-    "touch /tmp/workbench-snippets/should_be_visible.md"
+    "touch /tmp/workbench-snippets/should_be_visible.md\n",
+    "mkdir -p /tmp/workbench-snippets/some_diretory/\n",
+    "touch /tmp/workbench-snippets/some_diretory/should_be_ignored.CSV\n",
+    "touch /tmp/workbench-snippets/some_diretory/should_be_visible.sh"
    ]
   },
   {


### PR DESCRIPTION
Also
* re-enable the tests
* add tests for the source control protections
* `apt-get install less` to make looking through large hail logs easier
* `pip3 install papermill` to facilitate parameterized Hail notebooks run in the background, see also https://github.com/DataBiosphere/terra-example-notebooks/pull/21
