### PR TITLE
AoU: update base image, bump Hail

### DIFF
--- a/config/conf.json
+++ b/config/conf.json
@@ -135,7 +135,7 @@
                 "r"
             ],
             "packages" : {},
-            "version" : "2.0.12",
+            "version" : "2.0.13",
             "automated_flags" : {
                 "include_in_ui" : false,
                 "generate_docs" : false,

--- a/terra-jupyter-aou/CHANGELOG.md
+++ b/terra-jupyter-aou/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.0.13 - 2022-03-18
+
+- Update `terra-jupyter-gatk` to `2.0.8`
+- Update Hail installation to latest
+
 ## 2.0.12 - 2022-02-02T20:47:42.403024Z
 
 - Update `terra-jupyter-base` to `1.0.4`

--- a/terra-jupyter-aou/Dockerfile
+++ b/terra-jupyter-aou/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.0.7
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.0.8
 
 USER root
 
@@ -26,36 +26,38 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
 
 # Spark setup.
 # Copied from terra-jupyter-hail; keep updated.
-
-# Note Spark and Hadoop are mounted from the outside Dataproc VM.
-# Make empty conf dirs for the update-alternatives commands.
-RUN mkdir -p /etc/spark/conf.dist && mkdir -p /etc/hadoop/conf.empty && mkdir -p /etc/hive/conf.dist \
-    && update-alternatives --install /etc/spark/conf spark-conf /etc/spark/conf.dist 100 \
-    && update-alternatives --install /etc/hadoop/conf hadoop-conf /etc/hadoop/conf.empty 100 \
-    && update-alternatives --install /etc/hive/conf hive-conf /etc/hive/conf.dist 100
-
-ENV HAIL_VERSION=0.2.74
 ENV PIP_USER=false
-
-# For dataproc clusters, this path with will be automatically mounted. Else,
-# this is effectively ignored. On GCE VMs, this will result in failures to
-# import the pyspark package.
 ENV PYTHONPATH $PYTHONPATH:/usr/lib/spark/python
 ENV PYSPARK_PYTHON=python3
+ENV HAIL_VERSION=0.2.85
 
-RUN pip3 install pypandoc \
-      nbstripout \
-      papermill \
-      "git+https://github.com/all-of-us/workbench-snippets.git#egg=terra_widgets&subdirectory=py" \
+RUN find $JUPYTER_HOME/scripts -name '*.sh' -type f | xargs chmod +x \
+    && $JUPYTER_HOME/scripts/kernel/kernelspec.sh $JUPYTER_HOME/scripts/kernel /opt/conda/share/jupyter/kernels \
+    # Note Spark and Hadoop are mounted from the outside Dataproc VM.
+    # Make empty conf dirs for the update-alternatives commands.
+    && mkdir -p /etc/spark/conf.dist && mkdir -p /etc/hadoop/conf.empty && mkdir -p /etc/hive/conf.dist \
+    && update-alternatives --install /etc/spark/conf spark-conf /etc/spark/conf.dist 100 \
+    && update-alternatives --install /etc/hadoop/conf hadoop-conf /etc/hadoop/conf.empty 100 \
+    && update-alternatives --install /etc/hive/conf hive-conf /etc/hive/conf.dist 100 \
+    && apt-get update \
+    && apt install -yq --no-install-recommends openjdk-8-jdk \
+        g++ \
+        liblz4-dev \
+    # specify Java 8
+    && update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java \
+    && pip3 install pypandoc gnomad \
     && pip3 install --no-dependencies hail==$HAIL_VERSION \
     && X=$(mktemp -d) \
     && mkdir -p $X \
     && (cd $X && pip3 download hail==$HAIL_VERSION --no-dependencies && \
         unzip hail*.whl &&  \
         grep 'Requires-Dist: ' hail*dist-info/METADATA | sed 's/Requires-Dist: //' | sed 's/ (//' | sed 's/)//' | grep -v 'pyspark' | xargs pip install) \
-    && rm -rf $X
+    && rm -rf $X \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 ENV PIP_USER=true
+USER $USER
 
 # Install Wondershaper from source, for client-side egress limiting.
 RUN cd /usr/local/share && \
@@ -173,9 +175,6 @@ RUN mkdir -p /tmp/nextflow && \
   chmod 777 /bin/nextflow && \
   chown -R $USER:users $HOME/.nextflow && \
   rm -rf /tmp/nextflow
-
-ENV USER jupyter
-USER $USER
 
 RUN R -e 'BiocManager::install(c( \
   "SAIGEgds", \

--- a/terra-jupyter-aou/Dockerfile
+++ b/terra-jupyter-aou/Dockerfile
@@ -29,10 +29,10 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
 ENV PIP_USER=false
 ENV PYTHONPATH $PYTHONPATH:/usr/lib/spark/python
 
-RUN pip3 install pypandoc \
+RUN pip3 install
       nbstripout \
       papermill \
-      "git+https://github.com/all-of-us/workbench-snippets.git#egg=terra_widgets&subdirectory=py" \
+      "git+https://github.com/all-of-us/workbench-snippets.git#egg=terra_widgets&subdirectory=py"
 
 ENV PYSPARK_PYTHON=python3
 ENV HAIL_VERSION=0.2.91

--- a/terra-jupyter-aou/Dockerfile
+++ b/terra-jupyter-aou/Dockerfile
@@ -57,7 +57,6 @@ RUN find $JUPYTER_HOME/scripts -name '*.sh' -type f | xargs chmod +x \
     && rm -rf /var/lib/apt/lists/*
 
 ENV PIP_USER=true
-USER $USER
 
 # Install Wondershaper from source, for client-side egress limiting.
 RUN cd /usr/local/share && \
@@ -175,6 +174,8 @@ RUN mkdir -p /tmp/nextflow && \
   chmod 777 /bin/nextflow && \
   chown -R $USER:users $HOME/.nextflow && \
   rm -rf /tmp/nextflow
+
+USER $USER
 
 RUN R -e 'BiocManager::install(c( \
   "SAIGEgds", \

--- a/terra-jupyter-aou/Dockerfile
+++ b/terra-jupyter-aou/Dockerfile
@@ -28,6 +28,12 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
 # Copied from terra-jupyter-hail; keep updated.
 ENV PIP_USER=false
 ENV PYTHONPATH $PYTHONPATH:/usr/lib/spark/python
+
+RUN pip3 install pypandoc \
+      nbstripout \
+      papermill \
+      "git+https://github.com/all-of-us/workbench-snippets.git#egg=terra_widgets&subdirectory=py" \
+
 ENV PYSPARK_PYTHON=python3
 ENV HAIL_VERSION=0.2.91
 

--- a/terra-jupyter-aou/Dockerfile
+++ b/terra-jupyter-aou/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
 ENV PIP_USER=false
 ENV PYTHONPATH $PYTHONPATH:/usr/lib/spark/python
 
-RUN pip3 install
+RUN pip3 install \
       nbstripout \
       papermill \
       "git+https://github.com/all-of-us/workbench-snippets.git#egg=terra_widgets&subdirectory=py"

--- a/terra-jupyter-aou/Dockerfile
+++ b/terra-jupyter-aou/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
 ENV PIP_USER=false
 ENV PYTHONPATH $PYTHONPATH:/usr/lib/spark/python
 ENV PYSPARK_PYTHON=python3
-ENV HAIL_VERSION=0.2.85
+ENV HAIL_VERSION=0.2.91
 
 RUN find $JUPYTER_HOME/scripts -name '*.sh' -type f | xargs chmod +x \
     && $JUPYTER_HOME/scripts/kernel/kernelspec.sh $JUPYTER_HOME/scripts/kernel /opt/conda/share/jupyter/kernels \


### PR DESCRIPTION
We were seeing an issue with the scipy package given the previous Hail installation interactions. I'm not totally clear on why this manifested as it did, but it looks like some bad interaction with the Hail install instructions that uninstall several packages.

```
docker run -t --entrypoint='' --rm us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:2.0.12 pip install scipy
Requirement already satisfied: scipy in /opt/conda/lib/python3.7/site-packages (1.7.3)
ERROR: Could not install packages due to an OSError: [Errno 2] No such file or directory: '/opt/conda/lib/python3.7/site-packages/scipy-1.7.3.dist-info/METADATA'
```

Upgrading to the latest Hail install pattern resolves this.