### PR TITLE
Add updated dockerfile for Bioc3.15, R-4.2.0

### DIFF
--- a/terra-jupyter-r/Dockerfile
+++ b/terra-jupyter-r/Dockerfile
@@ -5,7 +5,7 @@ COPY scripts $JUPYTER_HOME/scripts
 
 # Add env vars to identify binary package installation
 ENV TERRA_R_PLATFORM="terra-jupyter-r"
-ENV TERRA_R_PLATFORM_BINARY_VERSION=3.14.0
+ENV TERRA_R_PLATFORM_BINARY_VERSION=3.15.0
 
 # Install protobuf 3.19.1. Note this version comes from base deep learning image. Use `conda list` to see what's installed
 RUN cd /tmp \
@@ -121,7 +121,7 @@ RUN pip3 -V \
 
 RUN R -e 'install.packages("BiocManager")' \
     ## check version
-    && R -e 'BiocManager::install(version="3.14", ask=FALSE)' \
+    && R -e 'BiocManager::install(version="3.15", ask=FALSE)' \
     && R -e 'BiocManager::install(c( \
     "boot", \
     "class", \
@@ -152,7 +152,7 @@ RUN R -e 'install.packages("BiocManager")' \
     "tidyverse", \
     "pbdZMQ", \
     "uuid"))' \
-		&& R -e 'BiocManager::install("DataBiosphere/Ronaldo")'
+    && R -e 'BiocManager::install("DataBiosphere/Ronaldo")'
 
 ## pip runs as jupyter user
 ENV PIP_USER=true


### PR DESCRIPTION
@gpcarr This should the PR which updates `terra-jupyter-r` image.

Note: This PR includes a Bioconductor version update, so a minor version bump on version number is required for the image for the ammonite script to work. i.e the CHANGELOG should indicate

```
diff --git a/terra-jupyter-r/CHANGELOG.md b/terra-jupyter-r/CHANGELOG.md
index 80a545b..f15925d 100644
--- a/terra-jupyter-r/CHANGELOG.md
+++ b/terra-jupyter-r/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.1.0 - 2022-05-02
+
+- Update Bioconductor to 3.15.0
+  - Install R 4.2.0
+  - Update all inheriting image 
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.1.0`