### PR TITLE
IA-2965  Update after PD mount change

### DIFF
--- a/.github/workflows/test-terra-jupyter-python.yml
+++ b/.github/workflows/test-terra-jupyter-python.yml
@@ -34,9 +34,7 @@ on:
 
 env:
   GOOGLE_PROJECT: ${{ secrets.GCP_PROJECT_ID }}
-  # Set the environment variables that are normally passed at runtime. https://github.com/DataBiosphere/leonardo/search?q=PIP_TARGET
   PIP_USER: "false"
-  PIP_TARGET: "/home/jupyter/notebooks/packages"
   R_LIBS: "/home/jupyter/notebooks/packages"
 
 jobs:

--- a/config/conf.json
+++ b/config/conf.json
@@ -26,7 +26,7 @@
                     "tidyverse"
                 ]
             },
-            "version" : "2.0.4",
+            "version" : "2.0.5",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : true,
@@ -47,7 +47,7 @@
                     "hail"
                 ]
             },
-            "version" : "1.0.4",
+            "version" : "1.0.5",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : true,
@@ -68,7 +68,7 @@
                     "scikit-learn"
                 ]
             },
-            "version" : "1.0.3",
+            "version" : "1.0.4",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : true,
@@ -86,7 +86,7 @@
             "packages" : {
                 
             },
-            "version" : "1.0.3",
+            "version" : "1.0.4",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : false,
@@ -104,7 +104,7 @@
             "packages" : {
                 
             },
