### PR TITLE
Add Intel classical ML optimization install and tests to terra-jupyter-python Docker image

### DIFF
--- a/terra-jupyter-python/Dockerfile
+++ b/terra-jupyter-python/Dockerfile
@@ -91,8 +91,6 @@ RUN pip3 -V \
  && sed -i 's/pd.tslib.Timestamp/pd.Timestamp/g' /opt/conda/lib/python3.7/site-packages/ggplot/stats/smoothers.py \
  && sed -i 's/pd.tslib.Timestamp/pd.Timestamp/g' /opt/conda/lib/python3.7/site-packages/ggplot/utils.py
 
-#Install intel optimizations, which are available by default on the Anaconda defaults channel, update numpy/scipy if possible with onemkl optimizations
-RUN conda install numpy scipy numba modin --force-reinstall
 
 ENV USER jupyter
 USER $USER

--- a/terra-jupyter-python/Dockerfile
+++ b/terra-jupyter-python/Dockerfile
@@ -74,6 +74,10 @@ RUN pip3 -V \
    wheel \
    plotnine \
    google-resumable-media \
+   #adding intel optimized xgboost and intel extension for scikit-learn
+   scikit-learn-intelex \
+   xgboost \
+
  # Remove this after https://broadworkbench.atlassian.net/browse/CA-1179
  # As of release [google-cloud-bigquery 1.26.0 (2020-07-20)](https://github.com/googleapis/python-bigquery/blob/master/CHANGELOG.md#1260-2020-07-20)
  # the BigQuery Python client uses the BigQuery Storage client by default.
@@ -86,6 +90,9 @@ RUN pip3 -V \
  && sed -i 's/pandas.tslib.Timestamp/pandas.Timestamp/g' /opt/conda/lib/python3.7/site-packages/ggplot/stats/smoothers.py \
  && sed -i 's/pd.tslib.Timestamp/pd.Timestamp/g' /opt/conda/lib/python3.7/site-packages/ggplot/stats/smoothers.py \
  && sed -i 's/pd.tslib.Timestamp/pd.Timestamp/g' /opt/conda/lib/python3.7/site-packages/ggplot/utils.py
+
+#Install intel optimizations, which are available by default on the Anaconda defaults channel, update numpy/scipy if possible with onemkl optimizations
+RUN conda install numpy scipy numba modin --force-reinstall
 
 ENV USER jupyter
 USER $USER

--- a/terra-jupyter-python/tests/smoke_test.ipynb
+++ b/terra-jupyter-python/tests/smoke_test.ipynb
@@ -495,30 +495,7 @@
     "### Validate Intel® Distribution of Modin Optimizations"
    ]
   },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "tags": []
