### PR TITLE
BW-1234 Install cromshell 2.0 to terra-jupyter-base image

### DIFF
--- a/config/conf.json
+++ b/config/conf.json
@@ -84,7 +84,7 @@
                 "python"
             ],
             "packages" : {},
-            "version" : "1.0.6",
+            "version" : "1.0.7",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : false,

--- a/config/conf.json
+++ b/config/conf.json
@@ -26,7 +26,7 @@
                     "tidyverse"
                 ]
             },
-            "version" : "2.1.0",
+            "version" : "2.1.1",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : true,
@@ -47,7 +47,7 @@
                     "hail"
                 ]
             },
-            "version" : "1.0.12",
+            "version" : "1.0.13",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : true,
@@ -68,7 +68,7 @@
                     "scikit-learn"
                 ]
             },
-            "version" : "1.0.6",
+            "version" : "1.0.7",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : true,
@@ -84,7 +84,7 @@
                 "python"
             ],
             "packages" : {},
-            "version" : "1.0.6",
+            "version" : "1.0.7",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : false,
@@ -99,8 +99,10 @@
             "tools" : [
                 "r"
             ],
-            "packages" : {},
-            "version" : "2.1.0",
+            "packages" : {
+                
+            },
+            "version" : "2.1.1",
             "automated_flags" : {
                 "include_in_ui" : false,
                 "generate_docs" : true,
@@ -117,8 +119,10 @@
                 "python",
                 "r"
             ],
-            "packages" : {},
-            "version" : "2.2.0",
+            "packages" : {
+                
+            },
+            "version" : "2.2.1",
             "automated_flags" : {
                 "include_in_ui" : true,
                 "generate_docs" : true,
@@ -134,8 +138,10 @@
                 "python",
                 "r"
             ],
-            "packages" : {},
-            "version" : "2.1.0",
+            "packages" : {
+                
+            },
+            "version" : "2.1.1",
             "automated_flags" : {
                 "include_in_ui" : false,
                 "generate_docs" : false,
@@ -152,8 +158,10 @@
                 "python",
                 "r"
             ],
-            "packages" : {},
-            "version" : "0.2.0",
+            "packages" : {
+                
+            },
+            "version" : "0.2.1",
             "automated_flags" : {
                 "include_in_ui" : false,
                 "generate_docs" : true,

--- a/config/conf.json
+++ b/config/conf.json
@@ -84,7 +84,7 @@
                 "python"
             ],
             "packages" : {},
-            "version" : "1.0.7",
+            "version" : "1.0.6",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : false,

