### PR TITLE
Update hail to 0.2.74

### DIFF
--- a/config/conf.json
+++ b/config/conf.json
@@ -47,7 +47,7 @@
                     "hail"
                 ]
             },
-            "version" : "1.0.2",
+            "version" : "1.0.3",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : true,
@@ -84,7 +84,7 @@
                 "python"
             ],
             "packages" : {
-                
+
             },
             "version" : "1.0.2",
             "automated_flags" : {
@@ -102,7 +102,7 @@
                 "r"
             ],
             "packages" : {
-                
+
             },
             "version" : "2.0.2",
             "automated_flags" : {
@@ -122,7 +122,7 @@
                 "r"
             ],
             "packages" : {
-                
+
             },
             "version" : "2.0.4",
             "automated_flags" : {
@@ -141,7 +141,7 @@
                 "r"
             ],
             "packages" : {
-                
+
             },
             "version" : "2.0.3",
             "automated_flags" : {
@@ -161,7 +161,7 @@
                 "r"
             ],
             "packages" : {
-                
+
             },
             "version" : "0.1.3",
             "automated_flags" : {

--- a/terra-jupyter-hail/CHANGELOG.md
+++ b/terra-jupyter-hail/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.3 - 2021-11-18
+
+- Update `hail` to `0.2.74`
+  - See https://hail.is/docs/0.2/change_log.html#version-0-2-74 for details.
+
 ## 1.0.2 - 2021-10-07T14:47:43.375974Z
 
 - Update `terra-jupyter-base` to `1.0.2`
@@ -230,16 +235,16 @@ Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-hail:0.0.5`
 
 Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-hail:0.0.4`
 
-## 0.0.3 - 11/16/2019 
+## 0.0.3 - 11/16/2019
 
 - Update to use python 0.0.4
-- Remove apt-get upgrade for security purposes 
+- Remove apt-get upgrade for security purposes
 
 Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-hail:0.0.3`
 
-## 0.0.2 - 10/10/2019 
+## 0.0.2 - 10/10/2019
 
-Update to use python 0.0.2 
+Update to use python 0.0.2
 
 Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-hail:0.0.2`
 

--- a/terra-jupyter-hail/Dockerfile
+++ b/terra-jupyter-hail/Dockerfile
@@ -4,7 +4,7 @@ USER root
 ENV PIP_USER=false
 ENV PYTHONPATH $PYTHONPATH:/usr/lib/spark/python
 ENV PYSPARK_PYTHON=python3
-ENV HAIL_VERSION=0.2.62
+ENV HAIL_VERSION=0.2.74
 
 RUN find $JUPYTER_HOME/scripts -name '*.sh' -type f | xargs chmod +x \
     && $JUPYTER_HOME/scripts/kernel/kernelspec.sh $JUPYTER_HOME/scripts/kernel /opt/conda/share/jupyter/kernels \


### PR DESCRIPTION
I made the normal changes that I make when updating hail version in Terra, but it's worth noting that Hail has also updated from using Spark 2.4.x to Spark 3.1.x by default. Are there other changes I have to make to reflect this? 