-   },
-   "source": [
-    "Let's test that [Intel® Distribution of Modin](https://www.intel.com/content/www/us/en/developer/tools/oneapi/distribution-of-modin) is installed properly by successfully running the following cell. If it is not, the following cell will fail."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#importing as mpd to not interfere with other Pandas test, but encouraged to be imported as \"pd\"\n",
-    "import modin.pandas as mpd \n",
-    "\n",
-    "d = {'col1': [1, 2], 'col2': [3, 4]}\n",
-    "df = mpd.DataFrame(data=d)\n",
-    "df"
-   ]
-  },
-  {
+    {
    "cell_type": "markdown",
    "metadata": {
     "tags": []

--- a/terra-jupyter-python/tests/smoke_test.ipynb
+++ b/terra-jupyter-python/tests/smoke_test.ipynb
@@ -486,16 +486,7 @@
     "probability_model(x_test[:5])"
    ]
   },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "tags": []
-   },
-   "source": [
-    "### Validate Intel® Distribution of Modin Optimizations"
-   ]
-  },
-    {
+      {
    "cell_type": "markdown",
    "metadata": {
     "tags": []

--- a/terra-jupyter-python/tests/smoke_test.ipynb
+++ b/terra-jupyter-python/tests/smoke_test.ipynb
@@ -485,6 +485,179 @@
    "source": [
     "probability_model(x_test[:5])"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Validate Intel® Distribution of Modin Optimizations"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "Let's test that [Intel® Distribution of Modin](https://www.intel.com/content/www/us/en/developer/tools/oneapi/distribution-of-modin) is installed properly by successfully running the following cell. If it is not, the following cell will fail."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#importing as mpd to not interfere with other Pandas test, but encouraged to be imported as \"pd\"\n",
+    "import modin.pandas as mpd \n",
+    "\n",
+    "d = {'col1': [1, 2], 'col2': [3, 4]}\n",
+    "df = mpd.DataFrame(data=d)\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Validate Intel® Extension for Scikit-Learn Optimization"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's test that [Intel® Extension for Scikit-Learn](https://www.intel.com/content/www/us/en/developer/articles/guide/intel-extension-for-scikit-learn-getting-started.html) is installed properly by successfully running the following cell. If it is on, a warning should print saying that Intel® Extension for Scikit-Learn has been enabled."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearnex import patch_sklearn, unpatch_sklearn\n",
+    "patch_sklearn()\n",
+    "from sklearn import datasets, svm, metrics, preprocessing\n",
+    "from sklearn.model_selection import train_test_split\n",
+    "#should print warning"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now let's just run some regular scikit-learn code with the optimization enabled to ensure everything is working properly with Intel® Extension for Scikit-Learn enabled."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "digits = datasets.load_digits()\n",
+    "X,Y = digits.data, digits.target\n",
+    "\n",
+    "# Split dataset into 80% train images and 20% test images\n",
+    "X_train, X_test, Y_train, Y_test = train_test_split(X, Y, test_size=0.2, shuffle=True)\n",
+    "# normalize the input values by scaling each feature by its maximum absolute value\n",
+    "X_train = preprocessing.maxabs_scale(X_train)\n",
+    "X_test = preprocessing.maxabs_scale(X_test)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a classifier: a support vector classifier\n",
+    "model = svm.SVC(gamma=0.001, C=100)\n",
+    "# Learn the digits on the train subset\n",
+    "model.fit(X_train, Y_train)\n",
+    "# Now predicting the digit for test images using the trained model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Y_pred = model.predict(X_test)\n",
+    "\n",
+    "result = model.score(X_test, Y_test)\n",
+    "\n",
+    "print(f\"Model accuracy on test data: {result}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Then turn off the Intel Extension for Scikit-Learn optimizations through the unpatch method."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "unpatch_sklearn() # then unpatch optimizations"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Validate Intel XGBoost Optimizations"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Starting with [XGBoost](https://xgboost.readthedocs.io/en/latest/index.html) 0.81 version onward, Intel has been directly upstreaming many training optimizations to provide superior performance on Intel® CPUs. \n",
+    "\n",
+    "Starting with XGBoost 1.3 version onward, Intel has been upstreaming inference optimizations to provide even more performance on Intel® CPUs. \n",
+    "\n",
+    "This well-known, machine-learning package for gradient-boosted decision trees now includes seamless, drop-in acceleration for Intel® architectures to significantly speed up model training and improve accuracy for better predictions. \n",
+    "\n",
+    "We will use the following cell to validate the XGBoost version to determine if these optimizations are enabled."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import xgboost as xgb\n",
+    "import os\n",
+    "\n",
+    "major_version = int(xgb.__version__.split(\".\")[0])\n",
+    "minor_version = int(xgb.__version__.split(\".\")[1])\n",
+    "\n",
+    "print(\"XGBoost version installed: \", xgb.__version__)\n",
+    "if major_version >= 0:\n",
+    "    if major_version == 0:\n",
+    "        if minor_version >= 81:\n",
+    "                print(\"Intel optimizations for XGBoost training enabled in hist method!\")\n",
+    "    if major_version >= 1:\n",
+    "        print(\"Intel optimizations for XGBoost training enabled in hist method!\")\n",
+    "        if minor_version >= 3:\n",
+    "            print(\"Intel optimizations for XGBoost inference enabled!\")\n",
+    "    else:\n",
+    "        print(\"Intel XGBoost optimizations are disabled! Please install or update XGBoost version to 0.81+ to enable Intel's optimizations that have been upstreamed to the main XGBoost project.\")"
+   ]
   }
  ],
  "metadata": {
@@ -494,9 +667,9 @@
    "uri": "gcr.io/deeplearning-platform-release/r-cpu.3-6:m56"
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3.7 (Intel® oneAPI)",
    "language": "python",
-   "name": "python3"
+   "name": "c009-intel_distribution_of_python_3_oneapi-beta05-python"
   },
   "language_info": {
    "codemirror_mode": {
@@ -508,7 +681,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.10"
+   "version": "3.7.11"
   },
   "toc": {
    "base_numbering": 1,

--- a/terra-jupyter-python/tests/smoke_test.ipynb
+++ b/terra-jupyter-python/tests/smoke_test.ipynb
@@ -479,40 +479,40 @@
    ]
   },
   {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      ">Please redirect standard outputs and errors to stdout.txt and stderr.txt files by starting jupyter notebook with below command.\n",
-      "```\n",
-      "jupyter notebook --ip=0.0.0.0 > stdout.txt 2>stderr.txt\n",
-      "```"
-     ]
-    },
-  {
-       "cell_type": "markdown",
-       "metadata": {},
-       "source": [
-        ">The oneAPI Deep Neural Network Library (oneDNN) optimizations are also now available in the official x86-64 TensorFlow after v2.5. Users can enable those CPU optimizations by setting the the environment variable TF_ENABLE_ONEDNN_OPTS=1 for the official x86-64 TensorFlow after v2.5."
-       ]
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    ">Please redirect standard outputs and errors to stdout.txt and stderr.txt files by starting jupyter notebook with below command.\n",
+    "```\n",
+    "jupyter notebook --ip=0.0.0.0 > stdout.txt 2>stderr.txt\n",
+    "```"
+   ]
   },
   {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      ">We enable oneDNN Verbose log to validate the existenance of oneDNN optimization via DNNL_VERBSOE environemnt variable, and also set CUDA_VISIBLE_DEVCIES to -1 to run the workload on CPU."
-     ]
-   },
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    ">The oneAPI Deep Neural Network Library (oneDNN) optimizations are also now available in the official x86-64 TensorFlow after v2.5. Users can enable those CPU optimizations by setting the the environment variable TF_ENABLE_ONEDNN_OPTS=1 for the official x86-64 TensorFlow after v2.5."
+   ]
+  },
   {
-     "cell_type": "code",
-     "execution_count": null,
-     "metadata": {},
-     "outputs": [],
-     "source": [
-      "import os\n",
-      "os.environ['TF_ENABLE_ONEDNN_OPTS'] = '1'\n",
-      "os.environ['DNNL_VERBOSE'] = '1'\n",
-      "os.environ['CUDA_VISIBLE_DEVICES']=\"-1\""
-     ]
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    ">We enable oneDNN Verbose log to validate the existenance of oneDNN optimization via DNNL_VERBSOE environemnt variable, and also set CUDA_VISIBLE_DEVCIES to -1 to run the workload on CPU."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "os.environ['TF_ENABLE_ONEDNN_OPTS'] = '1'\n",
+    "os.environ['DNNL_VERBOSE'] = '1'\n",
+    "os.environ['CUDA_VISIBLE_DEVICES']=\"-1\""
+   ]
   },
   {
    "cell_type": "code",
@@ -640,79 +640,71 @@
    ]
   },
   {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "### Validate usage of oneDNN optimization \n",
-      "First, we could check whether we have dnnl verose log or not while we test TensorFlow in the previous section."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "execution_count": null,
-     "metadata": {},
-     "outputs": [],
-     "source": [
-      "!cat /tmp/stdout.txt | grep dnnl"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Second, we could further analyze what oneDNN primitives are used while we run the workload by using a profile_utils.py script."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "execution_count": null,
-     "metadata": {},
-     "outputs": [],
-     "source": [
-      "!wget https://raw.githubusercontent.com/oneapi-src/oneAPI-samples/master/Libraries/oneDNN/tutorials/profiling/profile_utils.py"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "execution_count": null,
-     "metadata": {},
-     "outputs": [],
-     "source": [
-      "import warnings\n",
-      "warnings.filterwarnings('ignore')"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Finally, users should be able to see that inner_product oneDNN primitive is used for the workload."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "execution_count": null,
-     "metadata": {},
-     "outputs": [],
-     "source": [
-      "run profile_utils.py /tmp/stdout.txt"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "execution_count": null,
-     "metadata": {},
-     "outputs": [],
-     "source": []
-    },
-    <<<<<<< HEAD
-      {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Validate usage of oneDNN optimization \n",
+    "First, we could check whether we have dnnl verose log or not while we test TensorFlow in the previous section."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!cat /tmp/stdout.txt | grep dnnl"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Second, we could further analyze what oneDNN primitives are used while we run the workload by using a profile_utils.py script."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!wget https://raw.githubusercontent.com/oneapi-src/oneAPI-samples/master/Libraries/oneDNN/tutorials/profiling/profile_utils.py"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import warnings\n",
+    "warnings.filterwarnings('ignore')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally, users should be able to see that inner_product oneDNN primitive is used for the workload."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "run profile_utils.py /tmp/stdout.txt"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {
     "tags": []
    },
    "source": [
-    "### Validate Intel® Extension for Scikit-Learn Optimization"
+    "### Validate IntelÂ® Extension for Scikit-Learn Optimization"
    ]
   },
   {
@@ -847,7 +839,6 @@
     "        print(\"Intel XGBoost optimizations are disabled! Please install or update XGBoost version to 0.81+ to enable Intel's optimizations that have been upstreamed to the main XGBoost project.\")"
    ]
   }
->>>>>>> ab6080f45e26dd3693931e151595190b1b382c09
  ],
  "metadata": {
   "environment": {
@@ -870,11 +861,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-<<<<<<< HEAD
-   "version": "3.7.11"
-=======
-   "version": "3.7.8"
->>>>>>> ab6080f45e26dd3693931e151595190b1b382c09
+   "version": "3.9.7"
   },
   "toc": {
    "base_numbering": 1,


### PR DESCRIPTION
Added the following Intel classical ML Python optimizations and  installs to existing terra-jupyter-python Docker image:

- Intel Distribution of Modin
- Intel Extension for Scikit-Learn
- Intel optimizations for XGBoost
- Intel optimized NumPy, SciPy, and Numba (message me for details)

Added validation tests to smoke_test.ipynb for the following:
- Intel Distribution of Modin
- Intel Extension for Scikit-Learn
- Intel optimizations for XGBoost