### PR TITLE
[IA-2897] Change label for legacy images

### DIFF
--- a/config/legacy_static_images.json
+++ b/config/legacy_static_images.json
@@ -11,7 +11,7 @@
   {
     "updated": "2020-06-29", 
     "image": "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:1.1.3", 
-    "label": "Default: (GATK 4.1.4.1, Python 3.7.8, R 4.0.2)", 
+    "label": "Legacy GATK (GATK 4.1.4.1, Python 3.7.8, R 4.0.2)", 
     "version": "1.1.3", 
     "requiresSpark": false, 
     "packages": "https://storage.googleapis.com/terra-docker-image-documentation/terra-jupyter-gatk-1.1.3-versions.json", 

--- a/scripts/generate_version_docs.py
+++ b/scripts/generate_version_docs.py
@@ -68,10 +68,10 @@ def get_legacy_image(new_version, remote_doc):
   current_version_major = int(current_version[0])
   # major version bump
   if new_version_major > current_version_major and (new_version_minor == 0 and new_version_patch == 0):
-    return remote_doc
+    return generate_legacy_label(remote_doc)
   # minor version bump
   elif new_version_minor > current_version_minor and (new_version_patch == 0 and current_version_major == new_version_major):
-    return remote_doc
+    return generate_legacy_label(remote_doc)
   else: # TODO: remove this code after gatk and bioconductor images have a major or minor version bump
     #if no  major or minor version bump, hardcode legacy  images
     if "terra-jupyter-bioconductor" in remote_doc["image"]:
@@ -79,7 +79,13 @@ def get_legacy_image(new_version, remote_doc):
     else:
       return utils.read_json_file(static_config_location)[1]
 
-
+def generate_legacy_label(doc):
+  if "terra-jupyter-bioconductor" in doc["image"]:
+    doc["label"] = "Legacy " + doc["label"]
+    return doc
+  else:
+    doc["label"] = doc["label"].replace("Default", "Legacy GATK")
+    return doc
 
 def generate_doc_for_image(image_config):
   version = image_config["version"]


### PR DESCRIPTION
tested with minor and major version bumps of both GATK and Bioconductor images and validated that when we use the current image as the new legacy image, the label gets changed to reflect that it is now a legacy image