### PR TITLE
AoU: keep igv-jupyter on 1.x.x, the most recent known working version

### DIFF
--- a/terra-jupyter-aou/Dockerfile
+++ b/terra-jupyter-aou/Dockerfile
@@ -38,7 +38,8 @@ RUN pip3 install \
       dsub \
       "git+https://github.com/all-of-us/workbench-snippets.git#egg=terra_widgets&subdirectory=py"
 
-RUN pip3 install igv-jupyter
+# 2.0.0 has breaking changes and we're not ready for them yet.
+RUN pip3 install "igv-jupyter>=1.0.0,<2.0.0"
 RUN jupyter nbextension enable --py igv --sys-prefix
 
 # Spark/Hail setup.


### PR DESCRIPTION
2.0.0 was just released, and causes issues.