### PR TITLE
[IA-3261] Change ownership of /opt/conda to give users the ability to run conda install

### DIFF
--- a/config/conf.json
+++ b/config/conf.json
@@ -68,7 +68,7 @@
                     "scikit-learn"
                 ]
             },
-            "version" : "1.0.11",
+            "version" : "1.0.12",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : true,
@@ -124,7 +124,7 @@
             "packages" : {
                 
             },
-            "version" : "2.2.5",
+            "version" : "2.2.6",
             "automated_flags" : {
                 "include_in_ui" : true,
                 "generate_docs" : true,
@@ -143,7 +143,7 @@
             "packages" : {
                 
             },
-            "version" : "2.1.5",
+            "version" : "2.1.6",
             "automated_flags" : {
                 "include_in_ui" : false,
                 "generate_docs" : false,

--- a/config/conf.json
+++ b/config/conf.json
@@ -26,7 +26,7 @@
                     "tidyverse"
                 ]
             },
-            "version" : "2.1.3",
+            "version" : "2.1.4",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : true,
@@ -47,7 +47,7 @@
                     "hail"
                 ]
             },
-            "version" : "1.0.15",
+            "version" : "1.0.16",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : true,
@@ -68,7 +68,7 @@
                     "scikit-learn"
                 ]
             },
-            "version" : "1.0.9",
+            "version" : "1.0.10",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : true,
@@ -86,7 +86,7 @@
             "packages" : {
                 
             },
-            "version" : "1.0.9",
+            "version" : "1.0.10",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : false,
@@ -104,7 +104,7 @@
             "packages" : {
                 
             },
