### PR TITLE
Drop unused conda line

### DIFF
--- a/terra-jupyter-gatk/Dockerfile
+++ b/terra-jupyter-gatk/Dockerfile
@@ -1,7 +1,5 @@
 FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.11 AS python
 
-RUN conda list -n base --explicit > /tmp/conda_packages.txt
-
 FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.1.3
 
 USER root


### PR DESCRIPTION
This was accidentally left in from a previous failed approach. Innocuous, I don't see a need to cut a new version.