### PR TITLE
Adding Simple tests for OVTF

### DIFF
--- a/terra-jupyter-gatk-ovtf/README.md
+++ b/terra-jupyter-gatk-ovtf/README.md
@@ -10,7 +10,7 @@ https://hub.docker.com/r/iotgedge/terra-jupyter-gatk-ovtf
 
 The terra-jupyter-gatk extends the [terra-jupyter-python](../terra-jupyter-python/README.md) and [terra-jupyter-r](../terra-jupyter-r/README.md) by including the following:
 
-- Open JDK 
+- Open JDK
 - GATK
 - Samtools
 - [OpenVINO integration with TensorFlow](https://github.com/openvinotoolkit/openvino_tensorflow) (OVTF)
@@ -21,22 +21,31 @@ To see the complete contents of this image please see the [Dockerfile](./Dockerf
 
 This repo provides a sample notebook [GATK-OVTF-Notebook.ipynb](./GATK-OVTF-Notebook.ipynb) which showcases the performance benefits obtained by using OpenVINO™ integration with TensorFlow.
 
-## Build and Run Instructions - Locally
+## Build and Run Instructions - **Locally**
 
-- #### Clone the repository.
-- #### Build the docker image
-  ```
-  cd terra-docker/terra-jupyter-gatk-ovtf 
-  docker build . -t terra-jupyter-conda-gatk
-  ```
+- ### Clone the repository
 
-- #### Run the container, Then navigate a browser to http://localhost:8000/notebooks to access the Jupyter UI.
-  ```
-  docker run --rm -it -p 8000:8000 terra-jupyter-gatk-ovtf 
+  ```bash
+  git clone https://github.com/DataBiosphere/terra-docker
+
   ```
 
-- #### You can gain root access and open a bash terminal as follows:
+- ### Build the docker image
+
+  ```bash
+  cd terra-docker/terra-jupyter-gatk-ovtf
+  docker build . -t terra-jupyter-gatk-ovtf
   ```
+
+- ### Run the container, Then navigate a browser to http://localhost:8000/notebooks to access the Jupyter UI
+
+  ```bash
+  docker run --rm -it -p 8000:8000 terra-jupyter-gatk-ovtf
+  ```
+
+- ### You can gain root access and open a bash terminal as follows:
+
+  ```bash
   docker run --rm -it -u root -p 8000:8000 --entrypoint /bin/bash terra-jupyter-gatk-ovtf
   ```
 
@@ -44,4 +53,4 @@ This repo provides a sample notebook [GATK-OVTF-Notebook.ipynb](./GATK-OVTF-Note
 
 To select an older version this image, you can search the [CHANGELOG.md](./CHANGELOG.md) for a specific package version you need.
 
-Once you find an image version that you want, simply copy and paste the image url from the changelog into the corresponding custom docker field in the Terra notebook runtime widget. 
+Once you find an image version that you want, simply copy and paste the image url from the changelog into the corresponding custom docker field in the Terra notebook runtime widget.

--- a/terra-jupyter-gatk-ovtf/tests/ovtf_smoke_test.ipynb
+++ b/terra-jupyter-gatk-ovtf/tests/ovtf_smoke_test.ipynb
@@ -2,7 +2,6 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "# Test cases requiring or benefiting from the context of a notebook\n",
     "\n",
@@ -11,46 +10,92 @@
     "TODO(all): Add additional tests and/or tests with particular assertions, as we encounter Python package version incompatibilities not currently detected by these tests.\n",
     "\n",
     "In general, only add test cases here that require the context of a notebook. This is because this notebook, as currently written, will abort at the **first** failure. Compare this to a proper test suite where all cases are run, giving much more information about the full extent of any problems encountered."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "# Package versions"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "!pip3 freeze"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "# Test cases requiring the context of a notebook "
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
-    "## Test OVTF"
-   ]
+    "## Test OpenVINO integration with Tensorflow (OVTF)"
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
-    "print(\"TODO add test cases\")"
-   ]
+    "import tensorflow as tf\n",
+    "import openvino_tensorflow\n",
+    "\n",
+    "print('TensorFlow version: ',tf.__version__)\n",
+    "print(openvino_tensorflow.__version__)"
+   ],
+   "outputs": [],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Test GATK"
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "source": [
+    "!gatk -version"
+   ],
+   "outputs": [],
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "source": [
+    "!gatk --dry-run"
+   ],
+   "outputs": [],
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "source": [
+    "!gatk CNNScoreVariants \\\n",
+    "        -I gs://gatk-tutorials/workshop_2002/2-germline/CNNScoreVariants/bams/g94982_chr20_1m_10m_bamout.bam \\\n",
+    "        -V gs://gatk-tutorials/workshop_2002/2-germline/CNNScoreVariants/vcfs/g94982_b37_chr20_1m_15871.vcf.gz \\\n",
+    "        -R gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta \\\n",
+    "        -O my_2d_cnn_scored.vcf \\\n",
+    "        --tensor-type read_tensor \\\n",
+    "        --transfer-batch-size 256 \\\n",
+    "        --inference-batch-size 256"
+   ],
+   "outputs": [],
+   "metadata": {}
   }
  ],
  "metadata": {

--- a/terra-jupyter-gatk-ovtf/tests/ovtf_smoke_test.ipynb
+++ b/terra-jupyter-gatk-ovtf/tests/ovtf_smoke_test.ipynb
@@ -93,7 +93,8 @@
    "execution_count": null,
    "source": [
     "!gatk CNNScoreVariants \\\n",
-    "-V gs://gatk-tutorials/workshop_2002/2-germline/CNNScoreVariants/vcfs/g94982_b37_chr20_1m_15871.vcf.gz \\\n",
+    "-I gs://gatk-tutorials/$WORKSHOP/2-germline/CNNScoreVariants/bams/g94982_chr20_1m_10m_bamout.bam \\\n",
+    "-V gs://gatk-tutorials/$WORKSHOP/2-germline/CNNScoreVariants/vcfs/g94982_b37_chr20_1m_895.vcf \\\n",
     "-O output_my_1d_cnn_scored.vcf \\\n",
     "-R gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta"
    ],

--- a/terra-jupyter-gatk-ovtf/tests/ovtf_smoke_test.ipynb
+++ b/terra-jupyter-gatk-ovtf/tests/ovtf_smoke_test.ipynb
@@ -82,17 +82,20 @@
    "metadata": {}
   },
   {
+   "cell_type": "markdown",
+   "source": [
+    "## Test Run the default 1D model on the VCF with CNNScoreVariants"
+   ],
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "source": [
     "!gatk CNNScoreVariants \\\n",
-    "        -I gs://gatk-tutorials/workshop_2002/2-germline/CNNScoreVariants/bams/g94982_chr20_1m_10m_bamout.bam \\\n",
-    "        -V gs://gatk-tutorials/workshop_2002/2-germline/CNNScoreVariants/vcfs/g94982_b37_chr20_1m_15871.vcf.gz \\\n",
-    "        -R gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta \\\n",
-    "        -O my_2d_cnn_scored.vcf \\\n",
-    "        --tensor-type read_tensor \\\n",
-    "        --transfer-batch-size 256 \\\n",
-    "        --inference-batch-size 256"
+    "-V gs://gatk-tutorials/workshop_2002/2-germline/CNNScoreVariants/vcfs/g94982_b37_chr20_1m_15871.vcf.gz \\\n",
+    "-O output_my_1d_cnn_scored.vcf \\\n",
+    "-R gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta"
    ],
    "outputs": [],
    "metadata": {}

--- a/terra-jupyter-gatk-ovtf/tests/ovtf_smoke_test.ipynb
+++ b/terra-jupyter-gatk-ovtf/tests/ovtf_smoke_test.ipynb
@@ -93,10 +93,10 @@
    "execution_count": null,
    "source": [
     "!gatk CNNScoreVariants \\\n",
-    "-I gs://gatk-tutorials/$WORKSHOP/2-germline/CNNScoreVariants/bams/g94982_chr20_1m_10m_bamout.bam \\\n",
-    "-V gs://gatk-tutorials/$WORKSHOP/2-germline/CNNScoreVariants/vcfs/g94982_b37_chr20_1m_895.vcf \\\n",
-    "-O output_my_1d_cnn_scored.vcf \\\n",
-    "-R gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta"
+    "    -I gs://gatk-tutorials/workshop_2002/2-germline/CNNScoreVariants/bams/g94982_chr20_1m_10m_bamout.bam \\\n",
+    "    -V gs://gatk-tutorials/workshop_2002/2-germline/CNNScoreVariants/vcfs/g94982_b37_chr20_1m_895.vcf \\\n",
+    "    -O output_my_1d_cnn_scored.vcf \\\n",
+    "    -R gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta"
    ],
    "outputs": [],
    "metadata": {}

--- a/terra-jupyter-gatk-ovtf/tests/ovtf_smoke_test.py
+++ b/terra-jupyter-gatk-ovtf/tests/ovtf_smoke_test.py
@@ -15,7 +15,7 @@ import tensorflow as tf
 import openvino_tensorflow
 
 def test_ovtf():
-  print("TensorFlow version: ", tf.version.GIT_VERSION, tf.version.VERSION)
+  print("TensorFlow version : ", tf.version.GIT_VERSION, tf.version.VERSION)
 
   openvino_tensorflow.enable()
   assert openvino_tensorflow.is_enabled() == 1

--- a/terra-jupyter-gatk-ovtf/tests/ovtf_smoke_test.py
+++ b/terra-jupyter-gatk-ovtf/tests/ovtf_smoke_test.py
@@ -14,10 +14,9 @@ import pytest
 import tensorflow as tf
 import openvino_tensorflow
 
+
 def test_ovtf():
-  print("TensorFlow version : ", tf.version.GIT_VERSION, tf.version.VERSION)
+    print("TensorFlow version : ", tf.version.GIT_VERSION, tf.version.VERSION)
 
-  openvino_tensorflow.enable()
-  assert openvino_tensorflow.is_enabled() == 1
-
-
+    openvino_tensorflow.enable()
+    assert openvino_tensorflow.is_enabled() == 1

--- a/terra-jupyter-gatk-ovtf/tests/ovtf_smoke_test.py
+++ b/terra-jupyter-gatk-ovtf/tests/ovtf_smoke_test.py
@@ -7,8 +7,17 @@ TODO(all): Add additional tests and/or tests with particular assertions, as we e
 incompatibilities not currently detected by these tests.
 """
 
+from __future__ import print_function
 import os
 import pytest
 
+import tensorflow as tf
+import openvino_tensorflow
+
 def test_ovtf():
-  print("TODO")
+  print("TensorFlow version: ", tf.version.GIT_VERSION, tf.version.VERSION)
+
+  openvino_tensorflow.enable()
+  assert openvino_tensorflow.is_enabled() == 1
+
+


### PR DESCRIPTION
@rtitle We added simple tests for verifying OVTF.
Once the CI/CD pipe line is working, we need to update the `README` to update the container path to `us.gcr.io/broad-dsp-gcr-public/....`

cc: @cavusmustafa 