### PR TITLE
[IA-2991] update Rstudio to 3.14.1

### DIFF
--- a/config/community_images.json
+++ b/config/community_images.json
@@ -14,7 +14,7 @@
     "version": "3.14.1",
     "updated": "2022-02-08",
     "packages": "https://storage.googleapis.com/terra-docker-image-documentation/placeholder.json",
-    "image": "us.gcr.io/broad-dsp-gcr-public/anvil-rstudio-bioconductor:3.14.1-0",
+    "image": "us.gcr.io/broad-dsp-gcr-public/anvil-rstudio-bioconductor:3.14.1",
     "requiresSpark": false,
     "isRStudio": true
 },

--- a/config/community_images.json
+++ b/config/community_images.json
@@ -11,10 +11,10 @@
 {
     "id": "RStudio",
     "label": "RStudio (R 4.1.2, Bioconductor 3.14, Python 3.8.5)",
-    "version": "3.14.0",
-    "updated": "2021-11-09",
+    "version": "3.14.1",
+    "updated": "2022-02-08",
     "packages": "https://storage.googleapis.com/terra-docker-image-documentation/placeholder.json",
-    "image": "us.gcr.io/anvil-gcr-public/anvil-rstudio-bioconductor:3.14.0",
+    "image": "us.gcr.io/broad-dsp-gcr-public/anvil-rstudio-bioconductor:3.14.1-0",
     "requiresSpark": false,
     "isRStudio": true
 },


### PR DESCRIPTION
Includes changes in this PR: https://github.com/anvilproject/anvil-docker/pull/37