### PR TITLE
Update community_images.json to fix R version number

### DIFF
--- a/config/community_images.json
+++ b/config/community_images.json
@@ -10,7 +10,7 @@
 },
 {
     "id": "RStudio",
-    "label": "RStudio (R 4.1.0, Bioconductor 3.14, Python 3.8.5)",
+    "label": "RStudio (R 4.1.2, Bioconductor 3.14, Python 3.8.5)",
     "version": "3.14.0",
     "updated": "2021-11-09",
     "packages": "https://storage.googleapis.com/terra-docker-image-documentation/placeholder.json",


### PR DESCRIPTION
Simple fix of version number in R from 4.1.0 to 4.1.2 