### PR TITLE
enable oneDNN optimizatoin by default for TensorFlow

### DIFF
--- a/terra-jupyter-python/Dockerfile
+++ b/terra-jupyter-python/Dockerfile
@@ -91,6 +91,8 @@ ENV USER jupyter
 USER $USER
 # We want pip to install into the user's dir when the notebook is running.
 ENV PIP_USER=true
+# Enable Intel oneDNN optimizatoin by default
+ENV TF_ENABLE_ONEDNN_OPTS=1
 
 # Note: this entrypoint is provided for running Jupyter independently of Leonardo.
 # When Leonardo deploys this image onto a cluster, the entrypoint is overwritten to enable

--- a/terra-jupyter-python/tests/smoke_test.ipynb
+++ b/terra-jupyter-python/tests/smoke_test.ipynb
@@ -349,7 +349,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -365,12 +365,49 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    ">Please redirect standard outputs and errors to stdout.txt and stderr.txt files by starting jupyter notebook with below command.\n",
+    "```\n",
+    "jupyter notebook --ip=0.0.0.0 > stdout.txt 2>stderr.txt\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    ">The oneAPI Deep Neural Network Library (oneDNN) optimizations are also now available in the official x86-64 TensorFlow after v2.5. Users can enable those CPU optimizations by setting the the environment variable TF_ENABLE_ONEDNN_OPTS=1 for the official x86-64 TensorFlow after v2.5."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    ">We enable oneDNN Verbose log to validate the existenance of oneDNN optimization via DNNL_VERBSOE environemnt variable, and also set CUDA_VISIBLE_DEVCIES to -1 to run the workload on CPU."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "import tensorflow as tf"
+    "import os\n",
+    "os.environ['TF_ENABLE_ONEDNN_OPTS'] = '1'\n",
+    "os.environ['DNNL_VERBOSE'] = '1'\n",
+    "os.environ['CUDA_VISIBLE_DEVICES']=\"-1\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import tensorflow as tf\n",
+    "tf.executing_eagerly() "
    ]
   },
   {
@@ -480,11 +517,79 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "probability_model(x_test[:5])"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Validate usage of oneDNN optimization \n",
+    "First, we could check whether we have dnnl verose log or not while we test TensorFlow in the previous section."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!cat /tmp/stdout.txt | grep dnnl"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Second, we could further analyze what oneDNN primitives are used while we run the workload by using a profile_utils.py script."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!wget https://raw.githubusercontent.com/oneapi-src/oneAPI-samples/master/Libraries/oneDNN/tutorials/profiling/profile_utils.py"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import warnings\n",
+    "warnings.filterwarnings('ignore')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally, users should be able to see that inner_product oneDNN primitive is used for the workload."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "run profile_utils.py /tmp/stdout.txt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -508,7 +613,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.10"
+   "version": "3.5.2"
   },
   "toc": {
    "base_numbering": 1,


### PR DESCRIPTION
Since TensorFlow v2.5, oneDNN optimization is in the release by default, so users could easily leverage the oneDNN optimization by changing an environment variable.
You could refer to below release notes from official TensorFlow v2.5 release.
https://github.com/tensorflow/tensorflow/releases/tag/v2.5.0

This PR is to enable oneDNN optimization via the environment variable and then test it via smoke_test notebook.
Therefore, users could get the best TensorFlow performance on CPU.

For the validation, we add a oneDNN validation section in smoke_test notebook.
![image](https://user-images.githubusercontent.com/21761437/142091094-8f87bdf8-094e-43e2-a2e2-134d41333fa6.png)
