### PR TITLE
[IA-3156] legacy image changes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,10 @@ This is also a good opportunity to verify that all the appropriate image version
 
 You can also run `amm ./updateVersions.sc <image name> <release note>` to upgrade derived images. If you're updating `terra-jupyter-aou` image, please make a pull request similar to [this PR](https://github.com/DataBiosphere/leonardo/pull/1612) (less updating `terra_jupyter_aou_old`).
 
+## Legacy Image Versioning
+
+We have two legacy images - `terra-jupyter-gatk_legacy` and `terra-jupyter-bioconductor_legacy`. The version of these legacy images is the version prior to a major or minor version bump. For example, if `terra-jupyter-gatk` is at version `2.1.3` and we release either `3.0.0` (major version bump) or `2.2.0` (minor version bump) then the `terra-jupyter-gatk_legacy` would be `2.1.3`.
+
 ## External Contributions
 
 If you are from outside the Broad, don't worry about adding a JIRA issue number to PRs. More to come on external contributions.

--- a/config/legacy_static_images.json
+++ b/config/legacy_static_images.json
@@ -1,20 +1,11 @@
 [
   {
-    "updated": "2021-05-05", 
-    "image": "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:1.0.14", 
-    "label": "Legacy R / Bioconductor (R 4.0.5, Bioconductor 3.12, Python 3.8.5)", 
-    "version": "1.0.14", 
-    "requiresSpark": false, 
-    "packages": "https://storage.googleapis.com/terra-docker-image-documentation/terra-jupyter-bioconductor-1.0.14-versions.json", 
+    "updated": "2021-10-07",
+    "image": "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:2.0.2",
+    "label": "Legacy R / Bioconductor (R 4.1.1, Bioconductor 3.13, Python 3.7.10)",
+    "version": "2.0.2",
+    "requiresSpark": false,
+    "packages": "https://storage.googleapis.com/terra-docker-image-documentation/terra-jupyter-bioconductor-2.0.2-versions.json",
     "id": "terra-jupyter-bioconductor_legacy"
-  },
-  {
-    "updated": "2020-06-29", 
-    "image": "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:1.1.3", 
-    "label": "Legacy GATK (GATK 4.1.4.1, Python 3.7.8, R 4.0.2)", 
-    "version": "1.1.3", 
-    "requiresSpark": false, 
-    "packages": "https://storage.googleapis.com/terra-docker-image-documentation/terra-jupyter-gatk-1.1.3-versions.json", 
-    "id": "terra-jupyter-gatk_legacy"
   }
 ]

--- a/scripts/generate_version_docs.py
+++ b/scripts/generate_version_docs.py
@@ -29,15 +29,16 @@ def generate_docs():
 
   print "current versions detected: " + str(remote_versions)
 
-  legacy_gatk_doc = {}
-  legacy_bioconductor_doc = {}
+  legacy_gatk_doc = filter(lambda remote_doc: remote_doc["id"] == "terra-jupyter-gatk_legacy", remote_docs)[0]
+  legacy_bioconductor_doc = utils.read_json_file(static_config_location)[0] # hard coding this until next bioconductor release (~06/2022)
 
   for image_config in image_configs:
-      # Here we check first if the remote documentation exists, then if the local version is the same as the remote. 
+      # Here we check first if the remote documentation exists, then if the local version is the same as the remote.
       # If the remote documentation exists and the version matches the local, we re-use the old documentation
 
+      remote_doc = list(filter(lambda image_doc: image_doc["id"] == image_config["name"], remote_docs))[0]
       if image_config["name"] in remote_versions and image_config["version"] == remote_versions[image_config["name"]]:
-        remote_doc = list(filter(lambda image_doc: image_doc["id"] == image_config["name"], remote_docs))[0]
+        #remote_doc = list(filter(lambda image_doc: image_doc["id"] == image_config["name"], remote_docs))[0]
         print "using remote doc: {}".format(remote_doc)
         doc = remote_doc
       else:
@@ -45,20 +46,21 @@ def generate_docs():
 
       #Computing legacy  images for gatk and bioconductor
       if image_config["name"] == "terra-jupyter-gatk":
-        legacy_gatk_doc = get_legacy_image(image_config["version"], doc)
+        legacy_gatk_doc = get_legacy_image(image_config["version"], remote_doc, legacy_gatk_doc)
 
-      if image_config["name"] == "terra-jupyter-bioconductor":
-        legacy_bioconductor_doc = get_legacy_image(image_config["version"], doc)
-            
+      # TODO: add back in after next bioconductor release (~06/2022)
+      #if image_config["name"] == "terra-jupyter-bioconductor":
+        #legacy_bioconductor_doc = get_legacy_image(image_config["version"], doc)
+
       docs.append(doc)
 
   docs.extend(get_other_docs())
   docs.extend([legacy_gatk_doc, legacy_bioconductor_doc])
   return docs
 
-def get_legacy_image(new_version, remote_doc):
+def get_legacy_image(new_version, remote_doc, current_legacy_img):
   print "generating legacy image"
-  new_version = new_version.split(".") 
+  new_version = new_version.split(".")
   new_version_patch = int(new_version[2])
   new_version_minor = int(new_version[1])
   new_version_major = int(new_version[0])
@@ -72,12 +74,9 @@ def get_legacy_image(new_version, remote_doc):
   # minor version bump
   elif new_version_minor > current_version_minor and (new_version_patch == 0 and current_version_major == new_version_major):
     return generate_legacy_label(remote_doc)
-  else: # TODO: remove this code after gatk and bioconductor images have a major or minor version bump
-    #if no  major or minor version bump, hardcode legacy  images
-    if "terra-jupyter-bioconductor" in remote_doc["image"]:
-      return utils.read_json_file(static_config_location)[0]
-    else:
-      return utils.read_json_file(static_config_location)[1]
+  # patch version bump or no version bump
+  else:
+    return current_legacy_img
 
 def generate_legacy_label(doc):
   if "terra-jupyter-bioconductor" in doc["image"]:

--- a/scripts/generate_version_docs.py
+++ b/scripts/generate_version_docs.py
@@ -38,7 +38,6 @@ def generate_docs():
 
       remote_doc = list(filter(lambda image_doc: image_doc["id"] == image_config["name"], remote_docs))[0]
       if image_config["name"] in remote_versions and image_config["version"] == remote_versions[image_config["name"]]:
-        #remote_doc = list(filter(lambda image_doc: image_doc["id"] == image_config["name"], remote_docs))[0]
         print "using remote doc: {}".format(remote_doc)
         doc = remote_doc
       else:


### PR DESCRIPTION
This PR adds a few things around legacy images:

- Adds documentation in CONTRIBUTING.md on how terra-docker legacy image versioning works
- hard codes the legacy bioconductor image as 2.0.2 until the next bioconductor release (we have to do this because when we bumped to bioc 3.14, we only did a patch version bump of the bioc image instead of a minor version bump)
- removes a TODO for computing legacy images