### PR TITLE
Add pip install tests to terra-jupyter-python.

### DIFF
--- a/.github/workflows/test-terra-jupyter-python.yml
+++ b/.github/workflows/test-terra-jupyter-python.yml
@@ -52,12 +52,16 @@ jobs:
     - name: Free up some disk space
       run: sudo rm -rf /usr/share/dotnet    
 
+    - id: auth
+      uses: google-github-actions/auth@v0
+      with:
+        credentials_json: ${{ secrets.GCP_SA_KEY }}
+        create_credentials_file: true
+
     - name: Set up Cloud SDK
-      uses: google-github-actions/setup-gcloud@master
+      uses: google-github-actions/setup-gcloud@v0.3.0
       with:
         project_id: ${{ secrets.GCP_PROJECT_ID }}
-        service_account_key: ${{ secrets.GCP_SA_KEY }}
-        export_default_credentials: true
 
     - name: Build Docker image and base images too, if needed
       run: |
@@ -71,9 +75,10 @@ jobs:
       # workflow for notebooks is needed in the future.
       run: |
         chmod a+w $GITHUB_WORKSPACE/terra-jupyter-python/tests
+        chmod a+r "${{ steps.auth.outputs.credentials_file_path }}"
         docker run \
           --env GOOGLE_PROJECT \
-          --volume "${{ env.GOOGLE_APPLICATION_CREDENTIALS }}:/tmp/credentials.json:ro" \
+          --volume "${{ steps.auth.outputs.credentials_file_path }}":/tmp/credentials.json:ro \
           --env GOOGLE_APPLICATION_CREDENTIALS="/tmp/credentials.json" \
           --volume $GITHUB_WORKSPACE/terra-jupyter-python/tests:/tests \
           --workdir=/tests \
@@ -90,9 +95,10 @@ jobs:
 
     - name: Test Python code with pytest
       run: |
+        chmod a+r "${{ steps.auth.outputs.credentials_file_path }}"
         docker run \
           --env GOOGLE_PROJECT \
-          --volume "${{ env.GOOGLE_APPLICATION_CREDENTIALS }}:/tmp/credentials.json:ro" \
+          --volume "${{ steps.auth.outputs.credentials_file_path }}":/tmp/credentials.json:ro \
           --env GOOGLE_APPLICATION_CREDENTIALS="/tmp/credentials.json" \
           --volume $GITHUB_WORKSPACE/terra-jupyter-python/tests:/tests \
           --workdir=/tests \
@@ -106,9 +112,10 @@ jobs:
       # artifacts to understand if there are more failures than just the one that caused this task to halt.
       run: |
         chmod a+w $GITHUB_WORKSPACE/terra-jupyter-python
+        chmod a+r "${{ steps.auth.outputs.credentials_file_path }}"
         docker run \
           --env GOOGLE_PROJECT \
-          --volume "${{ env.GOOGLE_APPLICATION_CREDENTIALS }}:/tmp/credentials.json:ro" \
+          --volume "${{ steps.auth.outputs.credentials_file_path }}":/tmp/credentials.json:ro \
           --env GOOGLE_APPLICATION_CREDENTIALS="/tmp/credentials.json" \
           --volume $GITHUB_WORKSPACE/terra-jupyter-python/tests:/tests \
           --workdir=/tests \

--- a/.github/workflows/test-terra-jupyter-python.yml
+++ b/.github/workflows/test-terra-jupyter-python.yml
@@ -114,7 +114,9 @@ jobs:
           --workdir=/tests \
           --entrypoint="" \
           terra-jupyter-python:smoke-test \
-          /bin/sh -c "pip3 install --user pytest; pytest"
+          /bin/sh -c "pip3 install --no-deps pytest iniconfig pluggy py; pytest"
+          # Use --no-deps to avoid an unneccessary upgrade of pyparsing which then causes tensorflow tests to fail.
+          # TODO: whenever we no longer need to pin pyparsing, simplify the above command to 'pip3 install pytest ; pytest'
 
     - name: Test Python code specific to notebooks with nbconvert
       # Simply 'Cell -> Run All` these notebooks and expect no errors in the case of a successful run of the test suite.

--- a/.github/workflows/test-terra-jupyter-python.yml
+++ b/.github/workflows/test-terra-jupyter-python.yml
@@ -114,7 +114,7 @@ jobs:
           --workdir=/tests \
           --entrypoint="" \
           terra-jupyter-python:smoke-test \
