### PR TITLE
Update anvil-rstudio-bioconductor image

### DIFF
--- a/config/community_images.json
+++ b/config/community_images.json
@@ -11,10 +11,10 @@
 {
     "id": "RStudio",
     "label": "RStudio (R 4.1.2, Bioconductor 3.14, Python 3.8.5)",
-    "version": "3.14.1",
-    "updated": "2022-02-08",
+    "version": "3.14.2",
+    "updated": "2022-03-08",
     "packages": "https://storage.googleapis.com/terra-docker-image-documentation/placeholder.json",
-    "image": "us.gcr.io/broad-dsp-gcr-public/anvil-rstudio-bioconductor:3.14.1",
+    "image": "us.gcr.io/broad-dsp-gcr-public/anvil-rstudio-bioconductor:3.14.2",
     "requiresSpark": false,
     "isRStudio": true
 },


### PR DESCRIPTION
This will update the anvil-rstudio-bioconductor docker image that was rebuilt.

- this will add additional sys dependencies to make more Bioconductor packages work.


Related PR https://github.com/anvilproject/anvil-docker/pull/41