### PR TITLE
BW-1235 Fixes `workspace_cromwell.py` not available in notebook

### DIFF
--- a/config/conf.json
+++ b/config/conf.json
@@ -26,7 +26,7 @@
                     "tidyverse"
                 ]
             },
-            "version" : "2.1.2",
+            "version" : "2.1.3",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : true,
@@ -47,7 +47,7 @@
                     "hail"
                 ]
             },
-            "version" : "1.0.14",
+            "version" : "1.0.15",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : true,
@@ -68,7 +68,7 @@
                     "scikit-learn"
                 ]
             },
-            "version" : "1.0.8",
+            "version" : "1.0.9",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : true,
@@ -83,8 +83,10 @@
             "tools" : [
                 "python"
             ],
-            "packages" : {},
-            "version" : "1.0.8",
+            "packages" : {
+                
+            },
+            "version" : "1.0.9",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : false,
@@ -102,7 +104,7 @@
             "packages" : {
                 
             },
-            "version" : "2.1.2",
+            "version" : "2.1.3",
             "automated_flags" : {
                 "include_in_ui" : false,
                 "generate_docs" : true,
@@ -122,7 +124,7 @@
             "packages" : {
                 
             },
-            "version" : "2.2.2",
+            "version" : "2.2.3",
             "automated_flags" : {
                 "include_in_ui" : true,
                 "generate_docs" : true,
@@ -141,7 +143,7 @@
             "packages" : {
                 
             },
-            "version" : "2.1.2",
+            "version" : "2.1.3",
             "automated_flags" : {
                 "include_in_ui" : false,
                 "generate_docs" : false,
@@ -161,7 +163,7 @@
             "packages" : {
                 
             },
-            "version" : "0.2.2",
+            "version" : "0.2.3",
             "automated_flags" : {
                 "include_in_ui" : false,
                 "generate_docs" : true,

--- a/terra-jupyter-aou/CHANGELOG.md
+++ b/terra-jupyter-aou/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.1.3 - 2022-05-20T18:06:39.587654Z
+
+- Update `terra-jupyter-base` to `1.0.9`
+  - Fix adding workspace_cromwell.py script to manage Cromwell App
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:2.1.3`
+
 ## 2.1.2 - 2022-05-17T17:14:41.365718Z
 
 - Update `terra-jupyter-base` to `1.0.8`

--- a/terra-jupyter-aou/Dockerfile
+++ b/terra-jupyter-aou/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.2.2
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.2.3
 
 USER root
 

--- a/terra-jupyter-base/CHANGELOG.md
+++ b/terra-jupyter-base/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.0.9 - 2022-05-20T18:06:39.404395Z
+
+- Fix adding workspace_cromwell.py script to manage Cromwell App
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.0.9`
+
 ## 1.0.8 - 2022-05-17T17:14:41.200567Z
 
 - Add script that manages Cromwell app

--- a/terra-jupyter-base/Dockerfile
+++ b/terra-jupyter-base/Dockerfile
@@ -138,9 +138,9 @@ COPY scripts $JUPYTER_HOME/scripts
 COPY custom $JUPYTER_HOME/custom
 COPY jupyter_notebook_config.py $JUPYTER_HOME
 
-# copy workspace_cromwell.py script
-#RUN wget https://raw.githubusercontent.com/broadinstitute/cromwhelm/main/scripts/workspace_cromwell.py --directory-prefix $JUPYTER_HOME
-RUN curl -o $JUPYTER_HOME/workspace_cromwell.py https://raw.githubusercontent.com/broadinstitute/cromwhelm/main/scripts/workspace_cromwell.py
+# copy workspace_cromwell.py script and make it runnable by all users
+RUN curl -o /usr/local/bin/workspace_cromwell.py https://raw.githubusercontent.com/broadinstitute/cromwhelm/main/scripts/workspace_cromwell.py \
+ && chmod +x /usr/local/bin/workspace_cromwell.py
 
 RUN chown -R $USER:users $JUPYTER_HOME \
 # Disable nb_conda for now. Consider re-enable in the future

--- a/terra-jupyter-base/Dockerfile
+++ b/terra-jupyter-base/Dockerfile
@@ -118,9 +118,6 @@ RUN git clone https://github.com/broadinstitute/cromshell.git \
 # verify cromshell 2.0 is installed
 RUN cromshell-alpha version
 
-# copy workspace_cromwell.py script
-RUN wget https://raw.githubusercontent.com/broadinstitute/cromwhelm/main/scripts/workspace_cromwell.py --directory-prefix $HOME
-
 # tmp hack min-5
 # I'm not installing jupyterlab and I can't update init-actions.sh to not access it
 RUN mkdir -p /usr/local/share/jupyter/lab
@@ -140,6 +137,10 @@ ENV PATH="${PATH}:${HOME}/.local/bin:${HOME}/packages/bin"
 COPY scripts $JUPYTER_HOME/scripts
 COPY custom $JUPYTER_HOME/custom
 COPY jupyter_notebook_config.py $JUPYTER_HOME
+
+# copy workspace_cromwell.py script
+#RUN wget https://raw.githubusercontent.com/broadinstitute/cromwhelm/main/scripts/workspace_cromwell.py --directory-prefix $JUPYTER_HOME
+RUN curl -o $JUPYTER_HOME/workspace_cromwell.py https://raw.githubusercontent.com/broadinstitute/cromwhelm/main/scripts/workspace_cromwell.py
 
 RUN chown -R $USER:users $JUPYTER_HOME \
 # Disable nb_conda for now. Consider re-enable in the future

--- a/terra-jupyter-bioconductor/CHANGELOG.md
+++ b/terra-jupyter-bioconductor/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.1.3 - 2022-05-20T18:06:39.449113Z
+
+- Update `terra-jupyter-base` to `1.0.9`
+  - Fix adding workspace_cromwell.py script to manage Cromwell App
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:2.1.3`
+
 ## 2.1.2 - 2022-05-17T17:14:41.233909Z
 
 - Update `terra-jupyter-base` to `1.0.8`

--- a/terra-jupyter-bioconductor/Dockerfile
+++ b/terra-jupyter-bioconductor/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.1.2
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.1.3
 
 USER root
 

--- a/terra-jupyter-gatk-ovtf/CHANGELOG.md
+++ b/terra-jupyter-gatk-ovtf/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.2.3 - 2022-05-20T18:06:39.600661Z
+
+- Update `terra-jupyter-base` to `1.0.9`
+  - Fix adding workspace_cromwell.py script to manage Cromwell App
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk-ovtf:0.2.3`
+
 ## 0.2.2 - 2022-05-17T17:14:41.382147Z
 
 - Update `terra-jupyter-base` to `1.0.8`

--- a/terra-jupyter-gatk-ovtf/Dockerfile
+++ b/terra-jupyter-gatk-ovtf/Dockerfile
@@ -1,6 +1,6 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.8 AS python
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.9 AS python
 
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.1.2
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.1.3
 
 # copy everything pip installed from the python image
 COPY --from=python /opt/conda/lib/python3.7/site-packages /opt/conda/lib/python3.7/site-packages

--- a/terra-jupyter-gatk/CHANGELOG.md
+++ b/terra-jupyter-gatk/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.2.3 - 2022-05-20T18:06:39.552362Z
+
+- Update `terra-jupyter-base` to `1.0.9`
+  - Fix adding workspace_cromwell.py script to manage Cromwell App
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.2.3`
+
 ## 2.2.2 - 2022-05-17T17:14:41.328568Z
 
 - Update `terra-jupyter-base` to `1.0.8`

--- a/terra-jupyter-gatk/Dockerfile
+++ b/terra-jupyter-gatk/Dockerfile
@@ -1,6 +1,6 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.8 AS python
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.9 AS python
 
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.1.2
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.1.3
 
 # copy everything pip installed from the python image
 COPY --from=python /opt/conda/lib/python3.7/site-packages /opt/conda/lib/python3.7/site-packages

--- a/terra-jupyter-hail/CHANGELOG.md
+++ b/terra-jupyter-hail/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.0.15 - 2022-05-20T18:06:39.466439Z
+
+- Update `terra-jupyter-base` to `1.0.9`
+  - Fix adding workspace_cromwell.py script to manage Cromwell App
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-hail:1.0.15`
+
 ## 1.0.14 - 2022-05-17T17:14:41.258775Z
 
 - Update `terra-jupyter-base` to `1.0.8`

--- a/terra-jupyter-hail/Dockerfile
+++ b/terra-jupyter-hail/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.8
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.9
 USER root
 
 ENV PIP_USER=false

--- a/terra-jupyter-python/CHANGELOG.md
+++ b/terra-jupyter-python/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.0.9 - 2022-05-20T18:06:39.493915Z
+
+- Update `terra-jupyter-base` to `1.0.9`
+  - Fix adding workspace_cromwell.py script to manage Cromwell App
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.9`
+
 ## 1.0.8 - 2022-05-17T17:14:41.284361Z
 
 - Update `terra-jupyter-base` to `1.0.8`

--- a/terra-jupyter-python/Dockerfile
+++ b/terra-jupyter-python/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.0.8
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.0.9
 USER root
 # This makes it so pip runs as root, not the user.
 ENV PIP_USER=false

--- a/terra-jupyter-r/CHANGELOG.md
+++ b/terra-jupyter-r/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.1.3 - 2022-05-20T18:06:39.532374Z
+
+- Update `terra-jupyter-base` to `1.0.9`
+  - Fix adding workspace_cromwell.py script to manage Cromwell App
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.1.3`
+
 ## 2.1.2 - 2022-05-17T17:14:41.312584Z
 
 - Update `terra-jupyter-base` to `1.0.8`

--- a/terra-jupyter-r/Dockerfile
+++ b/terra-jupyter-r/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.0.8
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.0.9
 USER root
 
 COPY scripts $JUPYTER_HOME/scripts


### PR DESCRIPTION
For testing, I ran [leonardo-build-terra-docker #3837](https://fc-jenkins.dsp-techops.broadinstitute.org/job/leonardo-build-terra-docker/3837/console) to build only the base image and used it to create a custom notebook environment. The script is available in `/usr/local/bin` folder. 

(I had started the app in notebook terminal hence it is already in running state)
![Screen Shot 2022-05-23 at 4 49 43 PM](https://user-images.githubusercontent.com/16748522/169903782-2a49c513-743e-4630-8fa2-863f2d8a751f.png)

Submitting workflow through cromshell
![Screen Shot 2022-05-23 at 4 50 49 PM](https://user-images.githubusercontent.com/16748522/169903964-a56ab1fc-6a8e-4f2f-8017-52e2acc29d52.png)

The workflow eventually succeeded. Deleting the app:
![Screen Shot 2022-05-23 at 4 51 42 PM](https://user-images.githubusercontent.com/16748522/169904091-e4e9ce69-41b6-45d0-9f2a-d08cb1b92bcf.png)

Closes https://broadworkbench.atlassian.net/browse/BW-1235