-          /bin/sh -c "pip3 install pytest; pytest"
+          /bin/sh -c "pip3 install --user pytest; pytest"
 
     - name: Test Python code specific to notebooks with nbconvert
       # Simply 'Cell -> Run All` these notebooks and expect no errors in the case of a successful run of the test suite.

--- a/.github/workflows/test-terra-jupyter-python.yml
+++ b/.github/workflows/test-terra-jupyter-python.yml
@@ -34,6 +34,10 @@ on:
 
 env:
   GOOGLE_PROJECT: ${{ secrets.GCP_PROJECT_ID }}
+  # Set the environment variables that are normally passed at runtime. https://github.com/DataBiosphere/leonardo/search?q=PIP_TARGET
+  PIP_USER: "false"
+  PIP_TARGET: "/home/jupyter/notebooks/packages"
+  R_LIBS: "/home/jupyter/notebooks/packages"
 
 jobs:
 
@@ -78,6 +82,9 @@ jobs:
         chmod a+r "${{ steps.auth.outputs.credentials_file_path }}"
         docker run \
           --env GOOGLE_PROJECT \
+          --env PIP_USER \
+          --env PIP_TARGET \
+          --env R_LIBS \
           --volume "${{ steps.auth.outputs.credentials_file_path }}":/tmp/credentials.json:ro \
           --env GOOGLE_APPLICATION_CREDENTIALS="/tmp/credentials.json" \
           --volume $GITHUB_WORKSPACE/terra-jupyter-python/tests:/tests \
@@ -98,6 +105,9 @@ jobs:
         chmod a+r "${{ steps.auth.outputs.credentials_file_path }}"
         docker run \
           --env GOOGLE_PROJECT \
+          --env PIP_USER \
+          --env PIP_TARGET \
+          --env R_LIBS \
           --volume "${{ steps.auth.outputs.credentials_file_path }}":/tmp/credentials.json:ro \
           --env GOOGLE_APPLICATION_CREDENTIALS="/tmp/credentials.json" \
           --volume $GITHUB_WORKSPACE/terra-jupyter-python/tests:/tests \
@@ -115,6 +125,9 @@ jobs:
         chmod a+r "${{ steps.auth.outputs.credentials_file_path }}"
         docker run \
           --env GOOGLE_PROJECT \
+          --env PIP_USER \
+          --env PIP_TARGET \
+          --env R_LIBS \
           --volume "${{ steps.auth.outputs.credentials_file_path }}":/tmp/credentials.json:ro \
           --env GOOGLE_APPLICATION_CREDENTIALS="/tmp/credentials.json" \
           --volume $GITHUB_WORKSPACE/terra-jupyter-python/tests:/tests \

--- a/terra-jupyter-base/Dockerfile
+++ b/terra-jupyter-base/Dockerfile
@@ -1,6 +1,8 @@
 # adapted from https://hub.docker.com/r/jupyter/base-notebook/ AKA https://github.com/jupyter/docker-stacks/tree/master/base-notebook
 
-FROM gcr.io/deeplearning-platform-release/tf2-gpu.2-6 
+FROM gcr.io/deeplearning-platform-release/tf2-gpu.2-6
+# TODO When upgrading to a newer version of Tensorflow, be sure to remove the
+# package version pin on Keras in file terra-jupyter-python/Dockerfile.
 USER root
 
 #######################

--- a/terra-jupyter-python/Dockerfile
+++ b/terra-jupyter-python/Dockerfile
@@ -51,7 +51,8 @@ RUN pip3 -V \
    h5py \
    html5lib \
    joblib \
-   keras \
+   # Remove the version pin for keras when tensorflow is updated to 2.7 or higher.
+   keras==2.6.0 \
    patsy \
    pymc3 \
    # fix to 2.4.7 so that tensorflow still works

--- a/terra-jupyter-python/tests/smoke_test.ipynb
+++ b/terra-jupyter-python/tests/smoke_test.ipynb
@@ -40,6 +40,108 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Test package installations"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Install a package we do not anticipate already being installed on the base image"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip3 show rich  # Should show not installed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip3 install rich"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip3 show rich  # Should show that it is now installed!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import rich"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Install a package **from source** that we do not anticipate already being installed on the base image"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!env | grep PIP"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip3 show docstring-parser  # Should show not installed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip3 install docstring-parser==0.13"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip3 show docstring-parser  # Should show that it is now installed!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from docstring_parser import parse"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Test ipython widgets"
    ]
   },
