### PR TITLE
[IA-2902] [IA-2956] Use tf2-gpu.2-6 as base image

### DIFF
--- a/config/community_images.json
+++ b/config/community_images.json
@@ -21,10 +21,10 @@
 {
     "id": "OpenVINO integration with Tensorflow",
     "label": "OpenVINO integration with Tensorflow (openvino-tensorflow 0.5.0, Python 3.7.10, GATK 4.2.0.0)",
-    "version": "0.1.0",
-    "updated": "2021-08-31",
-    "packages": "https://storage.googleapis.com/terra-docker-image-documentation/terra-jupyter-gatk-ovtf-0.1.0-versions.json",
-    "image": "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk-ovtf:0.1.0",
+    "version": "0.1.1",
+    "updated": "2021-09-10",
+    "packages": "https://storage.googleapis.com/terra-docker-image-documentation/terra-jupyter-gatk-ovtf-0.1.1-versions.json",
+    "image": "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk-ovtf:0.1.1",
     "requiresSpark": false,
     "isCommunity": true
 }]

--- a/config/conf.json
+++ b/config/conf.json
@@ -26,7 +26,7 @@
                     "tidyverse"
                 ]
             },
-            "version" : "2.0.0",
+            "version" : "2.0.1",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : true,
@@ -47,7 +47,7 @@
                     "hail"
                 ]
             },
-            "version" : "1.0.0",
+            "version" : "1.0.1",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : true,
@@ -68,7 +68,7 @@
                     "scikit-learn"
                 ]
             },
-            "version" : "1.0.0",
+            "version" : "1.0.1",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : true,
@@ -86,7 +86,7 @@
             "packages" : {
                 
             },
-            "version" : "1.0.0",
+            "version" : "1.0.1",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : false,
@@ -104,7 +104,7 @@
             "packages" : {
                 
             },
