### PR TITLE
[IA-3261] Updated terra-jupyter-base to enable nb_conda

### DIFF
--- a/terra-jupyter-aou/CHANGELOG.md
+++ b/terra-jupyter-aou/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2.1.4 - 2022-06-03T16:36:39.131216Z
+
+- Update `terra-jupyter-base` to `1.0.10`
+  - Updated deeplearning-platform-release from tf-gpu.2-7 to tf-gpu.2-9.
+  - Re-enabled nb_conda.
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:2.1.4`
+
 ## 2.1.3 - 2022-05-20T18:06:39.587654Z
 
 - Update `terra-jupyter-base` to `1.0.9`

--- a/terra-jupyter-aou/Dockerfile
+++ b/terra-jupyter-aou/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.2.3
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.2.4
 
 USER root
 

--- a/terra-jupyter-base/CHANGELOG.md
+++ b/terra-jupyter-base/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.0.10 - 2022-06-03T16:36:38.767126Z
+
+- Updated deeplearning-platform-release from tf-gpu.2-7 to tf-gpu.2-9.
+- Re-enabled nb_conda.
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.0.10`
+
 ## 1.0.9 - 2022-05-20T18:06:39.404395Z
 
 - Fix adding workspace_cromwell.py script to manage Cromwell App

--- a/terra-jupyter-base/Dockerfile
+++ b/terra-jupyter-base/Dockerfile
@@ -1,6 +1,6 @@
 # adapted from https://hub.docker.com/r/jupyter/base-notebook/ AKA https://github.com/jupyter/docker-stacks/tree/master/base-notebook
 
-FROM gcr.io/deeplearning-platform-release/tf-gpu.2-7
+FROM gcr.io/deeplearning-platform-release/tf-gpu.2-9
 
 USER root
 
@@ -21,7 +21,6 @@ RUN sudo -i \
 # see article: https://developer.nvidia.com/blog/updating-the-cuda-linux-gpg-repository-key/
 # first we remove the bad keys from base image (https://github.com/NVIDIA/nvidia-docker/issues/1631#issuecomment-1112828208)
 RUN rm /etc/apt/sources.list.d/cuda.list \
-    && rm /etc/apt/sources.list.d/nvidia-ml.list \
     && sudo apt-key del 7fa2af80 \
     && curl -L -O https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.0-1_all.deb \
     && sudo dpkg -i cuda-keyring_1.0-1_all.deb
@@ -143,8 +142,6 @@ RUN curl -o /usr/local/bin/workspace_cromwell.py https://raw.githubusercontent.c
  && chmod +x /usr/local/bin/workspace_cromwell.py
 
 RUN chown -R $USER:users $JUPYTER_HOME \
-# Disable nb_conda for now. Consider re-enable in the future
- && jupyter nbextension disable nb_conda --py --sys-prefix \
  && find $JUPYTER_HOME/scripts -name '*.sh' -type f | xargs chmod +x \
 #  You can get kernel directory by running `jupyter kernelspec list`
  && $JUPYTER_HOME/scripts/kernel/kernelspec.sh $JUPYTER_HOME/scripts/kernel /opt/conda/share/jupyter/kernels

--- a/terra-jupyter-bioconductor/CHANGELOG.md
+++ b/terra-jupyter-bioconductor/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2.1.4 - 2022-06-03T16:36:38.844189Z
+
+- Update `terra-jupyter-base` to `1.0.10`
+  - Updated deeplearning-platform-release from tf-gpu.2-7 to tf-gpu.2-9.
+  - Re-enabled nb_conda.
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:2.1.4`
+
 ## 2.1.3 - 2022-05-20T18:06:39.449113Z
 
 - Update `terra-jupyter-base` to `1.0.9`

--- a/terra-jupyter-bioconductor/Dockerfile
+++ b/terra-jupyter-bioconductor/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.1.3
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.1.4
 
 USER root
 

--- a/terra-jupyter-gatk-ovtf/CHANGELOG.md
+++ b/terra-jupyter-gatk-ovtf/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.2.4 - 2022-06-03T16:36:39.152026Z
+
+- Update `terra-jupyter-base` to `1.0.10`
+  - Updated deeplearning-platform-release from tf-gpu.2-7 to tf-gpu.2-9.
+  - Re-enabled nb_conda.
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk-ovtf:0.2.4`
+
 ## 0.2.3 - 2022-05-20T18:06:39.600661Z
 
 - Update `terra-jupyter-base` to `1.0.9`