-            "version" : "2.0.4",
+            "version" : "2.0.5",
             "automated_flags" : {
                 "include_in_ui" : false,
                 "generate_docs" : true,
@@ -124,7 +124,7 @@
             "packages" : {
                 
             },
-            "version" : "2.0.7",
+            "version" : "2.0.8",
             "automated_flags" : {
                 "include_in_ui" : true,
                 "generate_docs" : true,
@@ -143,7 +143,7 @@
             "packages" : {
                 
             },
-            "version" : "2.0.11",
+            "version" : "2.0.12",
             "automated_flags" : {
                 "include_in_ui" : false,
                 "generate_docs" : false,
@@ -163,7 +163,7 @@
             "packages" : {
                 
             },
-            "version" : "0.1.7",
+            "version" : "0.1.8",
             "automated_flags" : {
                 "include_in_ui" : false,
                 "generate_docs" : true,

--- a/terra-jupyter-aou/CHANGELOG.md
+++ b/terra-jupyter-aou/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.0.12 - 2022-02-02T20:47:42.403024Z
+
+- Update `terra-jupyter-base` to `1.0.4`
+  - update notebook_dir to $HOME; install scikit-learn-intelex, xgboost
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:2.0.12`
+
 ## 2.0.11 - 2022-01-25
 
 - Add additional genomics tools: gcta, PRsice, vcftools, plink2

--- a/terra-jupyter-aou/Dockerfile
+++ b/terra-jupyter-aou/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.0.6
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.0.7
 
 USER root
 

--- a/terra-jupyter-base/CHANGELOG.md
+++ b/terra-jupyter-base/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.0.4 - 2022-02-02T20:47:42.308006Z
+
+- update notebook_dir to $HOME
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.0.4`
+
 ## 1.0.3 - 2022-01-06T18:21:41.124056Z
 
 - Bumping Google Deeplearning image to 2.7, removing gcc-6 and gcc-8 install due to package problems

--- a/terra-jupyter-base/Dockerfile
+++ b/terra-jupyter-base/Dockerfile
@@ -92,11 +92,6 @@ RUN useradd -m -s /bin/bash -N -u $WELDER_UID $WELDER_USER
 # ensure this matches c.NotebookApp.port in jupyter_notebook_config.py
 ENV JUPYTER_PORT 8000
 ENV JUPYTER_HOME /etc/jupyter
-ENV USER_INSTALL_DIR /home/jupyter/notebooks/packages
-
-# Prepend existing PYTHONPATH if it's not empty; otherwise prepend it
-ENV PYTHONPATH ${PYTHONPATH:+$PYTHONPATH:}$JUPYTER_HOME/custom:$USER_INSTALL_DIR
-ENV PATH ${PATH:+$PATH:}$USER_INSTALL_DIR/bin
 
 RUN pip3 -V \
  # When we upgraded from jupyter 5.7.8 to 6.1.1, we broke terminal button on terra-ui.
@@ -123,10 +118,7 @@ ENV PIP_USER=true
 # When using PIP_USER=true packages are installed into Python site.USER_BASE, which is '/home/jupyter' for this system.
 # Append '/home/jupyter/.local/bin' to PATH
 # pip docs: https://pip.pypa.io/en/stable/reference/pip_install/#cmdoption-user
-ENV PATH="${PATH}:${HOME}/.local/bin"
-
-# Default terminal directory should be where PD is mounted
-RUN echo "cd ${HOME}/notebooks" >> ${HOME}/.bashrc
+ENV PATH="${PATH}:${HOME}/.local/bin:${HOME}/packages/bin"
 
 #######################
 # Utilities

--- a/terra-jupyter-base/jupyter_notebook_config.py
+++ b/terra-jupyter-base/jupyter_notebook_config.py
@@ -27,16 +27,6 @@ else:
 
 c.NotebookApp.base_url = '/notebooks' + fragment
 
-# Using an alternate notebooks_dir allows for mounting of a shared volume here.
-# The default notebook root dir is /home/jupyter, which is also the home
-# directory (which contains several other files on the image). We don't want
-# to mount there as it effectively deletes existing files on the image.
-# See https://docs.google.com/document/d/1b8wIydzC4D7Sbb6h2zWe-jCvoNq-bbD02CT1cnKLbGk
-if os.environ.get('WELDER_ENABLED') == 'true':
-  # Only enable this along with Welder, as this change is backwards incompatible
-  # for older localization users.
-  c.NotebookApp.notebook_dir = os.environ.get('NOTEBOOKS_DIR', '/home/jupyter/notebooks')
-
 # This is also specified in run-jupyter.sh
 c.NotebookApp.nbserver_extensions = {
     'jupyter_localize_extension': True

--- a/terra-jupyter-bioconductor/CHANGELOG.md
+++ b/terra-jupyter-bioconductor/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.0.5 - 2022-02-02T20:47:42.326830Z
+
+- Update `terra-jupyter-base` to `1.0.4`
+  - update notebook_dir to $HOME; install scikit-learn-intelex, xgboost
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:2.0.5`
+
 ## 2.0.4 - 2022-01-06T18:21:41.155891Z
 
 - Update `terra-jupyter-base` to `1.0.3`

--- a/terra-jupyter-bioconductor/Dockerfile
+++ b/terra-jupyter-bioconductor/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.0.4
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.0.5
 
 USER root
 

--- a/terra-jupyter-gatk-ovtf/CHANGELOG.md
+++ b/terra-jupyter-gatk-ovtf/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.1.8 - 2022-02-02T20:47:42.409160Z
+
+- Update `terra-jupyter-base` to `1.0.4`
+  - update notebook_dir to $HOME; install scikit-learn-intelex, xgboost
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk-ovtf:0.1.8`
+
 ## 0.1.7 - 2022-01-26T17:05:04.719540Z
 
 - OVTF1.1.0 released, Updated to GATK 4.2.4.1, TF2.7, GPU support enabled

--- a/terra-jupyter-gatk-ovtf/Dockerfile
+++ b/terra-jupyter-gatk-ovtf/Dockerfile
@@ -1,6 +1,6 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.3 AS python
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.4 AS python
 
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.0.4
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.0.5
 
 # copy everything pip installed from the python image
 COPY --from=python /opt/conda/lib/python3.7/site-packages /opt/conda/lib/python3.7/site-packages

--- a/terra-jupyter-gatk/CHANGELOG.md
+++ b/terra-jupyter-gatk/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.0.8 - 2022-02-02T20:47:42.389262Z
+
+- Update `terra-jupyter-base` to `1.0.4`
+  - update notebook_dir to $HOME; install scikit-learn-intelex, xgboost
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.0.8`
+
 ## 2.0.7 - 2022-01-06T18:21:41.225176Z
 
 - Update `terra-jupyter-base` to `1.0.3`

--- a/terra-jupyter-gatk/Dockerfile
+++ b/terra-jupyter-gatk/Dockerfile
@@ -1,6 +1,6 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.3 AS python
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.4 AS python
 
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.0.4
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.0.5
 
 # copy everything pip installed from the python image
 COPY --from=python /opt/conda/lib/python3.7/site-packages /opt/conda/lib/python3.7/site-packages

--- a/terra-jupyter-hail/CHANGELOG.md
+++ b/terra-jupyter-hail/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.0.5 - 2022-02-02T20:47:42.341058Z
+
+- Update `terra-jupyter-base` to `1.0.4`
+  - update notebook_dir to $HOME; install scikit-learn-intelex, xgboost
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-hail:1.0.5`
+
 ## 1.0.4 - 2022-01-06T18:21:41.170621Z
 
 - Update `terra-jupyter-base` to `1.0.3`

--- a/terra-jupyter-hail/Dockerfile
+++ b/terra-jupyter-hail/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.3
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.4
 USER root
 
 ENV PIP_USER=false

--- a/terra-jupyter-python/CHANGELOG.md
+++ b/terra-jupyter-python/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.0.4 - 2022-02-02T20:47:42.360741Z
+
+- Update `terra-jupyter-base` to `1.0.4`
+  - update notebook_dir to $HOME; install scikit-learn-intelex, xgboost
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.4`
+
 ## 1.0.3 - 2022-01-06T18:21:41.192855Z
 
 - Update `terra-jupyter-base` to `1.0.3`

--- a/terra-jupyter-python/Dockerfile
+++ b/terra-jupyter-python/Dockerfile
@@ -61,7 +61,7 @@ RUN pip3 -V \
    # Downgrade setuptools from the base image due to incompatibilies with pysam.
    # As of 2021-09-10, this is the latest version of setuptools that works with pysam.
    # See https://pypi.org/project/setuptools/#history
-   setuptools=57.5.0 --force-reinstall \
+   setuptools==58.0.1 --force-reinstall \
    pysam --no-binary pysam \
    python-dateutil \
    pytz \

--- a/terra-jupyter-python/Dockerfile
+++ b/terra-jupyter-python/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.0.3
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.0.4
 USER root
 # This makes it so pip runs as root, not the user.
 ENV PIP_USER=false

--- a/terra-jupyter-python/Dockerfile
+++ b/terra-jupyter-python/Dockerfile
@@ -61,7 +61,7 @@ RUN pip3 -V \
    # Downgrade setuptools from the base image due to incompatibilies with pysam.
    # As of 2021-09-10, this is the latest version of setuptools that works with pysam.
    # See https://pypi.org/project/setuptools/#history
-   setuptools<58 --force-reinstall \
+   setuptools=57.5.0 --force-reinstall \
    pysam --no-binary pysam \
    python-dateutil \
    pytz \

--- a/terra-jupyter-python/Dockerfile
+++ b/terra-jupyter-python/Dockerfile
@@ -61,7 +61,7 @@ RUN pip3 -V \
    # Downgrade setuptools from the base image due to incompatibilies with pysam.
    # As of 2021-09-10, this is the latest version of setuptools that works with pysam.
    # See https://pypi.org/project/setuptools/#history
-   setuptools==58.0.1 --force-reinstall \
+   setuptools<58 --force-reinstall \
    pysam --no-binary pysam \
    python-dateutil \
    pytz \

--- a/terra-jupyter-r/CHANGELOG.md
+++ b/terra-jupyter-r/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.0.5 - 2022-02-02T20:47:42.380155Z
+
+- Update `terra-jupyter-base` to `1.0.4`
+  - update notebook_dir to $HOME; install scikit-learn-intelex, xgboost
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.0.5`
+
 ## 2.0.4 - 2022-01-06T18:21:41.216517Z
 
 - Update `terra-jupyter-base` to `1.0.3`

--- a/terra-jupyter-r/Dockerfile
+++ b/terra-jupyter-r/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.0.3
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.0.4
 USER root
 
 COPY scripts $JUPYTER_HOME/scripts


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-2965

For images derived from terra-jupyter-python, the change log also includes https://github.com/DataBiosphere/terra-docker/pull/278, because that PR didn't have version bump and there was no new images generated