### PR TITLE
BW-1235 Add workspace-cromwell.py script to terra-jupyter-base image

### DIFF
--- a/build_smoke_test_image.sh
+++ b/build_smoke_test_image.sh
@@ -36,7 +36,7 @@ build_smoke_test_image() {
     fi
   done
 
-  docker build . --file Dockerfile --progress=plain --tag ${IMAGE_TYPE}:smoke-test
+  docker build . --file Dockerfile --tag ${IMAGE_TYPE}:smoke-test
   popd
 }
 

--- a/build_smoke_test_image.sh
+++ b/build_smoke_test_image.sh
@@ -36,7 +36,7 @@ build_smoke_test_image() {
     fi
   done
 
-  docker build . --file Dockerfile --tag ${IMAGE_TYPE}:smoke-test
+  docker build . --file Dockerfile --progress=plain --tag ${IMAGE_TYPE}:smoke-test
   popd
 }
 

--- a/config/conf.json
+++ b/config/conf.json
@@ -26,7 +26,7 @@
                     "tidyverse"
                 ]
             },
-            "version" : "2.1.1",
+            "version" : "2.1.2",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : true,
@@ -47,7 +47,7 @@
                     "hail"
                 ]
             },
-            "version" : "1.0.13",
+            "version" : "1.0.14",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : true,
@@ -68,7 +68,7 @@
                     "scikit-learn"
                 ]
             },
-            "version" : "1.0.7",
+            "version" : "1.0.8",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : true,
@@ -84,7 +84,7 @@
                 "python"
             ],
             "packages" : {},
-            "version" : "1.0.7",
+            "version" : "1.0.8",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : false,
@@ -102,7 +102,7 @@
             "packages" : {
                 
             },