--- a/terra-jupyter-gatk-ovtf/Dockerfile
+++ b/terra-jupyter-gatk-ovtf/Dockerfile
@@ -1,6 +1,6 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.9 AS python
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.10 AS python
 
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.1.3
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.1.4
 
 # copy everything pip installed from the python image
 COPY --from=python /opt/conda/lib/python3.7/site-packages /opt/conda/lib/python3.7/site-packages

--- a/terra-jupyter-gatk/CHANGELOG.md
+++ b/terra-jupyter-gatk/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2.2.4 - 2022-06-03T16:36:39.096627Z
+
+- Update `terra-jupyter-base` to `1.0.10`
+  - Updated deeplearning-platform-release from tf-gpu.2-7 to tf-gpu.2-9.
+  - Re-enabled nb_conda.
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.2.4`
+
 ## 2.2.3 - 2022-05-20T18:06:39.552362Z
 
 - Update `terra-jupyter-base` to `1.0.9`

--- a/terra-jupyter-gatk/Dockerfile
+++ b/terra-jupyter-gatk/Dockerfile
@@ -1,6 +1,6 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.9 AS python
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.10 AS python
 
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.1.3
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.1.4
 
 # copy everything pip installed from the python image
 COPY --from=python /opt/conda/lib/python3.7/site-packages /opt/conda/lib/python3.7/site-packages

--- a/terra-jupyter-hail/CHANGELOG.md
+++ b/terra-jupyter-hail/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.0.16 - 2022-06-03T16:36:38.890322Z
+
+- Update `terra-jupyter-base` to `1.0.10`
+  - Updated deeplearning-platform-release from tf-gpu.2-7 to tf-gpu.2-9.
+  - Re-enabled nb_conda.
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-hail:1.0.16`
+
 ## 1.0.15 - 2022-05-20T18:06:39.466439Z
 
 - Update `terra-jupyter-base` to `1.0.9`

--- a/terra-jupyter-hail/Dockerfile
+++ b/terra-jupyter-hail/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.9
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.10
 USER root
 
 ENV PIP_USER=false

--- a/terra-jupyter-python/CHANGELOG.md
+++ b/terra-jupyter-python/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.0.10 - 2022-06-03T16:36:38.951037Z
+
+- Update `terra-jupyter-base` to `1.0.10`
+  - Updated deeplearning-platform-release from tf-gpu.2-7 to tf-gpu.2-9.
+  - Re-enabled nb_conda.
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.10`
+
 ## 1.0.9 - 2022-05-20T18:06:39.493915Z
 
 - Update `terra-jupyter-base` to `1.0.9`

--- a/terra-jupyter-python/Dockerfile
+++ b/terra-jupyter-python/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.0.9
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.0.10
 USER root
 # This makes it so pip runs as root, not the user.
 ENV PIP_USER=false

--- a/terra-jupyter-r/CHANGELOG.md
+++ b/terra-jupyter-r/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2.1.4 - 2022-06-03T16:36:39.031834Z
+
+- Update `terra-jupyter-base` to `1.0.10`
+  - Updated deeplearning-platform-release from tf-gpu.2-7 to tf-gpu.2-9.
+  - Re-enabled nb_conda.
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.1.4`
+
 ## 2.1.3 - 2022-05-20T18:06:39.532374Z
 
 - Update `terra-jupyter-base` to `1.0.9`

--- a/terra-jupyter-r/Dockerfile
+++ b/terra-jupyter-r/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.0.9
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.0.10
 USER root
 
 COPY scripts $JUPYTER_HOME/scripts


### PR DESCRIPTION
## Description

User runs conda install <package> and gets permissions error.
The conda installation and associated packages are owned by root:root, so when the "jupyter" user goes to install they will not have permissions to make changes.
nb_conda is disabled - this could be causing the permissions issues.

## Solution
With the new version of Conda (4.11.0 -> 4.12.0, still not latest) from the base image, we can enable nb_conda to give users back their flexibility within the Jupyter notebook.