-            "version" : "2.1.3",
+            "version" : "2.1.4",
             "automated_flags" : {
                 "include_in_ui" : false,
                 "generate_docs" : true,
@@ -124,7 +124,7 @@
             "packages" : {
                 
             },
-            "version" : "2.2.3",
+            "version" : "2.2.4",
             "automated_flags" : {
                 "include_in_ui" : true,
                 "generate_docs" : true,
@@ -143,7 +143,7 @@
             "packages" : {
                 
             },
-            "version" : "2.1.3",
+            "version" : "2.1.4",
             "automated_flags" : {
                 "include_in_ui" : false,
                 "generate_docs" : false,
@@ -163,7 +163,7 @@
             "packages" : {
                 
             },
-            "version" : "0.2.3",
+            "version" : "0.2.4",
             "automated_flags" : {
                 "include_in_ui" : false,
                 "generate_docs" : true,

--- a/config/conf.json
+++ b/config/conf.json
@@ -68,11 +68,7 @@
                     "scikit-learn"
                 ]
             },
-<<<<<<< HEAD
-            "version" : "1.0.10",
-=======
             "version" : "1.0.11",
->>>>>>> master
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : true,
@@ -128,11 +124,7 @@
             "packages" : {
                 
             },
-<<<<<<< HEAD
-            "version" : "2.2.4",
-=======
             "version" : "2.2.5",
->>>>>>> master
             "automated_flags" : {
                 "include_in_ui" : true,
                 "generate_docs" : true,
@@ -151,11 +143,7 @@
             "packages" : {
                 
             },
-<<<<<<< HEAD
-            "version" : "2.1.4",
-=======
             "version" : "2.1.5",
->>>>>>> master
             "automated_flags" : {
                 "include_in_ui" : false,
                 "generate_docs" : false,

--- a/terra-jupyter-aou/CHANGELOG.md
+++ b/terra-jupyter-aou/CHANGELOG.md
@@ -5,6 +5,7 @@
   - Change ownership of /opt/conda to $USER:users.
 
 Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:2.1.4`
+
 ## 2.1.5 - 2022-06-09
 
 - Update `terra-jupyter-gatk` base to `2.2.5`

--- a/terra-jupyter-aou/CHANGELOG.md
+++ b/terra-jupyter-aou/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2.1.4 - 2022-06-03T18:35:22.582705Z
+
+- Update `terra-jupyter-base` to `1.0.10`
+  - Updated deeplearning-platform-release from tf-gpu.2-7 to tf-gpu.2-9. 
+  - Changed ownership of /opt/conda to $USER:users.
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:2.1.4`
+
 ## 2.1.3 - 2022-05-20T18:06:39.587654Z
 
 - Update `terra-jupyter-base` to `1.0.9`

--- a/terra-jupyter-aou/CHANGELOG.md
+++ b/terra-jupyter-aou/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## 2.1.4 - 2022-06-03T18:35:22.582705Z
 
 - Update `terra-jupyter-base` to `1.0.10`
-  - Updated deeplearning-platform-release from tf-gpu.2-7 to tf-gpu.2-9. 
-  - Changed ownership of /opt/conda to $USER:users.
+  - Update deeplearning-platform-release from tf-gpu.2-7 to tf-gpu.2-9. 
+  - Change ownership of /opt/conda to $USER:users.
 
 Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:2.1.4`
 

--- a/terra-jupyter-aou/CHANGELOG.md
+++ b/terra-jupyter-aou/CHANGELOG.md
@@ -1,12 +1,10 @@
-<<<<<<< HEAD
-## 2.1.4 - 2022-06-03T18:35:22.582705Z
+## 2.1.6 - 2022-06-13T18:35:22.582705Z
 
 - Update `terra-jupyter-base` to `1.0.10`
   - Update deeplearning-platform-release from tf-gpu.2-7 to tf-gpu.2-9. 
   - Change ownership of /opt/conda to $USER:users.
 
 Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:2.1.4`
-=======
 ## 2.1.5 - 2022-06-09
 
 - Update `terra-jupyter-gatk` base to `2.2.5`
@@ -18,7 +16,6 @@ Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:2.1.5`
 ## 2.1.4 - 2022-06-03T18:35:22.582705Z
 
 - reverted, do not use
->>>>>>> master
 
 ## 2.1.3 - 2022-05-20T18:06:39.587654Z
 

--- a/terra-jupyter-aou/Dockerfile
+++ b/terra-jupyter-aou/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.2.3
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.2.4
 
 USER root
 
@@ -185,5 +185,7 @@ RUN R -e 'BiocManager::install(c("GENESIS"))'
 # and the jupyter user will have readonly access to the conda path.
 ENV R_LIBS /usr/local/lib/R/site-library:/opt/conda/lib/R/library
 RUN conda install -c bioconda r-saige
+
+RUN chown -R $USER:users /opt/conda
 
 USER $USER

--- a/terra-jupyter-base/CHANGELOG.md
+++ b/terra-jupyter-base/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.0.10 - 2022-06-03T18:35:22.276580Z
+## 1.0.10 - 2022-06-13T18:35:22.276580Z
 
 - Update deeplearning-platform-release from tf-gpu.2-7 to tf-gpu.2-9. 
   - Change ownership of /opt/conda to $USER:users.

--- a/terra-jupyter-base/CHANGELOG.md
+++ b/terra-jupyter-base/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.0.10 - 2022-06-03T18:35:22.276580Z
+
+- Updated deeplearning-platform-release from tf-gpu.2-7 to tf-gpu.2-9. 
+  - Changed ownership of /opt/conda to $USER:users.
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.0.10`
+
 ## 1.0.9 - 2022-05-20T18:06:39.404395Z
 
 - Fix adding workspace_cromwell.py script to manage Cromwell App

--- a/terra-jupyter-base/CHANGELOG.md
+++ b/terra-jupyter-base/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 1.0.10 - 2022-06-03T18:35:22.276580Z
 
-- Updated deeplearning-platform-release from tf-gpu.2-7 to tf-gpu.2-9. 
-  - Changed ownership of /opt/conda to $USER:users.
+- Update deeplearning-platform-release from tf-gpu.2-7 to tf-gpu.2-9. 
+  - Change ownership of /opt/conda to $USER:users.
 
 Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.0.10`
 

--- a/terra-jupyter-base/Dockerfile
+++ b/terra-jupyter-base/Dockerfile
@@ -1,6 +1,6 @@
 # adapted from https://hub.docker.com/r/jupyter/base-notebook/ AKA https://github.com/jupyter/docker-stacks/tree/master/base-notebook
 
-FROM gcr.io/deeplearning-platform-release/tf-gpu.2-7
+FROM gcr.io/deeplearning-platform-release/tf-gpu.2-9
 
 USER root
 
@@ -21,7 +21,6 @@ RUN sudo -i \
 # see article: https://developer.nvidia.com/blog/updating-the-cuda-linux-gpg-repository-key/
 # first we remove the bad keys from base image (https://github.com/NVIDIA/nvidia-docker/issues/1631#issuecomment-1112828208)
 RUN rm /etc/apt/sources.list.d/cuda.list \
-    && rm /etc/apt/sources.list.d/nvidia-ml.list \
     && sudo apt-key del 7fa2af80 \
     && curl -L -O https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.0-1_all.deb \
     && sudo dpkg -i cuda-keyring_1.0-1_all.deb
@@ -148,6 +147,8 @@ RUN chown -R $USER:users $JUPYTER_HOME \
  && find $JUPYTER_HOME/scripts -name '*.sh' -type f | xargs chmod +x \
 #  You can get kernel directory by running `jupyter kernelspec list`
  && $JUPYTER_HOME/scripts/kernel/kernelspec.sh $JUPYTER_HOME/scripts/kernel /opt/conda/share/jupyter/kernels
+
+RUN chown -R $USER:users /opt/conda
 
 USER $USER
 EXPOSE $JUPYTER_PORT

--- a/terra-jupyter-bioconductor/CHANGELOG.md
+++ b/terra-jupyter-bioconductor/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2.1.4 - 2022-06-03T18:35:22.326908Z
+
+- Update `terra-jupyter-base` to `1.0.10`
+  - Updated deeplearning-platform-release from tf-gpu.2-7 to tf-gpu.2-9. 
+  - Changed ownership of /opt/conda to $USER:users.
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:2.1.4`
+
 ## 2.1.3 - 2022-05-20T18:06:39.449113Z
 
 - Update `terra-jupyter-base` to `1.0.9`

--- a/terra-jupyter-bioconductor/CHANGELOG.md
+++ b/terra-jupyter-bioconductor/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## 2.1.4 - 2022-06-03T18:35:22.326908Z
 
 - Update `terra-jupyter-base` to `1.0.10`
-  - Updated deeplearning-platform-release from tf-gpu.2-7 to tf-gpu.2-9. 
-  - Changed ownership of /opt/conda to $USER:users.
+  - Update deeplearning-platform-release from tf-gpu.2-7 to tf-gpu.2-9. 
+  - Change ownership of /opt/conda to $USER:users.
 
 Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:2.1.4`
 

--- a/terra-jupyter-bioconductor/CHANGELOG.md
+++ b/terra-jupyter-bioconductor/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.1.4 - 2022-06-03T18:35:22.326908Z
+## 2.1.4 - 2022-06-13T18:35:22.326908Z
 
 - Update `terra-jupyter-base` to `1.0.10`
   - Update deeplearning-platform-release from tf-gpu.2-7 to tf-gpu.2-9. 

--- a/terra-jupyter-bioconductor/Dockerfile
+++ b/terra-jupyter-bioconductor/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.1.3
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.1.4
 
 USER root
 
@@ -6,5 +6,7 @@ USER root
 RUN curl -O https://raw.githubusercontent.com/Bioconductor/anvil-docker/master/anvil-rstudio-bioconductor/install.R \
 	&& R -f install.R \
 	&& rm -rf install.R
+
+RUN chown -R $USER:users /opt/conda
 
 USER $USER

--- a/terra-jupyter-gatk-ovtf/CHANGELOG.md
+++ b/terra-jupyter-gatk-ovtf/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.2.4 - 2022-06-03T18:35:22.604973Z
+## 0.2.4 - 2022-06-13T18:35:22.604973Z
 
 - Update `terra-jupyter-base` to `1.0.10`
   - Update deeplearning-platform-release from tf-gpu.2-7 to tf-gpu.2-9. 

--- a/terra-jupyter-gatk-ovtf/CHANGELOG.md
+++ b/terra-jupyter-gatk-ovtf/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## 0.2.4 - 2022-06-03T18:35:22.604973Z
 
 - Update `terra-jupyter-base` to `1.0.10`
-  - Updated deeplearning-platform-release from tf-gpu.2-7 to tf-gpu.2-9. 
-  - Changed ownership of /opt/conda to $USER:users.
+  - Update deeplearning-platform-release from tf-gpu.2-7 to tf-gpu.2-9. 
+  - Change ownership of /opt/conda to $USER:users.
 
 Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk-ovtf:0.2.4`
 

--- a/terra-jupyter-gatk-ovtf/CHANGELOG.md
+++ b/terra-jupyter-gatk-ovtf/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.2.4 - 2022-06-03T18:35:22.604973Z
+
+- Update `terra-jupyter-base` to `1.0.10`
+  - Updated deeplearning-platform-release from tf-gpu.2-7 to tf-gpu.2-9. 
+  - Changed ownership of /opt/conda to $USER:users.
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk-ovtf:0.2.4`
+
 ## 0.2.3 - 2022-05-20T18:06:39.600661Z
 
 - Update `terra-jupyter-base` to `1.0.9`

--- a/terra-jupyter-gatk-ovtf/Dockerfile
+++ b/terra-jupyter-gatk-ovtf/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.10 AS python
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.12 AS python
 
 FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.1.4
 

--- a/terra-jupyter-gatk-ovtf/Dockerfile
+++ b/terra-jupyter-gatk-ovtf/Dockerfile
@@ -1,6 +1,6 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.9 AS python
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.10 AS python
 
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.1.3
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.1.4
 
 # copy everything pip installed from the python image
 COPY --from=python /opt/conda/lib/python3.7/site-packages /opt/conda/lib/python3.7/site-packages
@@ -67,4 +67,6 @@ COPY --chown=jupyter:users run_gatk.sh /home/jupyter/run_gatk.sh
 COPY --chown=jupyter:users GATK-OVTF-Notebook.ipynb /home/jupyter/GATK-OVTF-Notebook.ipynb
 
 ENV USER jupyter
+RUN chown -R $USER:users /opt/conda
+
 USER $USER

--- a/terra-jupyter-gatk/CHANGELOG.md
+++ b/terra-jupyter-gatk/CHANGELOG.md
@@ -1,12 +1,11 @@
-<<<<<<< HEAD
-## 2.2.4 - 2022-06-03T18:35:22.539434Z
+## 2.2.6 - 2022-06-13T18:35:22.539434Z
 
 - Update `terra-jupyter-base` to `1.0.10`
   - Update deeplearning-platform-release from tf-gpu.2-7 to tf-gpu.2-9. 
   - Change ownership of /opt/conda to $USER:users.
 
 Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.2.4`
-=======
+
 ## 2.2.5 - 2022-06-09
 
 - Improve Python package matching from -python image. No longer causes downstream
@@ -17,7 +16,6 @@ Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.2.5`
 ## 2.2.4 - 2022-06-03T18:35:22.539434Z
 
 - reverted, do not use
->>>>>>> master
 
 ## 2.2.3 - 2022-05-20T18:06:39.552362Z
 

--- a/terra-jupyter-gatk/CHANGELOG.md
+++ b/terra-jupyter-gatk/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## 2.2.4 - 2022-06-03T18:35:22.539434Z
 
 - Update `terra-jupyter-base` to `1.0.10`
-  - Updated deeplearning-platform-release from tf-gpu.2-7 to tf-gpu.2-9. 
-  - Changed ownership of /opt/conda to $USER:users.
+  - Update deeplearning-platform-release from tf-gpu.2-7 to tf-gpu.2-9. 
+  - Change ownership of /opt/conda to $USER:users.
 
 Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.2.4`
 

--- a/terra-jupyter-gatk/CHANGELOG.md
+++ b/terra-jupyter-gatk/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2.2.4 - 2022-06-03T18:35:22.539434Z
+
+- Update `terra-jupyter-base` to `1.0.10`
+  - Updated deeplearning-platform-release from tf-gpu.2-7 to tf-gpu.2-9. 
+  - Changed ownership of /opt/conda to $USER:users.
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.2.4`
+
 ## 2.2.3 - 2022-05-20T18:06:39.552362Z
 
 - Update `terra-jupyter-base` to `1.0.9`

--- a/terra-jupyter-gatk/Dockerfile
+++ b/terra-jupyter-gatk/Dockerfile
@@ -1,12 +1,6 @@
-<<<<<<< HEAD
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.10 AS python
-
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.1.4
-=======
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.11 AS python
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.12 AS python
 
 RUN conda list -n base --explicit > /tmp/conda_packages.txt
->>>>>>> master
 
 FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.1.3
 

--- a/terra-jupyter-gatk/Dockerfile
+++ b/terra-jupyter-gatk/Dockerfile
@@ -1,6 +1,6 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.9 AS python
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.10 AS python
 
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.1.3
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.1.4
 
 # copy everything pip installed from the python image
 COPY --from=python /opt/conda/lib/python3.7/site-packages /opt/conda/lib/python3.7/site-packages
@@ -59,5 +59,7 @@ COPY cnn-models.patch /etc/gatk-$GATK_VERSION/cnn-models.patch
 RUN patch -u /opt/conda/lib/python3.7/site-packages/vqsr_cnn/vqsr_cnn/models.py -i /etc/gatk-$GATK_VERSION/cnn-models.patch
 
 ENV USER jupyter
+RUN chown -R $USER:users /opt/conda
+
 USER $USER
 

--- a/terra-jupyter-hail/CHANGELOG.md
+++ b/terra-jupyter-hail/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.0.16 - 2022-06-03T18:35:22.393865Z
+## 1.0.16 - 2022-06-13T18:35:22.393865Z
 
 - Update `terra-jupyter-base` to `1.0.10`
   - Update deeplearning-platform-release from tf-gpu.2-7 to tf-gpu.2-9. 

--- a/terra-jupyter-hail/CHANGELOG.md
+++ b/terra-jupyter-hail/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## 1.0.16 - 2022-06-03T18:35:22.393865Z
 
 - Update `terra-jupyter-base` to `1.0.10`
-  - Updated deeplearning-platform-release from tf-gpu.2-7 to tf-gpu.2-9. 
-  - Changed ownership of /opt/conda to $USER:users.
+  - Update deeplearning-platform-release from tf-gpu.2-7 to tf-gpu.2-9. 
+  - Change ownership of /opt/conda to $USER:users.
 
 Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-hail:1.0.16`
 

--- a/terra-jupyter-hail/CHANGELOG.md
+++ b/terra-jupyter-hail/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.0.16 - 2022-06-03T18:35:22.393865Z
+
+- Update `terra-jupyter-base` to `1.0.10`
+  - Updated deeplearning-platform-release from tf-gpu.2-7 to tf-gpu.2-9. 
+  - Changed ownership of /opt/conda to $USER:users.
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-hail:1.0.16`
+
 ## 1.0.15 - 2022-05-20T18:06:39.466439Z
 
 - Update `terra-jupyter-base` to `1.0.9`

--- a/terra-jupyter-hail/Dockerfile
+++ b/terra-jupyter-hail/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.9
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.10
 USER root
 
 ENV PIP_USER=false
@@ -32,4 +32,7 @@ RUN find $JUPYTER_HOME/scripts -name '*.sh' -type f | xargs chmod +x \
     && rm -rf /var/lib/apt/lists/*
 
 ENV PIP_USER=true
+
+RUN chown -R $USER:users /opt/conda
+
 USER $USER

--- a/terra-jupyter-hail/Dockerfile
+++ b/terra-jupyter-hail/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.10
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.12
 USER root
 
 ENV PIP_USER=false

--- a/terra-jupyter-python/CHANGELOG.md
+++ b/terra-jupyter-python/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.0.12 - 2022-06-13T18:35:22.435328Z
+
+- Update `terra-jupyter-base` to `1.0.10`
+  - Update deeplearning-platform-release from tf-gpu.2-7 to tf-gpu.2-9. 
+  - Change ownership of /opt/conda to $USER:users.
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.10`
+
 ## 1.0.11 - 2022-06-09
 
 - Switch to requirements.txt file

--- a/terra-jupyter-python/CHANGELOG.md
+++ b/terra-jupyter-python/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.0.10 - 2022-06-03T18:35:22.435328Z
+
+- Update `terra-jupyter-base` to `1.0.10`
+  - Updated deeplearning-platform-release from tf-gpu.2-7 to tf-gpu.2-9. 
+  - Changed ownership of /opt/conda to $USER:users.
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.10`
+
 ## 1.0.9 - 2022-05-20T18:06:39.493915Z
 
 - Update `terra-jupyter-base` to `1.0.9`

--- a/terra-jupyter-python/CHANGELOG.md
+++ b/terra-jupyter-python/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## 1.0.10 - 2022-06-03T18:35:22.435328Z
 
 - Update `terra-jupyter-base` to `1.0.10`
-  - Updated deeplearning-platform-release from tf-gpu.2-7 to tf-gpu.2-9. 
-  - Changed ownership of /opt/conda to $USER:users.
+  - Update deeplearning-platform-release from tf-gpu.2-7 to tf-gpu.2-9. 
+  - Change ownership of /opt/conda to $USER:users.
 
 Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.10`
 

--- a/terra-jupyter-python/Dockerfile
+++ b/terra-jupyter-python/Dockerfile
@@ -33,7 +33,6 @@ COPY requirements.txt /etc/terra-docker/
 RUN pip3 -V \
  && pip3 install --upgrade pip \
  && pip3 install --upgrade -r /etc/terra-docker/requirements.txt \
-
  # Remove this after https://broadworkbench.atlassian.net/browse/CA-1179
  # As of release [google-cloud-bigquery 1.26.0 (2020-07-20)](https://github.com/googleapis/python-bigquery/blob/master/CHANGELOG.md#1260-2020-07-20)
  # the BigQuery Python client uses the BigQuery Storage client by default.

--- a/terra-jupyter-python/Dockerfile
+++ b/terra-jupyter-python/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.0.9
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.0.10
 USER root
 # This makes it so pip runs as root, not the user.
 ENV PIP_USER=false
@@ -99,6 +99,8 @@ RUN pip3 -V \
 RUN pip3 install --upgrade markupsafe==2.0.1
 
 ENV USER jupyter
+RUN chown -R $USER:users /opt/conda
+
 USER $USER
 # We want pip to install into the user's dir when the notebook is running.
 ENV PIP_USER=true

--- a/terra-jupyter-r/CHANGELOG.md
+++ b/terra-jupyter-r/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2.1.4 - 2022-06-03T18:35:22.503157Z
+
+- Update `terra-jupyter-base` to `1.0.10`
+  - Updated deeplearning-platform-release from tf-gpu.2-7 to tf-gpu.2-9. 
+  - Changed ownership of /opt/conda to $USER:users.
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.1.4`
+
 ## 2.1.3 - 2022-05-20T18:06:39.532374Z
 
 - Update `terra-jupyter-base` to `1.0.9`

--- a/terra-jupyter-r/CHANGELOG.md
+++ b/terra-jupyter-r/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.1.4 - 2022-06-03T18:35:22.503157Z
+## 2.1.4 - 2022-06-13T18:35:22.503157Z
 
 - Update `terra-jupyter-base` to `1.0.10`
   - Update deeplearning-platform-release from tf-gpu.2-7 to tf-gpu.2-9. 

--- a/terra-jupyter-r/CHANGELOG.md
+++ b/terra-jupyter-r/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## 2.1.4 - 2022-06-03T18:35:22.503157Z
 
 - Update `terra-jupyter-base` to `1.0.10`
-  - Updated deeplearning-platform-release from tf-gpu.2-7 to tf-gpu.2-9. 
-  - Changed ownership of /opt/conda to $USER:users.
+  - Update deeplearning-platform-release from tf-gpu.2-7 to tf-gpu.2-9. 
+  - Change ownership of /opt/conda to $USER:users.
 
 Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.1.4`
 

--- a/terra-jupyter-r/Dockerfile
+++ b/terra-jupyter-r/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.0.9
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.0.10
 USER root
 
 COPY scripts $JUPYTER_HOME/scripts
@@ -159,5 +159,7 @@ ENV PIP_USER=true
 
 RUN R -e 'IRkernel::installspec(user=FALSE)' \
     && chown -R $USER:users /usr/local/lib/R/site-library
+
+RUN chown -R $USER:users /opt/conda
 
 USER $USER


### PR DESCRIPTION
## Description

User runs conda install <package> and gets permissions error.
The conda installation and associated packages are owned by root:root, so when the "jupyter" user goes to install they will not have permissions to make changes.

## Solution
Enable users to have greater control over Conda installs by changing ownership of /opt/conda

Also update to newer version of conda by upgrading the deeplearning base image.