### PR TITLE
add a run with Intel oneDNN enablement

### DIFF
--- a/terra-jupyter-gatk-ovtf/GATK-OVTF-Notebook.ipynb
+++ b/terra-jupyter-gatk-ovtf/GATK-OVTF-Notebook.ipynb
@@ -19,31 +19,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## GATK CNNScoreVariants on OV-TF"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "!gatk CNNScoreVariants \\\n",
-    "        -I gs://gatk-tutorials/workshop_2002/2-germline/CNNScoreVariants/bams/g94982_chr20_1m_10m_bamout.bam \\\n",
-    "        -V gs://gatk-tutorials/workshop_2002/2-germline/CNNScoreVariants/vcfs/g94982_b37_chr20_1m_15871.vcf.gz \\\n",
-    "        -R gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta \\\n",
-    "        -O my_2d_cnn_scored.vcf \\\n",
-    "        --tensor-type read_tensor \\\n",
-    "        --transfer-batch-size 256 \\\n",
-    "        --inference-batch-size 256"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "## Baseline GATK CNNScoreVariants"
    ]
   },
@@ -61,6 +36,58 @@
     "        -V gs://gatk-tutorials/workshop_2002/2-germline/CNNScoreVariants/vcfs/g94982_b37_chr20_1m_15871.vcf.gz \\\n",
     "        -R gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta \\\n",
     "        -O my_2d_cnn_scored_ovtf.vcf \\\n",
+    "        --tensor-type read_tensor \\\n",
+    "        --transfer-batch-size 256 \\\n",
+    "        --inference-batch-size 256"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## GATK CNNScoreVariants with oneDNN optimization\n",
+    "The oneAPI Deep Neural Network Library (oneDNN) optimizations are also now available in the official x86-64 TensorFlow after v2.5. Users can enable those CPU optimizations by setting the the environment variable TF_ENABLE_ONEDNN_OPTS=1 for the official x86-64 TensorFlow after v2.5."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "!TF_ENABLE_ONEDNN_OPTS=1 OPENVINO_TF_DISABLE=\"1\" \\\n",
+    " gatk CNNScoreVariants \\\n",
+    "        -I gs://gatk-tutorials/workshop_2002/2-germline/CNNScoreVariants/bams/g94982_chr20_1m_10m_bamout.bam \\\n",
+    "        -V gs://gatk-tutorials/workshop_2002/2-germline/CNNScoreVariants/vcfs/g94982_b37_chr20_1m_15871.vcf.gz \\\n",
+    "        -R gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta \\\n",
+    "        -O my_2d_cnn_scored_ovtf.vcf \\\n",
+    "        --tensor-type read_tensor \\\n",
+    "        --transfer-batch-size 256 \\\n",
+    "        --inference-batch-size 256"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## GATK CNNScoreVariants on OV-TF"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "!gatk CNNScoreVariants \\\n",
+    "        -I gs://gatk-tutorials/workshop_2002/2-germline/CNNScoreVariants/bams/g94982_chr20_1m_10m_bamout.bam \\\n",
+    "        -V gs://gatk-tutorials/workshop_2002/2-germline/CNNScoreVariants/vcfs/g94982_b37_chr20_1m_15871.vcf.gz \\\n",
+    "        -R gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta \\\n",
+    "        -O my_2d_cnn_scored.vcf \\\n",
     "        --tensor-type read_tensor \\\n",
     "        --transfer-batch-size 256 \\\n",
     "        --inference-batch-size 256"
@@ -83,7 +110,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.10"
+   "version": "3.7.6"
   },
   "toc": {
    "base_numbering": 1,


### PR DESCRIPTION
The oneAPI Deep Neural Network Library (oneDNN) optimizations are also now available in the official x86-64 TensorFlow after v2.5. Users can enable those CPU optimizations by setting the the environment variable TF_ENABLE_ONEDNN_OPTS=1 for the official x86-64 TensorFlow after v2.5.

Add one more run for perf comparison between baseline and oneDNN enabled version.