### PR TITLE
[IA-3401] Fix broken Python packages in gatk / AoU images

### DIFF
--- a/config/conf.json
+++ b/config/conf.json
@@ -68,7 +68,7 @@
                     "scikit-learn"
                 ]
             },
-            "version" : "1.0.9",
+            "version" : "1.0.11",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : true,
@@ -124,7 +124,7 @@
             "packages" : {
                 
             },
-            "version" : "2.2.3",
+            "version" : "2.2.5",
             "automated_flags" : {
                 "include_in_ui" : true,
                 "generate_docs" : true,
@@ -143,7 +143,7 @@
             "packages" : {
                 
             },
-            "version" : "2.1.3",
+            "version" : "2.1.5",
             "automated_flags" : {
                 "include_in_ui" : false,
                 "generate_docs" : false,

--- a/terra-jupyter-aou/CHANGELOG.md
+++ b/terra-jupyter-aou/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.1.5 - 2022-06-09
 
-- Update `terra-jupyter-gatk` base to `2.2.4`
+- Update `terra-jupyter-gatk` base to `2.2.5`
   - Fix Python sites-packages to avoid issues on uninstall
 - Bump Hail to 0.2.93
 

--- a/terra-jupyter-aou/CHANGELOG.md
+++ b/terra-jupyter-aou/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 2.1.5 - 2022-06-09
+
+- Update `terra-jupyter-gatk` base to `2.2.4`
+  - Fix Python sites-packages to avoid issues on uninstall
+- Bump Hail to 0.2.93
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:2.1.5`
+
+## 2.1.4 - 2022-06-03T18:35:22.582705Z
+
+- reverted, do not use
+
 ## 2.1.3 - 2022-05-20T18:06:39.587654Z
 
 - Update `terra-jupyter-base` to `1.0.9`

--- a/terra-jupyter-aou/Dockerfile
+++ b/terra-jupyter-aou/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.2.3
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.2.5
 
 USER root
 
@@ -23,9 +23,14 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
+ENV PIP_USER=false
+
+# pandas-profiling 3.1.0 causes conflicts with pyplot
+# pandas-profiling 3.2.0 is incompatible with markupsafe 2.0.1
+# 3.0.0 (lower is untested) avoids both of these issues.
 RUN pip3 install --upgrade \
-  "markupsafe>=2.0.1" \
-  "pandas_profiling>=3.0.2"
+  "pandas_profiling<=3.0.0" \
+  "markupsafe==2.0.1"
 
 RUN pip3 install \
       nbstripout \
@@ -33,7 +38,7 @@ RUN pip3 install \
       dsub \
       "git+https://github.com/all-of-us/workbench-snippets.git#egg=terra_widgets&subdirectory=py"
 
-RUN PIP_USER=false pip3 install igv-jupyter
+RUN pip3 install igv-jupyter
 RUN jupyter nbextension enable --py igv --sys-prefix
 
 # Spark/Hail setup.
@@ -183,4 +188,5 @@ RUN R -e 'BiocManager::install(c("GENESIS"))'
 ENV R_LIBS /usr/local/lib/R/site-library:/opt/conda/lib/R/library
 RUN conda install -c bioconda r-saige
 
+ENV PIP_USER=true
 USER $USER

--- a/terra-jupyter-aou/Dockerfile
+++ b/terra-jupyter-aou/Dockerfile
@@ -23,24 +23,25 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
-
-# Spark setup.
-# Copied from terra-jupyter-hail; keep updated.
-ENV PIP_USER=false
-ENV PYTHONPATH $PYTHONPATH:/usr/lib/spark/python
-
-RUN pip3 install --upgrade markupsafe==2.0.1
+RUN pip3 install --upgrade \
+  "markupsafe>=2.0.1" \
+  "pandas_profiling>=3.0.2"
 
 RUN pip3 install \
-      igv-jupyter \
       nbstripout \
       papermill \
+      dsub \
       "git+https://github.com/all-of-us/workbench-snippets.git#egg=terra_widgets&subdirectory=py"
 
-RUN jupyter nbextension enable --py igv
+RUN PIP_USER=false pip3 install igv-jupyter
+RUN jupyter nbextension enable --py igv --sys-prefix
+
+# Spark/Hail setup.
+# Copied from terra-jupyter-hail; keep updated.
+ENV PYTHONPATH $PYTHONPATH:/usr/lib/spark/python
 
 ENV PYSPARK_PYTHON=python3
-ENV HAIL_VERSION=0.2.91
+ENV HAIL_VERSION=0.2.93
 
 RUN find $JUPYTER_HOME/scripts -name '*.sh' -type f | xargs chmod +x \
     && $JUPYTER_HOME/scripts/kernel/kernelspec.sh $JUPYTER_HOME/scripts/kernel /opt/conda/share/jupyter/kernels \
@@ -51,11 +52,9 @@ RUN find $JUPYTER_HOME/scripts -name '*.sh' -type f | xargs chmod +x \
     && update-alternatives --install /etc/hadoop/conf hadoop-conf /etc/hadoop/conf.empty 100 \
     && update-alternatives --install /etc/hive/conf hive-conf /etc/hive/conf.dist 100 \
     && apt-get update \
-    && apt install -yq --no-install-recommends openjdk-8-jdk \
+    && apt install -yq --no-install-recommends \
         g++ \
         liblz4-dev \
-    # specify Java 8
-    && update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java \
     && pip3 install pypandoc gnomad \
     && pip3 install --no-dependencies hail==$HAIL_VERSION \
     && X=$(mktemp -d) \
@@ -66,8 +65,6 @@ RUN find $JUPYTER_HOME/scripts -name '*.sh' -type f | xargs chmod +x \
     && rm -rf $X \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
-
-ENV PIP_USER=true
 
 # Install Wondershaper from source, for client-side egress limiting.
 RUN cd /usr/local/share && \

--- a/terra-jupyter-gatk/CHANGELOG.md
+++ b/terra-jupyter-gatk/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 2.2.5 - 2022-06-09
+
+- Improve Python package matching from -python image. No longer causes downstream
+  issues on package uninstall.
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.2.5`
+
+## 2.2.4 - 2022-06-03T18:35:22.539434Z
+
+- reverted, do not use
+
 ## 2.2.3 - 2022-05-20T18:06:39.552362Z
 
 - Update `terra-jupyter-base` to `1.0.9`

--- a/terra-jupyter-gatk/Dockerfile
+++ b/terra-jupyter-gatk/Dockerfile
@@ -1,9 +1,8 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.9 AS python
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.11 AS python
+
+RUN conda list -n base --explicit > /tmp/conda_packages.txt
 
 FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.1.3
-
-# copy everything pip installed from the python image
-COPY --from=python /opt/conda/lib/python3.7/site-packages /opt/conda/lib/python3.7/site-packages
 
 USER root
 
@@ -28,6 +27,15 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
+ENV PIP_USER=false
+
+# Grab the requirements from the python base image and reinstall them. By
+# comparison, simply copying the python sites-packages can result in issues when
+# uninstalling packages: https://github.com/conda/conda/issues/10357
+COPY --from=python /etc/terra-docker/requirements.txt /etc/terra-docker/base_requirements.txt
+
+RUN pip install --upgrade -r /etc/terra-docker/base_requirements.txt
+
 # Install GATK
 ENV GATK_VERSION 4.2.4.0
 ENV GATK_ZIP_PATH /tmp/gatk-${GATK_VERSION}.zip
@@ -47,17 +55,14 @@ RUN mkdir -p /tmp/nextflow && \
   chown -R $USER:users $HOME/.nextflow && \
   rm -rf /tmp/nextflow
 
-ENV PIP_USER=false
-
 RUN pip install /etc/gatk-$GATK_VERSION/gatkPythonPackageArchive.zip
 RUN pip3 install --upgrade markupsafe==2.0.1
-
-ENV PIP_USER=true
 
 COPY cnn-models.patch /etc/gatk-$GATK_VERSION/cnn-models.patch
 
 RUN patch -u /opt/conda/lib/python3.7/site-packages/vqsr_cnn/vqsr_cnn/models.py -i /etc/gatk-$GATK_VERSION/cnn-models.patch
 
+ENV PIP_USER=true
+
 ENV USER jupyter
 USER $USER
-

--- a/terra-jupyter-python/CHANGELOG.md
+++ b/terra-jupyter-python/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 1.0.11 - 2022-06-09
+
+- Switch to requirements.txt file
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.11`
+
+## 1.0.10 - 2022-06-03T18:35:22.435328Z
+
+- reverted, do not use
+
 ## 1.0.9 - 2022-05-20T18:06:39.493915Z
 
 - Update `terra-jupyter-base` to `1.0.9`

--- a/terra-jupyter-python/Dockerfile
+++ b/terra-jupyter-python/Dockerfile
@@ -20,6 +20,8 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
 
 ENV HTSLIB_CONFIGURE_OPTIONS="--enable-gcs"
 
+COPY requirements.txt /etc/terra-docker/
+
 # Dev note: in general, do not pin Python packages to any particular version.
 # Depend on the smoke tests to help us identify any package incompatibilties.
 #
@@ -30,57 +32,7 @@ ENV HTSLIB_CONFIGURE_OPTIONS="--enable-gcs"
 #    test coverage for the identified problem.
 RUN pip3 -V \
  && pip3 install --upgrade pip \
- && pip3 install --upgrade \
-   py4j \
-   pandas-gbq \
-   seaborn \
-   python-lzo \
-   # Hold back from the 3.0 upgrade, as it requires the BigQuery Storage API. See
-   # further in the Dockerfile for explanation of why BQ Storage is currently uninstalled.
-   "google-cloud-bigquery<3.0.0" \
-   google-cloud-bigquery-datatransfer \
-   google-cloud-resource-manager \
-   statsmodels \
-   ggplot \
-   bokeh \
-   pyfasta \
-   pdoc3 \
-   biopython \
-   bx-python \
-   fastinterval \
-   matplotlib-venn \
-   bleach \
-   cycler \
-   h5py \
-   html5lib \
-   joblib \
-   # Remove the version pin for keras when tensorflow is updated to 2.7 or higher.
-   keras==2.7.0 \
-   patsy \
-   pymc3 \
-   # fix to 2.4.7 so that tensorflow still works
-   pyparsing==2.4.7 \
-   Cython \
-   # Downgrade setuptools from the base image due to incompatibilies with pysam.
-   # As of 2021-09-10, this is the latest version of setuptools that works with pysam.
-   # See https://pypi.org/project/setuptools/#history
-   setuptools==58.0.1 --force-reinstall \
-   pysam --no-binary pysam \
-   python-dateutil \
-   pytz \
-   pyvcf3 \
-   theano \
-   tqdm \
-   werkzeug \
-   certifi \
-   intel-openmp \
-   mkl \
-   wheel \
-   plotnine \
-   google-resumable-media \
-   #adding intel optimized xgboost and intel extension for scikit-learn
-   scikit-learn-intelex \
-   xgboost \
+ && pip3 install --upgrade -r /etc/terra-docker/requirements.txt \
 
  # Remove this after https://broadworkbench.atlassian.net/browse/CA-1179
  # As of release [google-cloud-bigquery 1.26.0 (2020-07-20)](https://github.com/googleapis/python-bigquery/blob/master/CHANGELOG.md#1260-2020-07-20)

--- a/terra-jupyter-python/requirements.txt
+++ b/terra-jupyter-python/requirements.txt
@@ -1,0 +1,47 @@
+py4j
+pandas-gbq
+seaborn
+python-lzo
+# Hold back from the 3.0 upgrade, as it requires the BigQuery Storage API. See
+# further in the Dockerfile for explanation of why BQ Storage is currently uninstalled.
+google-cloud-bigquery<3.0.0
+google-cloud-bigquery-datatransfer
+google-cloud-resource-manager
+statsmodels
+ggplot
+bokeh
+pyfasta
+pdoc3
+biopython
+bx-python
+fastinterval
+matplotlib-venn
+bleach
+cycler
+h5py
+html5lib
+joblib
+# Remove the version pin for keras when tensorflow is updated to 2.7 or higher.
+keras==2.7.0
+patsy
+pymc3
+# fix to 2.4.7 so that tensorflow still works
+pyparsing==2.4.7
+Cython
+pysam
+--no-binary=pysam
+python-dateutil
+pytz
+pyvcf3
+theano
+tqdm
+werkzeug
+certifi
+intel-openmp
+mkl
+wheel
+plotnine
+google-resumable-media
+#adding intel optimized xgboost and intel extension for scikit-learn
+scikit-learn-intelex
+xgboost


### PR DESCRIPTION
See https://broadworkbench.atlassian.net/jira/software/c/projects/IA/issues/IA-3401 for a description of the bug.

I narrowed the cause down to the GATK image (the issue did not repro in -base, -r, -python). I then further narrowed it down to the way in which sites-packages were being copied from the python image. I'm not 100% sure of why the previous approach caused this bug, but my suspicion is that bringing packages through the backdoor like this missed some initialization or setup with the base conda environment; the bug seems related to installing with conda vs pip.

By switching to a requirements.txt file in terra-jupyter-python, we can reuse the dependencies in both images via `pip install -r`.

This also:
- removes the setuptools downgrade in the python image, pysam now installs, so this seems to no longer be necessary
- bumps hail to 0.2.93
- removes the java8 logic  for Hail (this seems to have not made a difference...)

Known issues:
- `cloud alpha storage cp` is not working due to the crc32c package not being fully installed. I've tried a few fixes but failed - leaving that for now.