-            "version" : "2.0.0",
+            "version" : "2.0.1",
             "automated_flags" : {
                 "include_in_ui" : false,
                 "generate_docs" : true,
@@ -124,7 +124,7 @@
             "packages" : {
                 
             },
-            "version" : "2.0.1",
+            "version" : "2.0.2",
             "automated_flags" : {
                 "include_in_ui" : true,
                 "generate_docs" : true,
@@ -143,7 +143,7 @@
             "packages" : {
                 
             },
-            "version" : "2.0.1",
+            "version" : "2.0.2",
             "automated_flags" : {
                 "include_in_ui" : false,
                 "generate_docs" : false,
@@ -161,9 +161,9 @@
                 "r"
             ],
             "packages" : {
-
+                
             },
-            "version" : "0.1.0",
+            "version" : "0.1.1",
             "automated_flags" : {
                 "include_in_ui" : false,
                 "generate_docs" : true,

--- a/terra-jupyter-aou/CHANGELOG.md
+++ b/terra-jupyter-aou/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.0.2 - 2021-09-10T15:10:44.156815Z
+
+- Update `terra-jupyter-base` to `1.0.1`
+  - Update base image to gcr.io/deeplearning-platform-release/tf2-gpu.2-6 to support TensorFlow 2.6.0
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:2.0.2`
+
 ## 2.0.1 - 2021-07-20
 
 - Upgrade `terra-jupyter-gatk` to `2.0.1`

--- a/terra-jupyter-aou/CHANGELOG.md
+++ b/terra-jupyter-aou/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Update `terra-jupyter-base` to `1.0.1`
   - Update base image to gcr.io/deeplearning-platform-release/tf2-gpu.2-6 to support TensorFlow 2.6.0
+  - Fix multipart Jupyter uploads
 
 Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:2.0.2`
 

--- a/terra-jupyter-aou/Dockerfile
+++ b/terra-jupyter-aou/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.0.1
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.0.2
 
 USER root
 

--- a/terra-jupyter-base/CHANGELOG.md
+++ b/terra-jupyter-base/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.0.1 - 2021-09-10T15:10:44.047182Z
+
+- Update base image to gcr.io/deeplearning-platform-release/tf2-gpu.2-6 to support TensorFlow 2.6.0
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.0.1`
+
 ## 1.0.0 - 2021-06-09T16:18:53.734840Z
 
 - use `gcr.io/deeplearning-platform-release/base-cu110:latest` as base

--- a/terra-jupyter-base/CHANGELOG.md
+++ b/terra-jupyter-base/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.0.1 - 2021-09-10T15:10:44.047182Z
 
 - Update base image to gcr.io/deeplearning-platform-release/tf2-gpu.2-6 to support TensorFlow 2.6.0
+- Fix multipart Jupyter uploads
 
 Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.0.1`
 

--- a/terra-jupyter-base/Dockerfile
+++ b/terra-jupyter-base/Dockerfile
@@ -1,6 +1,6 @@
 # adapted from https://hub.docker.com/r/jupyter/base-notebook/ AKA https://github.com/jupyter/docker-stacks/tree/master/base-notebook
 
-FROM gcr.io/deeplearning-platform-release/base-cu110:latest
+FROM gcr.io/deeplearning-platform-release/tf2-gpu.2-6 
 USER root
 
 #######################

--- a/terra-jupyter-base/Dockerfile
+++ b/terra-jupyter-base/Dockerfile
@@ -94,8 +94,6 @@ RUN pip3 -V \
  # Hence, make sure to manually test out "launch terminal" button (the button in the green bar next to start and stop buttons)
  # to make sure we don't accidentally break it every time we upgrade notebook version until we figure out an automation test for this
  && pip3 install python-datauri \
- # This is to avoid incompatibility issue, see https://github.com/ipython-contrib/jupyter_contrib_nbextensions/issues/1529
- && conda install "nbconvert<6" \
  && pip3 install jupyter_contrib_nbextensions \
  && pip3 install jupyter_nbextensions_configurator \
  # for jupyter_delocalize.py and jupyter_notebook_config.py
@@ -140,6 +138,7 @@ RUN chown -R $USER:users $JUPYTER_HOME \
 
 USER $USER
 EXPOSE $JUPYTER_PORT
+WORKDIR $HOME
 
 # Note: this entrypoint is provided for running Jupyter independently of Leonardo.
 # When Leonardo deploys this image onto a cluster, the entrypoint is overwritten to enable

--- a/terra-jupyter-bioconductor/CHANGELOG.md
+++ b/terra-jupyter-bioconductor/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.0.1 - 2021-09-10T15:10:44.079307Z
+
+- Update `terra-jupyter-base` to `1.0.1`
+  - Update base image to gcr.io/deeplearning-platform-release/tf2-gpu.2-6 to support TensorFlow 2.6.0
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:2.0.1`
+
 ## 2.0.0 - 2021-06-09T16:18:53.763986Z
 
 - Update `terra-jupyter-base` to `1.0.0`

--- a/terra-jupyter-bioconductor/CHANGELOG.md
+++ b/terra-jupyter-bioconductor/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Update `terra-jupyter-base` to `1.0.1`
   - Update base image to gcr.io/deeplearning-platform-release/tf2-gpu.2-6 to support TensorFlow 2.6.0
+  - Fix multipart Jupyter uploads
 
 Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:2.0.1`
 

--- a/terra-jupyter-bioconductor/Dockerfile
+++ b/terra-jupyter-bioconductor/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.0.0
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.0.1
 
 USER root
 

--- a/terra-jupyter-gatk-ovtf/CHANGELOG.md
+++ b/terra-jupyter-gatk-ovtf/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Update `terra-jupyter-base` to `1.0.1`
   - Update base image to gcr.io/deeplearning-platform-release/tf2-gpu.2-6 to support TensorFlow 2.6.0
+  - Fix multipart Jupyter uploads
 
 Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk-ovtf:0.1.1`
 

--- a/terra-jupyter-gatk-ovtf/CHANGELOG.md
+++ b/terra-jupyter-gatk-ovtf/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.1.1 - 2021-09-10T15:10:44.164165Z
+
+- Update `terra-jupyter-base` to `1.0.1`
+  - Update base image to gcr.io/deeplearning-platform-release/tf2-gpu.2-6 to support TensorFlow 2.6.0
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk-ovtf:0.1.1`
+
 ## 0.1.0 - 08/25/2021
 
 - Added OpenVINO integration with TensorFlow (OVTF)

--- a/terra-jupyter-gatk-ovtf/Dockerfile
+++ b/terra-jupyter-gatk-ovtf/Dockerfile
@@ -1,6 +1,6 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.0 AS python
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.1 AS python
 
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.0.0
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.0.1
 
 # copy everything pip installed from the python image
 COPY --from=python /opt/conda/lib/python3.7/site-packages /opt/conda/lib/python3.7/site-packages
@@ -44,8 +44,7 @@ RUN cd /gatk-build \
     && cd .. && rm -rf gatk
 
 ENV PIP_USER=false
-RUN pip install --force-reinstall tensorflow==2.4.1 \
-    && pip install openvino_tensorflow \
+RUN pip install openvino_tensorflow \
     && pip install keras matplotlib sklearn \
     && pip install /etc/gatk-tfov/gatkPythonPackageArchive.zip
 ENV PIP_USER=true

--- a/terra-jupyter-gatk-ovtf/Dockerfile
+++ b/terra-jupyter-gatk-ovtf/Dockerfile
@@ -44,7 +44,8 @@ RUN cd /gatk-build \
     && cd .. && rm -rf gatk
 
 ENV PIP_USER=false
-RUN pip install openvino_tensorflow \
+RUN pip install --force-reinstall tensorflow==2.5.0 \
+    && pip install openvino_tensorflow \
     && pip install keras matplotlib sklearn \
     && pip install /etc/gatk-tfov/gatkPythonPackageArchive.zip
 ENV PIP_USER=true

--- a/terra-jupyter-gatk-ovtf/Dockerfile
+++ b/terra-jupyter-gatk-ovtf/Dockerfile
@@ -45,6 +45,7 @@ RUN cd /gatk-build \
 
 ENV PIP_USER=false
 RUN pip install --force-reinstall tensorflow==2.5.0 \
+    && conda install six \
     && pip install openvino_tensorflow \
     && pip install keras matplotlib sklearn \
     && pip install /etc/gatk-tfov/gatkPythonPackageArchive.zip

--- a/terra-jupyter-gatk/CHANGELOG.md
+++ b/terra-jupyter-gatk/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.0.2 - 2021-09-10T15:10:44.143280Z
+
+- Update `terra-jupyter-base` to `1.0.1`
+  - Update base image to gcr.io/deeplearning-platform-release/tf2-gpu.2-6 to support TensorFlow 2.6.0
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.0.2`
+
 ## 2.0.1 - 2021-07-12
 
 - Upgrade `gatk` version to `4.2.0.0`

--- a/terra-jupyter-gatk/CHANGELOG.md
+++ b/terra-jupyter-gatk/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Update `terra-jupyter-base` to `1.0.1`
   - Update base image to gcr.io/deeplearning-platform-release/tf2-gpu.2-6 to support TensorFlow 2.6.0
+  - Fix multipart Jupyter uploads
 
 Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.0.2`
 

--- a/terra-jupyter-gatk/Dockerfile
+++ b/terra-jupyter-gatk/Dockerfile
@@ -1,6 +1,6 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.0 AS python
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.1 AS python
 
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.0.0
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.0.1
 
 # copy everything pip installed from the python image
 COPY --from=python /opt/conda/lib/python3.7/site-packages /opt/conda/lib/python3.7/site-packages

--- a/terra-jupyter-hail/CHANGELOG.md
+++ b/terra-jupyter-hail/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.0.1 - 2021-09-10T15:10:44.093747Z
+
+- Update `terra-jupyter-base` to `1.0.1`
+  - Update base image to gcr.io/deeplearning-platform-release/tf2-gpu.2-6 to support TensorFlow 2.6.0
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-hail:1.0.1`
+
 ## 1.0.0 - 2021-06-09T16:18:53.782701Z
 
 - Update `terra-jupyter-base` to `1.0.0`

--- a/terra-jupyter-hail/CHANGELOG.md
+++ b/terra-jupyter-hail/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Update `terra-jupyter-base` to `1.0.1`
   - Update base image to gcr.io/deeplearning-platform-release/tf2-gpu.2-6 to support TensorFlow 2.6.0
+  - Fix multipart Jupyter uploads
 
 Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-hail:1.0.1`
 

--- a/terra-jupyter-hail/Dockerfile
+++ b/terra-jupyter-hail/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.0
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.1
 USER root
 
 COPY scripts $JUPYTER_HOME/scripts

--- a/terra-jupyter-python/CHANGELOG.md
+++ b/terra-jupyter-python/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.0.1 - 2021-09-10T15:10:44.113546Z
+
+- Update `terra-jupyter-base` to `1.0.1`
+  - Update base image to gcr.io/deeplearning-platform-release/tf2-gpu.2-6 to support TensorFlow 2.6.0
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.1`
+
 ## 1.0.0 - 2021-06-09T16:18:53.809656Z
 
 - Update `terra-jupyter-base` to `1.0.0`

--- a/terra-jupyter-python/CHANGELOG.md
+++ b/terra-jupyter-python/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Update `terra-jupyter-base` to `1.0.1`
   - Update base image to gcr.io/deeplearning-platform-release/tf2-gpu.2-6 to support TensorFlow 2.6.0
+  - Fix multipart Jupyter uploads
 
 Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.1`
 

--- a/terra-jupyter-python/Dockerfile
+++ b/terra-jupyter-python/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.0.0
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.0.1
 USER root
 # This makes it so pip runs as root, not the user.
 ENV PIP_USER=false
@@ -60,8 +60,6 @@ RUN pip3 -V \
    python-dateutil \
    pytz \
    pyvcf \
-   # We can't use higher version of tensorflow because it'll require higher version of CUDA to work with GPUs.
-   tensorflow==2.4.2 \
    theano \
    tqdm \
    werkzeug \

--- a/terra-jupyter-python/Dockerfile
+++ b/terra-jupyter-python/Dockerfile
@@ -56,6 +56,10 @@ RUN pip3 -V \
    pymc3 \
    pyparsing \
    Cython \
+   # Downgrade setuptools from the base image due to incompatibilies with pysam.
+   # As of 2021-09-10, this is the latest version of setuptools that works with pysam.
+   # See https://pypi.org/project/setuptools/#history
+   setuptools==58.0.1 --force-reinstall \
    pysam --no-binary pysam \
    python-dateutil \
    pytz \
@@ -66,7 +70,6 @@ RUN pip3 -V \
    certifi \
    intel-openmp \
    mkl \
-   setuptools \
    wheel \
    plotnine \
    google-resumable-media \

--- a/terra-jupyter-python/tests/smoke_test.ipynb
+++ b/terra-jupyter-python/tests/smoke_test.ipynb
@@ -304,7 +304,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Test Google Libraries"
+    "## Test Google Libraries"
    ]
   },
   {
@@ -354,6 +354,136 @@
    "outputs": [],
    "source": [
     "from google.cloud import bigquery"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Test TensorFlow\n",
+    "### See https://www.tensorflow.org/tutorials/quickstart/beginner"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import tensorflow as tf"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mnist = tf.keras.datasets.mnist\n",
+    "\n",
+    "(x_train, y_train), (x_test, y_test) = mnist.load_data()\n",
+    "x_train, x_test = x_train / 255.0, x_test / 255.0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = tf.keras.models.Sequential([\n",
+    "  tf.keras.layers.Flatten(input_shape=(28, 28)),\n",
+    "  tf.keras.layers.Dense(128, activation='relu'),\n",
+    "  tf.keras.layers.Dropout(0.2),\n",
+    "  tf.keras.layers.Dense(10)\n",
+    "])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "predictions = model(x_train[:1]).numpy()\n",
+    "predictions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tf.nn.softmax(predictions).numpy()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "loss_fn = tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "loss_fn(y_train[:1], predictions).numpy()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model.compile(optimizer='adam',\n",
+    "              loss=loss_fn,\n",
+    "              metrics=['accuracy'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model.fit(x_train, y_train, epochs=5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model.evaluate(x_test,  y_test, verbose=2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "probability_model = tf.keras.Sequential([\n",
+    "  model,\n",
+    "  tf.keras.layers.Softmax()\n",
+    "])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "probability_model(x_test[:5])"
    ]
   }
  ],

--- a/terra-jupyter-python/tests/smoke_test.py
+++ b/terra-jupyter-python/tests/smoke_test.py
@@ -48,3 +48,38 @@ def test_tensorflow_hello_world():
   hello = tf.constant('Hello, TensorFlow!')
   sess = tf.Session()
   print(sess.run(hello))
+
+def test_pysam():
+  import pysam
+
+  # Create BAM file from scratch
+  # Code stolen from https://pysam.readthedocs.io/en/latest/usage.html#creating-bam-cram-sam-files-from-scratch
+  header = { 'HD': {'VN': '1.0'},
+            'SQ': [{'LN': 1575, 'SN': 'chr1'},
+                   {'LN': 1584, 'SN': 'chr2'}] }
+
+  file_name = "out.bam"
+  with pysam.AlignmentFile(file_name, "wb", header=header) as outf:
+    a = pysam.AlignedSegment()
+    a.query_name = "read_28833_29006_6945"
+    a.query_sequence="AGCTTAGCTAGCTACCTATATCTTGGTCTTGGCCG"
+    a.flag = 99
+    a.reference_id = 0
+    a.reference_start = 32
+    a.mapping_quality = 20
+    a.cigar = ((0,10), (2,1), (0,25))
+    a.next_reference_id = 0
+    a.next_reference_start=199
+    a.template_length=167
+    a.query_qualities = pysam.qualitystring_to_array("<<<<<<<<<<<<<<<<<<<<<:<9/,&,22;;<<<")
+    a.tags = (("NM", 1),
+              ("RG", "L1"))
+    outf.write(a)
+
+  # Verify output file exists
+  assert os.path.isfile(file_name)
+
+  # Call samtools to sort the file
+  # This will fail if the file is not a valid BAM file
+  pysam.sort("-o", "sorted.bam", file_name)
+  assert os.path.isfile("sorted.bam")

--- a/terra-jupyter-python/tests/smoke_test.py
+++ b/terra-jupyter-python/tests/smoke_test.py
@@ -46,8 +46,7 @@ def test_tensorflow_hello_world():
   import tensorflow as tf
   print("TensorFlow version : ", tf.version.GIT_VERSION, tf.version.VERSION)
   hello = tf.constant('Hello, TensorFlow!')
-  sess = tf.Session()
-  print(sess.run(hello))
+  tf.print(hello)
 
 def test_pysam():
   import pysam

--- a/terra-jupyter-python/tests/smoke_test.py
+++ b/terra-jupyter-python/tests/smoke_test.py
@@ -41,3 +41,10 @@ def test_tensorflow_gfile():
   tf.io.gfile.copy(src='gs://genomics-public-data/1000-genomes/other/sample_info/sample_info.csv',
                    dst='/tmp/genomics-public-data-1000-genomes-sample_info.csv',
                    overwrite=True)
+
+def test_tensorflow_hello_world():
+  import tensorflow as tf
+  print("TensorFlow version : ", tf.version.GIT_VERSION, tf.version.VERSION)
+  hello = tf.constant('Hello, TensorFlow!')
+  sess = tf.Session()
+  print(sess.run(hello))

--- a/terra-jupyter-r/CHANGELOG.md
+++ b/terra-jupyter-r/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Update `terra-jupyter-base` to `1.0.1`
   - Update base image to gcr.io/deeplearning-platform-release/tf2-gpu.2-6 to support TensorFlow 2.6.0
+  - Fix multipart Jupyter uploads
 
 Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.0.1`
 

--- a/terra-jupyter-r/CHANGELOG.md
+++ b/terra-jupyter-r/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.0.1 - 2021-09-10T15:10:44.133967Z
+
+- Update `terra-jupyter-base` to `1.0.1`
+  - Update base image to gcr.io/deeplearning-platform-release/tf2-gpu.2-6 to support TensorFlow 2.6.0
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.0.1`
+
 ## 2.0.0 - 2021-06-09T16:18:53.836988Z
 
 - Update `terra-jupyter-base` to `1.0.0`

--- a/terra-jupyter-r/Dockerfile
+++ b/terra-jupyter-r/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.0.0
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.0.1
 USER root
 
 COPY scripts $JUPYTER_HOME/scripts


### PR DESCRIPTION
See: 
* https://broadworkbench.atlassian.net/browse/IA-2902
* https://github.com/DataBiosphere/terra-docker/issues/244

This PR updates the `terra-jupyter-base` parent image to `gcr.io/deeplearning-platform-release/tf2-gpu.2-6 `. This supports tensorflow 2.6.0 with GPUs, whereas previously only 2.4.0 was supported due to a CUDA library mismatch.

The base image size difference is:
* old: 13.5GB
* new: 16GB
Since we cache all the images I think the size differential is reasonable.

Added a couple test cases around tensorflow which should run on this PR. I'll also do some local manual testing.

Note: this PR also includes https://broadworkbench.atlassian.net/browse/IA-2956

After this PR is merged and the images are built and pushed, we will rebuild the Leo custom image (to update the caches), and then test through Leo before pushing live.