### PR TITLE
IA-3484 Update community.json RStudio version

### DIFF
--- a/config/community_images.json
+++ b/config/community_images.json
@@ -11,10 +11,10 @@
 {
     "id": "RStudio",
     "label": "RStudio (R 4.2.0, Bioconductor 3.15, Python 3.8.10)",
-    "version": "3.15.1",
+    "version": "3.15.2",
     "updated": "2022-05-09",
     "packages": "https://storage.googleapis.com/terra-docker-image-documentation/placeholder.json",
-    "image": "us.gcr.io/broad-dsp-gcr-public/anvil-rstudio-bioconductor:3.15.1",
+    "image": "us.gcr.io/broad-dsp-gcr-public/anvil-rstudio-bioconductor:3.15.2",
     "requiresSpark": false,
     "isRStudio": true
 },


### PR DESCRIPTION
The RStudio image needs to be updated to 3.15.2 as per this commit https://github.com/anvilproject/anvil-docker/commit/2eb4018718ff105fd1a5373921f8bcc99179877c


https://broadworkbench.atlassian.net/browse/IA-3484