### PR TITLE
Update to OVTF1.1.0, GATK4.2.4.1, TF2.7.0

### DIFF
--- a/config/conf.json
+++ b/config/conf.json
@@ -163,7 +163,7 @@
             "packages" : {
                 
             },
-            "version" : "0.1.6",
+            "version" : "0.1.7",
             "automated_flags" : {
                 "include_in_ui" : false,
                 "generate_docs" : true,

--- a/terra-jupyter-gatk-ovtf/CHANGELOG.md
+++ b/terra-jupyter-gatk-ovtf/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.1.7 - 2022-01-26T17:05:04.719540Z
+
+- OVTF1.1.0 released, Updated to GATK 4.2.4.1, TF2.7, GPU support enabled
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk-ovtf:0.1.7`
+
 ## 0.1.6 - 2022-01-06T18:21:41.248206Z
 
 - Update `terra-jupyter-base` to `1.0.3`

--- a/terra-jupyter-gatk-ovtf/Dockerfile
+++ b/terra-jupyter-gatk-ovtf/Dockerfile
@@ -53,10 +53,15 @@ RUN conda install six typing_extensions --force-reinstall \
 ENV PIP_USER=true
 
 COPY gatk-ovtf.patch /etc/gatk-$GATK_VERSION/gatk-ovtf.patch
+COPY ovtf-cuda-disabling.patch /etc/gatk-$GATK_VERSION/ovtf-cuda-disabling.patch
 
 # Apply patch to GATK to fix TFv2 compatibility. 
 RUN cd /opt/conda/lib/python3.7/site-packages/vqsr_cnn/vqsr_cnn/ \
     && patch -p1 < /etc/gatk-$GATK_VERSION/gatk-ovtf.patch
+
+# Apply patch to GATK to fix TFv2 compatibility. 
+RUN cd /opt/conda/lib/python3.7/site-packages/openvino_tensorflow/ \
+    && patch __init__.py < /etc/gatk-$GATK_VERSION/ovtf-cuda-disabling.patch
 
 COPY --chown=jupyter:users run_gatk.sh /home/jupyter/run_gatk.sh
 COPY --chown=jupyter:users GATK-OVTF-Notebook.ipynb /home/jupyter/GATK-OVTF-Notebook.ipynb

--- a/terra-jupyter-gatk-ovtf/Dockerfile
+++ b/terra-jupyter-gatk-ovtf/Dockerfile
@@ -29,25 +29,32 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
   && rm -rf /var/lib/apt/lists/* 
 
 # Install GATK
-ENV GATK_VERSION 4.2.0.0
+ENV GATK_VERSION 4.2.3.0
 ENV GATK_ZIP_PATH /tmp/gatk-${GATK_VERSION}.zip
 
 RUN curl -L -o $GATK_ZIP_PATH https://github.com/broadinstitute/gatk/releases/download/$GATK_VERSION/gatk-$GATK_VERSION.zip \
  && unzip -o $GATK_ZIP_PATH -d /etc/ \
  && ln -s /etc/gatk-$GATK_VERSION/gatk /bin/gatk
 
+# Install OpenVINO™ integration with TensorFlow (OVTF)
+ENV TF_VER 2.7.0
+ENV KERAS_VER 2.7.0
+ENV OVTF_VER 1.1.0
+ENV TF_ENABLE_ONEDNN_OPTS 1
+
 ENV PIP_USER=false
 
-# Force reinstalling TF-2.5.1, Keras-2.5.0 to satisfy OVTF compatibility.
-RUN pip install --force-reinstall tensorflow==2.5.1 keras==2.5.0rc0
+# Force reinstalling TF and Keras to satisfy OVTF compatibility.
+RUN pip install --force-reinstall tensorflow==$TF_VER keras==$KERAS_VER
 RUN conda install six typing_extensions --force-reinstall \
-    && pip install openvino_tensorflow==1.0.0 \
+    && pip install openvino_tensorflow==$OVTF_VER \
     && pip install matplotlib sklearn \
     && pip install /etc/gatk-$GATK_VERSION/gatkPythonPackageArchive.zip
 ENV PIP_USER=true
 
 COPY gatk-ovtf.patch /etc/gatk-$GATK_VERSION/gatk-ovtf.patch
 
+# Apply patch to GATK to fix TFv2 compatibility. 
 RUN cd /opt/conda/lib/python3.7/site-packages/vqsr_cnn/vqsr_cnn/ \
     && patch -p1 < /etc/gatk-$GATK_VERSION/gatk-ovtf.patch
 

--- a/terra-jupyter-gatk-ovtf/Dockerfile
+++ b/terra-jupyter-gatk-ovtf/Dockerfile
@@ -59,7 +59,7 @@ COPY ovtf-cuda-disabling.patch /etc/gatk-$GATK_VERSION/ovtf-cuda-disabling.patch
 RUN cd /opt/conda/lib/python3.7/site-packages/vqsr_cnn/vqsr_cnn/ \
     && patch -p1 < /etc/gatk-$GATK_VERSION/gatk-ovtf.patch
 
-# Apply patch to GATK to fix TFv2 compatibility. 
+# Apply patch to OVTF to disable CUDA devices if OVTF is enabled. 
 RUN cd /opt/conda/lib/python3.7/site-packages/openvino_tensorflow/ \
     && patch __init__.py < /etc/gatk-$GATK_VERSION/ovtf-cuda-disabling.patch
 

--- a/terra-jupyter-gatk-ovtf/Dockerfile
+++ b/terra-jupyter-gatk-ovtf/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
   && rm -rf /var/lib/apt/lists/* 
 
 # Install GATK
-ENV GATK_VERSION 4.2.3.0
+ENV GATK_VERSION 4.2.4.0
 ENV GATK_ZIP_PATH /tmp/gatk-${GATK_VERSION}.zip
 
 RUN curl -L -o $GATK_ZIP_PATH https://github.com/broadinstitute/gatk/releases/download/$GATK_VERSION/gatk-$GATK_VERSION.zip \

--- a/terra-jupyter-gatk-ovtf/Dockerfile
+++ b/terra-jupyter-gatk-ovtf/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
   && rm -rf /var/lib/apt/lists/* 
 
 # Install GATK
-ENV GATK_VERSION 4.2.4.0
+ENV GATK_VERSION 4.2.4.1
 ENV GATK_ZIP_PATH /tmp/gatk-${GATK_VERSION}.zip
 
 RUN curl -L -o $GATK_ZIP_PATH https://github.com/broadinstitute/gatk/releases/download/$GATK_VERSION/gatk-$GATK_VERSION.zip \

--- a/terra-jupyter-gatk-ovtf/README.md
+++ b/terra-jupyter-gatk-ovtf/README.md
@@ -9,7 +9,6 @@ In Terra, this image is available in the drop-down menu under **COMMUNITY-MAINTA
 
 
 
-
 ## Image contents
 
 The `terra-jupyter-gatk-ovtf` docker image extends the [terra-jupyter-python](../terra-jupyter-python/README.md) and [terra-jupyter-r](../terra-jupyter-r/README.md) by including the following:
@@ -21,13 +20,44 @@ The `terra-jupyter-gatk-ovtf` docker image extends the [terra-jupyter-python](..
 
 To see the complete contents of this image please see the [Dockerfile](./Dockerfile).
 
-Note: Enabling OpenVINO™ integration with TensorFlow disables TensorFlow GPU support for CUDA-enabled devices in this docker image. To be able to enable TensorFlow GPU support, OpenVINO™ integration with TensorFlow should be disabled by setting the environment varible below.
-
-    export OPENVINO_TF_DISABLE=1
-
 ## Sample Notebook
 
 This repo provides a sample notebook [GATK-OVTF-Notebook.ipynb](./GATK-OVTF-Notebook.ipynb) which showcases the performance benefits obtained by using OpenVINO™ integration with TensorFlow.
+
+## Note on CUDA-enabled GPU devices Support
+
+Enabling OpenVINO™ integration with TensorFlow disables TensorFlow GPU support for CUDA-enabled devices in this docker image. 
+If you prefer to use CUDA-enabled GPU devices, DONOT import openvino_tensorflow
+
+#### Scenario #1: Use CUDA-enabled GPU devices with native Tensorflow.
+```
+import tensorflow 
+# CPU and GPU support available. openvino_tensorflow is disabled
+```
+
+#### Scenario #2: Use OpenVINO™ integration with TensorFlow
+```
+import tensorflow 
+import openvino_tensorflow as ovtf
+ovtf.set_backend("CPU")
+
+# By importing openvino_tensorflow, CUDA-enabled GPU devices support is disabled. 
+# To re-enable GPU support, restart the Jupyter kernel, and remove "import openvino_tensorflow as ovtf"
+```
+
+#### Scenario #3: GATK Developers
+In this Docker image, GATK is enabled with OpenVINO™ integration with TensorFlow by default.
+If you prefer to use GATK with with CUDA-enabled GPU devices, then OpenVINO integration with TensorFlow should be disabled before executing GATK CNNScoreVariants. To disable OpenVINO™ integration with TensorFlow, run the command below in the Jupyter notebook.
+```   
+ ! export OPENVINO_TF_DISABLE=1
+ ```
+ 
+#### Scenario #4: Use OpenVINO™ integration with TensorFlow with CUDA-enabled GPU devices
+
+Not Supported. 
+
+---------
+
 
 ## Build and Run Instructions - **Locally**
 

--- a/terra-jupyter-gatk-ovtf/README.md
+++ b/terra-jupyter-gatk-ovtf/README.md
@@ -45,12 +45,12 @@ ovtf.set_backend("CPU")
 # To re-enable GPU support, restart the Jupyter kernel, and remove "import openvino_tensorflow as ovtf"
 ```
 
-#### Scenario #3: GATK Developers
+#### Scenario #3: Use GATK with CUDA-enabled GPU devices
 In this Docker image, GATK is enabled with OpenVINO™ integration with TensorFlow by default.
 If you prefer to use GATK with CUDA-enabled GPU devices, then OpenVINO integration with TensorFlow should be disabled before executing GATK CNNScoreVariants. To disable OpenVINO™ integration with TensorFlow, run the command below in the Jupyter notebook.
 ```   
- ! export OPENVINO_TF_DISABLE=1
- ```
+! export OPENVINO_TF_DISABLE=1
+```
  
 #### Scenario #4: Use OpenVINO™ integration with TensorFlow with CUDA-enabled GPU devices
 

--- a/terra-jupyter-gatk-ovtf/README.md
+++ b/terra-jupyter-gatk-ovtf/README.md
@@ -47,7 +47,7 @@ ovtf.set_backend("CPU")
 
 #### Scenario #3: GATK Developers
 In this Docker image, GATK is enabled with OpenVINO™ integration with TensorFlow by default.
-If you prefer to use GATK with with CUDA-enabled GPU devices, then OpenVINO integration with TensorFlow should be disabled before executing GATK CNNScoreVariants. To disable OpenVINO™ integration with TensorFlow, run the command below in the Jupyter notebook.
+If you prefer to use GATK with CUDA-enabled GPU devices, then OpenVINO integration with TensorFlow should be disabled before executing GATK CNNScoreVariants. To disable OpenVINO™ integration with TensorFlow, run the command below in the Jupyter notebook.
 ```   
  ! export OPENVINO_TF_DISABLE=1
  ```

--- a/terra-jupyter-gatk-ovtf/README.md
+++ b/terra-jupyter-gatk-ovtf/README.md
@@ -30,15 +30,19 @@ Enabling OpenVINO™ integration with TensorFlow disables TensorFlow GPU support
 If you prefer to use CUDA-enabled GPU devices, DONOT import openvino_tensorflow
 
 #### Scenario #1: Use CUDA-enabled GPU devices with native Tensorflow.
+After installing CUDA drivers in the host machine, you will need to start the docker with `--gpus all` to enable GPU devices inside docker container. 
+
+Example: `docker run --gpus all --rm -it -p 8000:8000 terra-jupyter-gatk-ovtf`, Then navigate a browser to http://localhost:8000/notebooks to access the Jupyter UI. 
+
 ```
-import tensorflow 
+import tensorflow as tf
 # CPU and GPU support available. openvino_tensorflow is disabled
 tf.config.list_physical_devices()
 ```
 
 #### Scenario #2: Use OpenVINO™ integration with TensorFlow
 ```
-import tensorflow 
+import tensorflow as tf
 import openvino_tensorflow as ovtf
 ovtf.set_backend("CPU")
 

--- a/terra-jupyter-gatk-ovtf/README.md
+++ b/terra-jupyter-gatk-ovtf/README.md
@@ -33,6 +33,7 @@ If you prefer to use CUDA-enabled GPU devices, DONOT import openvino_tensorflow
 ```
 import tensorflow 
 # CPU and GPU support available. openvino_tensorflow is disabled
+tf.config.list_physical_devices()
 ```
 
 #### Scenario #2: Use OpenVINO™ integration with TensorFlow

--- a/terra-jupyter-gatk-ovtf/README.md
+++ b/terra-jupyter-gatk-ovtf/README.md
@@ -21,6 +21,10 @@ The `terra-jupyter-gatk-ovtf` docker image extends the [terra-jupyter-python](..
 
 To see the complete contents of this image please see the [Dockerfile](./Dockerfile).
 
+Note: Enabling OpenVINO™ integration with TensorFlow disables TensorFlow GPU support for CUDA-enabled devices in this docker image. To be able to enable TensorFlow GPU support, OpenVINO™ integration with TensorFlow should be disabled by setting the environment varible below.
+
+    export OPENVINO_TF_DISABLE=1
+
 ## Sample Notebook
 
 This repo provides a sample notebook [GATK-OVTF-Notebook.ipynb](./GATK-OVTF-Notebook.ipynb) which showcases the performance benefits obtained by using OpenVINO™ integration with TensorFlow.

--- a/terra-jupyter-gatk-ovtf/ovtf-cuda-disabling.patch
+++ b/terra-jupyter-gatk-ovtf/ovtf-cuda-disabling.patch
@@ -1,0 +1,12 @@
+--- /opt/conda/lib/python3.7/site-packages/openvino_tensorflow/__init__.py      2021-12-09 22:39:36.000000000 +0000
++++ __init__.py 2021-12-10 00:20:28.433852578 +0000
+@@ -30,6 +30,9 @@
+
+ import ctypes
+
++if (os.environ.get("OPENVINO_TF_DISABLE") != "1"):
++    os.environ["CUDA_VISIBLE_DEVICES"] = "-1"
++
+ __all__ = [
+     'enable', 'disable', 'is_enabled', 'list_backends',
+     'set_backend', 'get_backend',


### PR DESCRIPTION
Hi @Qi77Qi, @rtitle 
OVTF1.1.0 is released, we updated the dockerfile.
- Along with the OVTF update, we updated with GATK-4.2.4.1, TF-2.7.0.
- GPU support is enabled. We added notes on GPU support in the README.
- The end-user options are either:  `OVTF with CPUs` or `Native TF with CPUs/GPUs`

CC: @cavusmustafa 