-            "version" : "2.1.1",
+            "version" : "2.1.2",
             "automated_flags" : {
                 "include_in_ui" : false,
                 "generate_docs" : true,
@@ -122,7 +122,7 @@
             "packages" : {
                 
             },
-            "version" : "2.2.1",
+            "version" : "2.2.2",
             "automated_flags" : {
                 "include_in_ui" : true,
                 "generate_docs" : true,
@@ -141,7 +141,7 @@
             "packages" : {
                 
             },
-            "version" : "2.1.1",
+            "version" : "2.1.2",
             "automated_flags" : {
                 "include_in_ui" : false,
                 "generate_docs" : false,
@@ -161,7 +161,7 @@
             "packages" : {
                 
             },
-            "version" : "0.2.1",
+            "version" : "0.2.2",
             "automated_flags" : {
                 "include_in_ui" : false,
                 "generate_docs" : true,

--- a/terra-jupyter-aou/CHANGELOG.md
+++ b/terra-jupyter-aou/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.1.2 - 2022-05-17T17:14:41.365718Z
+
+- Update `terra-jupyter-base` to `1.0.8`
+  - Add script that manages Cromwell app
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:2.1.2`
+
 ## 2.1.1 - 2022-05-10T22:08:26.056998Z
 
 - Update `terra-jupyter-base` to `1.0.7`

--- a/terra-jupyter-aou/Dockerfile
+++ b/terra-jupyter-aou/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.2.1
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.2.2
 
 USER root
 

--- a/terra-jupyter-base/CHANGELOG.md
+++ b/terra-jupyter-base/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.0.8 - 2022-05-17T17:14:41.200567Z
+
+- Add script that manages Cromwell app
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.0.8`
+
 ## 1.0.7 - 2022-05-10T22:08:25.901765Z
 
 - Install Cromshell 2.0 (https://github.com/broadinstitute/cromshell)

--- a/terra-jupyter-base/Dockerfile
+++ b/terra-jupyter-base/Dockerfile
@@ -121,7 +121,7 @@ RUN cromshell-alpha version
 # copy workspace_cromwell.py script
 RUN git clone https://github.com/broadinstitute/cromwhelm.git \
  && cd cromwhelm \
- && cp scripts/workspace_cromwell.py $JUPYTER_HOME/scripts
+ && cp scripts/workspace_cromwell.py $JUPYTER_HOME/workspace_cromwell.py
 
 # tmp hack min-5
 # I'm not installing jupyterlab and I can't update init-actions.sh to not access it

--- a/terra-jupyter-base/Dockerfile
+++ b/terra-jupyter-base/Dockerfile
@@ -109,6 +109,7 @@ RUN pip3 -V \
  # For gcloud alpha storage support.
  && pip3 install google-crc32c --target /usr/lib/google-cloud-sdk/lib/third_party
 
+# install Cromshell 2.0
 RUN git clone https://github.com/broadinstitute/cromshell.git \
  && cd cromshell \
  && git checkout cromshell_2.0 \
@@ -116,6 +117,11 @@ RUN git clone https://github.com/broadinstitute/cromshell.git \
 
 # verify cromshell 2.0 is installed
 RUN cromshell-alpha version
+
+# copy workspace_cromwell.py script
+RUN git clone https://github.com/broadinstitute/cromwhelm.git \
+ && cd cromwhelm \
+ && cp scripts/workspace_cromwell.py $JUPYTER_HOME
 
 # tmp hack min-5
 # I'm not installing jupyterlab and I can't update init-actions.sh to not access it

--- a/terra-jupyter-base/Dockerfile
+++ b/terra-jupyter-base/Dockerfile
@@ -119,9 +119,9 @@ RUN git clone https://github.com/broadinstitute/cromshell.git \
 RUN cromshell-alpha version
 
 # copy workspace_cromwell.py script
-RUN git clone https://github.com/broadinstitute/cromwhelm.git
-# && cd cromwhelm \
-# && cp scripts/workspace_cromwell.py $JUPYTER_HOME/workspace_cromwell.py
+RUN git clone https://github.com/broadinstitute/cromwhelm.git \
+ && cd cromwhelm \
+ && cp scripts/workspace_cromwell.py $HOME
 
 # tmp hack min-5
 # I'm not installing jupyterlab and I can't update init-actions.sh to not access it
@@ -139,13 +139,9 @@ ENV PATH="${PATH}:${HOME}/.local/bin:${HOME}/packages/bin"
 # Utilities
 #######################
 
-RUN echo $(find . -name "workspace_cromwell.py")
-
 COPY scripts $JUPYTER_HOME/scripts
 COPY custom $JUPYTER_HOME/custom
 COPY jupyter_notebook_config.py $JUPYTER_HOME
-
-COPY ./cromwhelm/scripts/workspace_cromwell.py $JUPYTER_HOME
 
 RUN chown -R $USER:users $JUPYTER_HOME \
 # Disable nb_conda for now. Consider re-enable in the future

--- a/terra-jupyter-base/Dockerfile
+++ b/terra-jupyter-base/Dockerfile
@@ -121,7 +121,7 @@ RUN cromshell-alpha version
 # copy workspace_cromwell.py script
 RUN git clone https://github.com/broadinstitute/cromwhelm.git \
  && cd cromwhelm \
- && cp scripts/workspace_cromwell.py $JUPYTER_HOME
+ && cp scripts/workspace_cromwell.py $JUPYTER_HOME/scripts
 
 # tmp hack min-5
 # I'm not installing jupyterlab and I can't update init-actions.sh to not access it

--- a/terra-jupyter-base/Dockerfile
+++ b/terra-jupyter-base/Dockerfile
@@ -119,9 +119,9 @@ RUN git clone https://github.com/broadinstitute/cromshell.git \
 RUN cromshell-alpha version
 
 # copy workspace_cromwell.py script
-RUN git clone https://github.com/broadinstitute/cromwhelm.git \
- && cd cromwhelm \
- && cp scripts/workspace_cromwell.py $JUPYTER_HOME/workspace_cromwell.py
+RUN git clone https://github.com/broadinstitute/cromwhelm.git
+# && cd cromwhelm \
+# && cp scripts/workspace_cromwell.py $JUPYTER_HOME/workspace_cromwell.py
 
 # tmp hack min-5
 # I'm not installing jupyterlab and I can't update init-actions.sh to not access it
@@ -142,6 +142,8 @@ ENV PATH="${PATH}:${HOME}/.local/bin:${HOME}/packages/bin"
 COPY scripts $JUPYTER_HOME/scripts
 COPY custom $JUPYTER_HOME/custom
 COPY jupyter_notebook_config.py $JUPYTER_HOME
+
+COPY cromwhelm/scripts/workspace_cromwell.py $JUPYTER_HOME
 
 RUN chown -R $USER:users $JUPYTER_HOME \
 # Disable nb_conda for now. Consider re-enable in the future

--- a/terra-jupyter-base/Dockerfile
+++ b/terra-jupyter-base/Dockerfile
@@ -119,9 +119,7 @@ RUN git clone https://github.com/broadinstitute/cromshell.git \
 RUN cromshell-alpha version
 
 # copy workspace_cromwell.py script
-RUN git clone https://github.com/broadinstitute/cromwhelm.git \
- && cd cromwhelm \
- && cp scripts/workspace_cromwell.py $HOME
+RUN wget https://raw.githubusercontent.com/broadinstitute/cromwhelm/main/scripts/workspace_cromwell.py --directory-prefix $HOME
 
 # tmp hack min-5
 # I'm not installing jupyterlab and I can't update init-actions.sh to not access it

--- a/terra-jupyter-base/Dockerfile
+++ b/terra-jupyter-base/Dockerfile
@@ -139,11 +139,13 @@ ENV PATH="${PATH}:${HOME}/.local/bin:${HOME}/packages/bin"
 # Utilities
 #######################
 
+RUN echo $(find . -name "workspace_cromwell.py")
+
 COPY scripts $JUPYTER_HOME/scripts
 COPY custom $JUPYTER_HOME/custom
 COPY jupyter_notebook_config.py $JUPYTER_HOME
 
-COPY cromwhelm/scripts/workspace_cromwell.py $JUPYTER_HOME
+COPY ./cromwhelm/scripts/workspace_cromwell.py $JUPYTER_HOME
 
 RUN chown -R $USER:users $JUPYTER_HOME \
 # Disable nb_conda for now. Consider re-enable in the future

--- a/terra-jupyter-bioconductor/CHANGELOG.md
+++ b/terra-jupyter-bioconductor/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.1.2 - 2022-05-17T17:14:41.233909Z
+
+- Update `terra-jupyter-base` to `1.0.8`
+  - Add script that manages Cromwell app
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:2.1.2`
+
 ## 2.1.1 - 2022-05-10T22:08:25.936576Z
 
 - Update `terra-jupyter-base` to `1.0.7`

--- a/terra-jupyter-bioconductor/Dockerfile
+++ b/terra-jupyter-bioconductor/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.1.1
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.1.2
 
 USER root
 

--- a/terra-jupyter-gatk-ovtf/CHANGELOG.md
+++ b/terra-jupyter-gatk-ovtf/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.2.2 - 2022-05-17T17:14:41.382147Z
+
+- Update `terra-jupyter-base` to `1.0.8`
+  - Add script that manages Cromwell app
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk-ovtf:0.2.2`
+
 ## 0.2.1 - 2022-05-10T22:08:26.070940Z
 
 - Update `terra-jupyter-base` to `1.0.7`

--- a/terra-jupyter-gatk-ovtf/Dockerfile
+++ b/terra-jupyter-gatk-ovtf/Dockerfile
@@ -1,6 +1,6 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.7 AS python
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.8 AS python
 
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.1.1
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.1.2
 
 # copy everything pip installed from the python image
 COPY --from=python /opt/conda/lib/python3.7/site-packages /opt/conda/lib/python3.7/site-packages

--- a/terra-jupyter-gatk/CHANGELOG.md
+++ b/terra-jupyter-gatk/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.2.2 - 2022-05-17T17:14:41.328568Z
+
+- Update `terra-jupyter-base` to `1.0.8`
+  - Add script that manages Cromwell app
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.2.2`
+
 ## 2.2.1 - 2022-05-10T22:08:26.027031Z
 
 - Update `terra-jupyter-base` to `1.0.7`

--- a/terra-jupyter-gatk/Dockerfile
+++ b/terra-jupyter-gatk/Dockerfile
@@ -1,6 +1,6 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.7 AS python
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.8 AS python
 
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.1.1
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.1.2
 
 # copy everything pip installed from the python image
 COPY --from=python /opt/conda/lib/python3.7/site-packages /opt/conda/lib/python3.7/site-packages

--- a/terra-jupyter-hail/CHANGELOG.md
+++ b/terra-jupyter-hail/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.0.14 - 2022-05-17T17:14:41.258775Z
+
+- Update `terra-jupyter-base` to `1.0.8`
+  - Add script that manages Cromwell app
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-hail:1.0.14`
+
 ## 1.0.13 - 2022-05-10T22:08:25.952927Z
 
 - Update `terra-jupyter-base` to `1.0.7`

--- a/terra-jupyter-hail/Dockerfile
+++ b/terra-jupyter-hail/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.7
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.8
 USER root
 
 ENV PIP_USER=false

--- a/terra-jupyter-python/CHANGELOG.md
+++ b/terra-jupyter-python/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.0.8 - 2022-05-17T17:14:41.284361Z
+
+- Update `terra-jupyter-base` to `1.0.8`
+  - Add script that manages Cromwell app
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.8`
+
 ## 1.0.7 - 2022-05-10T22:08:25.979318Z
 
 - Update `terra-jupyter-base` to `1.0.7`

--- a/terra-jupyter-python/Dockerfile
+++ b/terra-jupyter-python/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.0.7
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.0.8
 USER root
 # This makes it so pip runs as root, not the user.
 ENV PIP_USER=false

--- a/terra-jupyter-r/CHANGELOG.md
+++ b/terra-jupyter-r/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.1.2 - 2022-05-17T17:14:41.312584Z
+
+- Update `terra-jupyter-base` to `1.0.8`
+  - Add script that manages Cromwell app
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.1.2`
+
 ## 2.1.1 - 2022-05-10T22:08:26.010910Z
 
 - Update `terra-jupyter-base` to `1.0.7`

--- a/terra-jupyter-r/Dockerfile
+++ b/terra-jupyter-r/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.0.7
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.0.8
 USER root
 
 COPY scripts $JUPYTER_HOME/scripts


### PR DESCRIPTION
I tested it by building it locally and it `workspace-cromwell.py` was available in the image. Using it caused error because the env variables were not set.
```
terra-jupyter-base % docker run --rm -it -u root -p 8000:8000 --entrypoint /bin/bash sshah-terra-juypter-base
root@31b75eb2f247:~# ls
workspace_cromwell.py
root@31b75eb2f247:~# python3 workspace_cromwell.py start
Traceback (most recent call last):
  File "workspace_cromwell.py", line 296, in <module>
    main()
  File "workspace_cromwell.py", line 260, in main
    'workspace_namespace': os.environ['WORKSPACE_NAMESPACE'],
  File "/opt/conda/lib/python3.7/os.py", line 681, in __getitem__
    raise KeyError(key) from None
KeyError: 'WORKSPACE_NAMESPACE'
```

Closes https://broadworkbench.atlassian.net/browse/BW-1235