### PR TITLE
IA-3143 Update terra-jupyter-r image to Bioc 3.14, R 4.1.2

### DIFF
--- a/.github/workflows/test-terra-jupyter-bioconductor.yml
+++ b/.github/workflows/test-terra-jupyter-bioconductor.yml
@@ -53,7 +53,7 @@ jobs:
       run: sudo rm -rf /usr/share/dotnet    
 
     - name: Set up Cloud SDK
-      uses: google-github-actions/setup-gcloud@master
+      uses: google-github-actions/setup-gcloud@1021f43415bff191e4694da31bc052b3aada3243
       with:
         project_id: ${{ secrets.GCP_PROJECT_ID }}
         service_account_key: ${{ secrets.GCP_SA_KEY }}

--- a/.github/workflows/test-terra-jupyter-hail.yml
+++ b/.github/workflows/test-terra-jupyter-hail.yml
@@ -53,7 +53,7 @@ jobs:
       run: sudo rm -rf /usr/share/dotnet    
 
     - name: Set up Cloud SDK
-      uses: google-github-actions/setup-gcloud@master
+      uses: google-github-actions/setup-gcloud@1021f43415bff191e4694da31bc052b3aada3243
       with:
         project_id: ${{ secrets.GCP_PROJECT_ID }}
         service_account_key: ${{ secrets.GCP_SA_KEY }}

--- a/config/conf.json
+++ b/config/conf.json
@@ -26,7 +26,7 @@
                     "tidyverse"
                 ]
             },
-            "version" : "2.0.2",
+            "version" : "2.0.3",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : true,
@@ -104,7 +104,7 @@
             "packages" : {
                 
             },