--- a/terra-jupyter-aou/CHANGELOG.md
+++ b/terra-jupyter-aou/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.1.1 - 2022-05-10T22:08:26.056998Z
+
+- Update `terra-jupyter-base` to `1.0.7`
+  - Install Cromshell 2.0 (https://github.com/broadinstitute/cromshell)
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:2.1.1`
+
 ## 2.1.0 - 2022-05-02
 
 - Update `terra-jupyter-r` to `2.1.0`

--- a/terra-jupyter-aou/Dockerfile
+++ b/terra-jupyter-aou/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.1.1
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.2.1
 
 USER root
 

--- a/terra-jupyter-aou/Dockerfile
+++ b/terra-jupyter-aou/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.1.0
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.1.1
 
 USER root
 

--- a/terra-jupyter-aou/Dockerfile
+++ b/terra-jupyter-aou/Dockerfile
@@ -175,6 +175,8 @@ RUN mkdir -p /tmp/vcftools && \
     cd $HOME && \
     rm -rf /tmp/vcftools
 
+RUN R -e 'BiocManager::install(c("GENESIS"))'
+
 # TODO(IA-3261): Remove this hack, and just conda install normally. R SAIGE
 # unfortunately is difficult to install outside of conda. Conda is also not
 # fully supported on the terra-docker base image. Here we workaround this by
@@ -185,5 +187,3 @@ ENV R_LIBS /usr/local/lib/R/site-library:/opt/conda/lib/R/library
 RUN conda install -c bioconda r-saige
 
 USER $USER
-
-RUN R -e 'BiocManager::install(c("GENESIS"))'

--- a/terra-jupyter-base/CHANGELOG.md
+++ b/terra-jupyter-base/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.7 - 2022-05-10
+
+- Install Cromshell 2.0 (https://github.com/broadinstitute/cromshell)
+
 ## 1.0.6 - 2022-05-02T14:33:23.893656Z
 
 - use new nvidia key

--- a/terra-jupyter-base/CHANGELOG.md
+++ b/terra-jupyter-base/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.0.7 - 2022-05-10T22:08:25.901765Z
+
+- Install Cromshell 2.0 (https://github.com/broadinstitute/cromshell)
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.0.7`
+
 ## 1.0.6 - 2022-05-02T14:33:23.893656Z
 
 - use new nvidia key

--- a/terra-jupyter-base/CHANGELOG.md
+++ b/terra-jupyter-base/CHANGELOG.md
@@ -1,7 +1,3 @@
-## 1.0.7 - 2022-05-10
-
-- Install Cromshell 2.0 (https://github.com/broadinstitute/cromshell)
-
 ## 1.0.6 - 2022-05-02T14:33:23.893656Z
 
 - use new nvidia key

--- a/terra-jupyter-base/Dockerfile
+++ b/terra-jupyter-base/Dockerfile
@@ -109,10 +109,12 @@ RUN pip3 -V \
  # For gcloud alpha storage support.
  && pip3 install google-crc32c --target /usr/lib/google-cloud-sdk/lib/third_party
 
-RUN git clone git@github.com:broadinstitute/cromshell.git \
+RUN git clone https://github.com/broadinstitute/cromshell.git \
  && cd cromshell \
  && git checkout cromshell_2.0 \
- && pip install .
+ && pip install . \
+ # for testing remove this later
+ && cromshell-alpha --help
 
 # tmp hack min-5
 # I'm not installing jupyterlab and I can't update init-actions.sh to not access it

--- a/terra-jupyter-base/Dockerfile
+++ b/terra-jupyter-base/Dockerfile
@@ -114,6 +114,9 @@ RUN git clone https://github.com/broadinstitute/cromshell.git \
  && git checkout cromshell_2.0 \
  && pip install .
 
+# verify cromshell 2.0 is installed
+RUN cromshell-alpha version
+
 # tmp hack min-5
 # I'm not installing jupyterlab and I can't update init-actions.sh to not access it
 RUN mkdir -p /usr/local/share/jupyter/lab

--- a/terra-jupyter-base/Dockerfile
+++ b/terra-jupyter-base/Dockerfile
@@ -109,6 +109,11 @@ RUN pip3 -V \
  # For gcloud alpha storage support.
  && pip3 install google-crc32c --target /usr/lib/google-cloud-sdk/lib/third_party
 
+RUN git clone git@github.com:broadinstitute/cromshell.git \
+ && cd cromshell \
+ && git checkout cromshell_2.0 \
+ && pip install .
+
 # tmp hack min-5
 # I'm not installing jupyterlab and I can't update init-actions.sh to not access it
 RUN mkdir -p /usr/local/share/jupyter/lab

--- a/terra-jupyter-base/Dockerfile
+++ b/terra-jupyter-base/Dockerfile
@@ -112,9 +112,7 @@ RUN pip3 -V \
 RUN git clone https://github.com/broadinstitute/cromshell.git \
  && cd cromshell \
  && git checkout cromshell_2.0 \
- && pip install . \
- # for testing remove this later
- && cromshell-alpha --help
+ && pip install .
 
 # tmp hack min-5
 # I'm not installing jupyterlab and I can't update init-actions.sh to not access it

--- a/terra-jupyter-bioconductor/CHANGELOG.md
+++ b/terra-jupyter-bioconductor/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.1.1 - 2022-05-10T22:08:25.936576Z
+
+- Update `terra-jupyter-base` to `1.0.7`
+  - Install Cromshell 2.0 (https://github.com/broadinstitute/cromshell)
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:2.1.1`
+
 ## 2.1.0 - 2022-05-02
 
 - Update `terra-jupyter-r` to `2.1.0`

--- a/terra-jupyter-bioconductor/Dockerfile
+++ b/terra-jupyter-bioconductor/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.1.0
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.1.1
 
 USER root
 

--- a/terra-jupyter-gatk-ovtf/CHANGELOG.md
+++ b/terra-jupyter-gatk-ovtf/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.2.1 - 2022-05-10T22:08:26.070940Z
+
+- Update `terra-jupyter-base` to `1.0.7`
+  - Install Cromshell 2.0 (https://github.com/broadinstitute/cromshell)
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk-ovtf:0.2.1`
+
 ## 0.2.0 - 2022-05-02
 
 - Update `terra-jupyter-r` to `2.1.0`

--- a/terra-jupyter-gatk-ovtf/Dockerfile
+++ b/terra-jupyter-gatk-ovtf/Dockerfile
@@ -1,6 +1,6 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.6 AS python
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.7 AS python
 
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.1.0
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.1.1
 
 # copy everything pip installed from the python image
 COPY --from=python /opt/conda/lib/python3.7/site-packages /opt/conda/lib/python3.7/site-packages

--- a/terra-jupyter-gatk/CHANGELOG.md
+++ b/terra-jupyter-gatk/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.2.1 - 2022-05-10T22:08:26.027031Z
+
+- Update `terra-jupyter-base` to `1.0.7`
+  - Install Cromshell 2.0 (https://github.com/broadinstitute/cromshell)
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.2.1`
+
 ## 2.2.0 - 2022-05-02
 
 - Update `terra-jupyter-r` to `2.1.0`

--- a/terra-jupyter-gatk/Dockerfile
+++ b/terra-jupyter-gatk/Dockerfile
@@ -1,6 +1,6 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.6 AS python
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.7 AS python
 
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.1.0
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.1.1
 
 # copy everything pip installed from the python image
 COPY --from=python /opt/conda/lib/python3.7/site-packages /opt/conda/lib/python3.7/site-packages

--- a/terra-jupyter-hail/CHANGELOG.md
+++ b/terra-jupyter-hail/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.0.13 - 2022-05-10T22:08:25.952927Z
+
+- Update `terra-jupyter-base` to `1.0.7`
+  - Install Cromshell 2.0 (https://github.com/broadinstitute/cromshell)
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-hail:1.0.13`
+
 ## 1.0.12 - 2022-05-02T14:33:23.942987Z
 
 - Update `terra-jupyter-base` to `1.0.6`

--- a/terra-jupyter-hail/Dockerfile
+++ b/terra-jupyter-hail/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.6
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.7
 USER root
 
 ENV PIP_USER=false

--- a/terra-jupyter-python/CHANGELOG.md
+++ b/terra-jupyter-python/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.0.7 - 2022-05-10T22:08:25.979318Z
+
+- Update `terra-jupyter-base` to `1.0.7`
+  - Install Cromshell 2.0 (https://github.com/broadinstitute/cromshell)
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.7`
+
 ## 1.0.6 - 2022-05-02T14:33:23.968430Z
 
 - Update `terra-jupyter-base` to `1.0.6`

--- a/terra-jupyter-python/Dockerfile
+++ b/terra-jupyter-python/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.0.6
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.0.7
 USER root
 # This makes it so pip runs as root, not the user.
 ENV PIP_USER=false

--- a/terra-jupyter-r/CHANGELOG.md
+++ b/terra-jupyter-r/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.1.1 - 2022-05-10T22:08:26.010910Z
+
+- Update `terra-jupyter-base` to `1.0.7`
+  - Install Cromshell 2.0 (https://github.com/broadinstitute/cromshell)
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.1.1`
+
 ## 2.1.0 - 2022-05-02
 
 - Update Bioconductor to 3.15.0 and R to 4.2.0

--- a/terra-jupyter-r/Dockerfile
+++ b/terra-jupyter-r/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.0.6
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.0.7
 USER root
 
 COPY scripts $JUPYTER_HOME/scripts


### PR DESCRIPTION
To test if cromshell was installed properly, I added the `cromshell-alpha --help` command to the dockerfile and this was the result from test run (it has now been removed):
```
Step 18/29 : RUN git clone https://github.com/broadinstitute/cromshell.git  && cd cromshell  && git checkout cromshell_2.0  && pip install .  && cromshell-alpha --help
 ---> Running in 3447216c2a39
Cloning into 'cromshell'...
Switched to a new branch 'cromshell_2.0'
Branch 'cromshell_2.0' set up to track remote branch 'cromshell_2.0' from 'origin'.
....
....
Successfully built cromshell
Installing collected packages: pygments, cromshell
  Attempting uninstall: pygments
    Found existing installation: Pygments 2.11.2
    Uninstalling Pygments-2.11.2:
      Successfully uninstalled Pygments-2.11.2
Successfully installed cromshell-2.0.0 pygments-2.12.0
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
Please update the cromwell server in the following config file /home/jupyter/.cromshell/cromshell_config.json
Usage: cromshell-alpha [OPTIONS] COMMAND [ARGS]...

  Cromshell is a script for submitting workflows to a cromwell server and
  monitoring / querying their results.
....
....
```
Link to test_docker_image run: https://github.com/DataBiosphere/terra-docker/runs/6375029283?check_suite_focus=true

Closes https://broadworkbench.atlassian.net/browse/BW-1234