### PR TITLE
[no ticket] Temporarily downgrade OpenVINO image to 0.1.0

### DIFF
--- a/config/community_images.json
+++ b/config/community_images.json
@@ -21,10 +21,10 @@
 {
     "id": "OpenVINO integration with Tensorflow",
     "label": "OpenVINO integration with Tensorflow (openvino-tensorflow 0.5.0, Python 3.7.10, GATK 4.2.0.0)",
-    "version": "0.1.1",
-    "updated": "2021-09-10",
-    "packages": "https://storage.googleapis.com/terra-docker-image-documentation/terra-jupyter-gatk-ovtf-0.1.1-versions.json",
-    "image": "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk-ovtf:0.1.1",
+    "version": "0.1.0",
+    "updated": "2021-08-31",
+    "packages": "https://storage.googleapis.com/terra-docker-image-documentation/terra-jupyter-gatk-ovtf-0.1.0-versions.json",
+    "image": "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk-ovtf:0.1.0",
     "requiresSpark": false,
     "isCommunity": true
 }]


### PR DESCRIPTION
`0.1.1`, `0.1.2` versions have an issue where they can't detect GPUs due to CUDA library mismatches. See https://github.com/DataBiosphere/terra-docker/issues/264

The `0.1.0` version seems to still work:

![image](https://user-images.githubusercontent.com/5368863/137936654-15949852-d7bf-472d-b940-c7eedaf7990e.png)

We can bump the OpenVINO image to `0.1.2` once they release support for TF 2.6.0 (expected mid-Nov).