-            "version" : "2.0.2",
+            "version" : "2.0.3",
             "automated_flags" : {
                 "include_in_ui" : false,
                 "generate_docs" : true,
@@ -124,7 +124,7 @@
             "packages" : {
                 
             },
-            "version" : "2.0.5",
+            "version" : "2.0.6",
             "automated_flags" : {
                 "include_in_ui" : true,
                 "generate_docs" : true,
@@ -143,7 +143,7 @@
             "packages" : {
                 
             },
-            "version" : "2.0.8",
+            "version" : "2.0.9",
             "automated_flags" : {
                 "include_in_ui" : false,
                 "generate_docs" : false,
@@ -163,7 +163,7 @@
             "packages" : {
                 
             },
-            "version" : "0.1.4",
+            "version" : "0.1.5",
             "automated_flags" : {
                 "include_in_ui" : false,
                 "generate_docs" : true,

--- a/terra-jupyter-aou/CHANGELOG.md
+++ b/terra-jupyter-aou/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.0.9 - 2021-12-14T19:48:03.857067Z
+
+- Update `terra-jupyter-r` to `2.0.3`
+  - Update Terra Jupyter image to use latest Bioconductor 3.14
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:2.0.9`
+
 ## 2.0.8 - 2021-12-16
 
 - Bump Hail version to 0.2.74

--- a/terra-jupyter-bioconductor/CHANGELOG.md
+++ b/terra-jupyter-bioconductor/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.0.3 - 2021-12-14T19:48:03.812081Z
+
+- Update `terra-jupyter-r` to `2.0.3`
+  - Update Terra Jupyter image to use latest Bioconductor 3.14
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:2.0.3`
+
 ## 2.0.2 - 2021-10-07T14:47:43.359733Z
 
 - Update `terra-jupyter-base` to `1.0.2`

--- a/terra-jupyter-bioconductor/Dockerfile
+++ b/terra-jupyter-bioconductor/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.0.2
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.0.3
 
 USER root
 

--- a/terra-jupyter-bioconductor/tests/smoke_test.ipynb
+++ b/terra-jupyter-bioconductor/tests/smoke_test.ipynb
@@ -354,36 +354,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d98dc2db",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "BiocManager::install('RGtk2')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "f16fa471",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "library(RGtk2)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "premier-volunteer",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "assert_that('RGtk2' %in% rownames(installed.packages()) == 'TRUE')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "id": "younger-greenhouse",
    "metadata": {
     "scrolled": true

--- a/terra-jupyter-gatk-ovtf/CHANGELOG.md
+++ b/terra-jupyter-gatk-ovtf/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.1.5 - 2021-12-14T19:48:03.867076Z
+
+- Update `terra-jupyter-r` to `2.0.3`
+  - Update Terra Jupyter image to use latest Bioconductor 3.14
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk-ovtf:0.1.5`
+
 ## 0.1.4 - 2021-12-15T18:30:57.568303Z
 
 - Upgrade gatk image to 4.2.4.0

--- a/terra-jupyter-gatk-ovtf/Dockerfile
+++ b/terra-jupyter-gatk-ovtf/Dockerfile
@@ -1,6 +1,6 @@
 FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.2 AS python
 
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.0.2
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.0.3
 
 # copy everything pip installed from the python image
 COPY --from=python /opt/conda/lib/python3.7/site-packages /opt/conda/lib/python3.7/site-packages

--- a/terra-jupyter-gatk/CHANGELOG.md
+++ b/terra-jupyter-gatk/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.0.6 - 2021-12-14T19:48:03.830678Z
+
+- Update `terra-jupyter-r` to `2.0.3`
+  - Update Terra Jupyter image to use latest Bioconductor 3.14
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.0.6`
+
 ## 2.0.5 - 2021-12-15T18:29:12.526374Z
 
 - Upgrade gatk image to 4.2.4.0

--- a/terra-jupyter-gatk/Dockerfile
+++ b/terra-jupyter-gatk/Dockerfile
@@ -1,6 +1,6 @@
 FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.2 AS python
 
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.0.2
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.0.3
 
 # copy everything pip installed from the python image
 COPY --from=python /opt/conda/lib/python3.7/site-packages /opt/conda/lib/python3.7/site-packages

--- a/terra-jupyter-r/CHANGELOG.md
+++ b/terra-jupyter-r/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.0.3 - 2021-12-14T19:48:03.777851Z
+
+- Update Terra Jupyter image to use latest Bioconductor 3.14
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.0.3`
+
 ## 2.0.2 - 2021-10-07T14:47:43.422197Z
 
 - Update `terra-jupyter-base` to `1.0.2`

--- a/terra-jupyter-r/Dockerfile
+++ b/terra-jupyter-r/Dockerfile
@@ -5,7 +5,7 @@ COPY scripts $JUPYTER_HOME/scripts
 
 # Add env vars to identify binary package installation
 ENV TERRA_R_PLATFORM="terra-jupyter-r"
-ENV TERRA_R_PLATFORM_BINARY_VERSION=3.13.0
+ENV TERRA_R_PLATFORM_BINARY_VERSION=3.14.0
 
 # Install protobuf 3.18. Note this version comes from base deep learning image. Use `conda list` to see what's installed
 RUN cd /tmp \
@@ -121,7 +121,7 @@ RUN pip3 -V \
 
 RUN R -e 'install.packages("BiocManager")' \
     ## check version
-    && R -e 'BiocManager::install(version="3.13", ask=FALSE)' \
+    && R -e 'BiocManager::install(version="3.14", ask=FALSE)' \
     && R -e 'BiocManager::install(c( \
     "boot", \
     "class", \

--- a/terra-jupyter-r/README.md
+++ b/terra-jupyter-r/README.md
@@ -8,7 +8,7 @@ The terra-jupyter-r extends the [terra-jupyter-base](../terra-jupyter-base/READM
 
 - R 4.1.0
 
-- CRAN and Bioc 3.13 package system dependencies
+- CRAN and Bioc 3.14 package system dependencies
 
 To see the complete contents of this image please see the [Dockerfile](./Dockerfile).
 


### PR DESCRIPTION
Update Terra Jupyter image to use latest Bioconductor 3.14.

https://broadworkbench.atlassian.net/browse/IA-3143