### PR TITLE
Switch AoU to latest gatk base

### DIFF
--- a/config/conf.json
+++ b/config/conf.json
@@ -143,7 +143,7 @@
             "packages" : {
 
             },
-            "version" : "2.0.5",
+            "version" : "2.0.6",
             "automated_flags" : {
                 "include_in_ui" : false,
                 "generate_docs" : false,

--- a/terra-jupyter-aou/CHANGELOG.md
+++ b/terra-jupyter-aou/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.0.6 - 2021-12-13
+
+- Update `terra-jupyter-gatk` base image to `2.0.4`
+  - Update AsyncMappingKernelManager https://github.com/jupyter/notebook/issues/6164
+
 ## 2.0.5 - 2021-12-02T21:50:37.297833
 
 - Fix nextflow install path.
@@ -12,8 +17,6 @@ Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:2.0.4`
 
 ## 2.0.3 - 2021-10-07T14:47:43.445699Z
 
-- Update `terra-jupyter-base` to `1.0.2`
-  - Update AsyncMappingKernelManager https://github.com/jupyter/notebook/issues/6164
 - Unpinning cwltool version and updating protobuf version to 3.18
 
 Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:2.0.3`

--- a/terra-jupyter-aou/Dockerfile
+++ b/terra-jupyter-aou/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.0.3
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.0.4
 
 USER root
 


### PR DESCRIPTION
The intended change with https://github.com/DataBiosphere/terra-docker/pull/263/files#diff-df40bbb7ec38ec9c9fcdba2e7f8375b32309e761e675b54d5182f63b023b23b0R1 was to bump to 2.0.4. This was an easy error since aou and gatk were confusingly close in version numbers.