@@ -349,7 +451,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -508,7 +610,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.10"
+   "version": "3.7.8"
   },
   "toc": {
    "base_numbering": 1,

--- a/terra-jupyter-python/tests/smoke_test.ipynb
+++ b/terra-jupyter-python/tests/smoke_test.ipynb
@@ -40,7 +40,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Test package installations"
+    "## Test package installations\n",
+    "\n",
+    "NOTE: installing packages via `%pip` installs them into the running kernel - no kernel restart needed."
    ]
   },
   {
@@ -65,7 +67,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip3 install rich"
+    "%pip install rich"
    ]
   },
   {
@@ -117,7 +119,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip3 install docstring-parser==0.13"
+    "%pip3 install docstring-parser==0.13"
    ]
   },
   {

--- a/terra-jupyter-python/tests/smoke_test.ipynb
+++ b/terra-jupyter-python/tests/smoke_test.ipynb
@@ -85,7 +85,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import rich"
+    "from rich import print"
    ]
   },
   {
@@ -119,7 +119,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip3 install docstring-parser==0.13"
+    "%pip install docstring-parser==0.13"
    ]
   },
   {

--- a/terra-jupyter-python/tests/smoke_test.ipynb
+++ b/terra-jupyter-python/tests/smoke_test.ipynb
@@ -46,6 +46,34 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pkg_resources\n",
+    "import sys"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sys.path"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!env | grep PIP"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -67,7 +95,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install rich"
+    "%pip install rich==10.16.1"
    ]
   },
   {
@@ -85,7 +113,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from rich import print"
+    "pkg_resources.get_distribution(\"rich\").version"
    ]
   },
   {
@@ -93,15 +121,6 @@
    "metadata": {},
    "source": [
     "### Install a package **from source** that we do not anticipate already being installed on the base image"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!env | grep PIP"
    ]
   },
   {
@@ -137,7 +156,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from docstring_parser import parse"
+    "# TODO uncomment this test after https://github.com/DataBiosphere/terra-docker/issues/285\n",
+    "# is fixed.\n",
+    "#pkg_resources.get_distribution(\"docstring_parser\").version"
    ]
   },
   {

--- a/terra-jupyter-python/tests/smoke_test.ipynb
+++ b/terra-jupyter-python/tests/smoke_test.ipynb
@@ -51,7 +51,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import pkg_resources\n",
     "import sys"
    ]
   },
@@ -86,7 +85,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip3 show rich  # Should show not installed."
+    "output = !pip3 show rich\n",
+    "print(output)  # Should show not yet installed.\n",
+    "assert(0 == output.count('Name: rich'))"
    ]
   },
   {
@@ -104,16 +105,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip3 show rich  # Should show that it is now installed!"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "pkg_resources.get_distribution(\"rich\").version"
+    "output = !pip3 show rich\n",
+    "print(output)  # Should show that it is now installed!\n",
+    "assert(1 == output.count('Name: rich'))"
    ]
   },
   {
@@ -129,7 +123,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip3 show docstring-parser  # Should show not installed."
+    "output = !pip3 show docstring-parser\n",
+    "print(output)  # Should show not yet installed.\n",
+    "assert(0 == output.count('Name: docstring-parser'))"
    ]
   },
   {
@@ -147,18 +143,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip3 show docstring-parser  # Should show that it is now installed!"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "output = !pip3 show docstring-parser\n",
+    "print(output)  # Should show that it is now installed!\n",
     "# TODO uncomment this test after https://github.com/DataBiosphere/terra-docker/issues/285\n",
     "# is fixed.\n",
-    "#pkg_resources.get_distribution(\"docstring_parser\").version"
+    "#assert(1 == output.count('Name: docstring-parser'))"
    ]
   },
   {


### PR DESCRIPTION
Added new tests to demonstrate:
1) that new Python packages can be installed via pip <-- works
2) that new Python packages **_compiled from source_** can be installed via pip <--- won't work till after https://github.com/DataBiosphere/terra-docker/issues/285 is fixed, the final assertion is commented out for now

Also fixes some test breakage:
* address tensorflow 2.6 test failures by
    * pinning the package version of Keras
    * ensuring that the installation of pytest does not upgrade pyparsing
* fix test auth failures by updating to the latest gcloud github actions