### PR TITLE
[IA-3261] Change ownership of /opt/conda to give users the ability to run conda install

### DIFF
--- a/config/conf.json
+++ b/config/conf.json
@@ -26,7 +26,7 @@
                     "tidyverse"
                 ]
             },
-            "version" : "2.1.5",
+            "version" : "2.1.6",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : true,
@@ -68,7 +68,7 @@
                     "scikit-learn"
                 ]
             },
-            "version" : "1.0.13",
+            "version" : "1.0.14",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : true,
@@ -83,8 +83,10 @@
             "tools" : [
                 "python"
             ],
-            "packages" : {},
-            "version" : "1.0.11",
+            "packages" : {
+                
+            },
+            "version" : "1.0.12",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : false,
@@ -99,8 +101,10 @@
             "tools" : [
                 "r"
             ],
-            "packages" : {},
-            "version" : "2.1.5",
+            "packages" : {
+                
+            },
+            "version" : "2.1.6",
             "automated_flags" : {
                 "include_in_ui" : false,
                 "generate_docs" : true,
@@ -117,8 +121,10 @@
                 "python",
                 "r"
             ],
-            "packages" : {},
-            "version" : "2.2.7",
+            "packages" : {
+                
+            },
+            "version" : "2.2.8",
             "automated_flags" : {
                 "include_in_ui" : true,
                 "generate_docs" : true,
@@ -134,8 +140,10 @@
                 "python",
                 "r"
             ],
-            "packages" : {},
-            "version" : "2.1.6",
+            "packages" : {
+                
+            },
+            "version" : "2.1.7",
             "automated_flags" : {
                 "include_in_ui" : false,
                 "generate_docs" : false,
@@ -152,8 +160,10 @@
                 "python",
                 "r"
             ],
-            "packages" : {},
-            "version" : "0.2.5",
+            "packages" : {
+                
+            },
+            "version" : "0.2.6",
             "automated_flags" : {
                 "include_in_ui" : false,
                 "generate_docs" : true,

--- a/terra-jupyter-aou/CHANGELOG.md
+++ b/terra-jupyter-aou/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.1.7 - 2022-07-05T14:07:53.025073Z
+
+- Update `terra-jupyter-base` to `1.0.12`
+  - Change ownership of the Conda install to $USER:users.
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:2.1.7`
+
 ## 2.1.6 - 2022-06-23T10:58:12.961300Z
 
 - Update `terra-jupyter-base` to `1.0.10`

--- a/terra-jupyter-aou/Dockerfile
+++ b/terra-jupyter-aou/Dockerfile
@@ -1,4 +1,12 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.2.7
+<<<<<<< HEAD
+<<<<<<< HEAD
+FROM  us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.2.8
+=======
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.2.8
+>>>>>>> 4d5c1cf (Updated dockerfiles for changing ownership of conda install, and updated the README files with updateVersion.sc.)
+=======
+FROM  us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.2.8
+>>>>>>> 1bc0385 (Updates to images. WIP.)
 
 USER root
 
@@ -190,6 +198,16 @@ RUN R -e 'BiocManager::install(c("GENESIS"))'
 # and the jupyter user will have readonly access to the conda path.
 ENV R_LIBS /usr/local/lib/R/site-library:/opt/conda/lib/R/library
 RUN conda install -c bioconda r-saige
+
+<<<<<<< HEAD
+<<<<<<< HEAD
+RUN conda create --clone base -n user-aou -y
+=======
+RUN chown -R $USER:users /opt/conda
+>>>>>>> 4d5c1cf (Updated dockerfiles for changing ownership of conda install, and updated the README files with updateVersion.sc.)
+=======
+RUN conda create --clone base -n user-aou -y
+>>>>>>> 1bc0385 (Updates to images. WIP.)
 
 ENV PIP_USER=true
 USER $USER

--- a/terra-jupyter-aou/Dockerfile
+++ b/terra-jupyter-aou/Dockerfile
@@ -1,16 +1,4 @@
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
 FROM  us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.2.8
-=======
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.2.8
->>>>>>> 4d5c1cf (Updated dockerfiles for changing ownership of conda install, and updated the README files with updateVersion.sc.)
-=======
-FROM  us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.2.8
->>>>>>> 1bc0385 (Updates to images. WIP.)
-=======
-FROM  us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.2.8
->>>>>>> f674eed999b1f0f4a03935b27c6df4787b811817
 
 USER root
 
@@ -203,19 +191,7 @@ RUN R -e 'BiocManager::install(c("GENESIS"))'
 ENV R_LIBS /usr/local/lib/R/site-library:/opt/conda/lib/R/library
 RUN conda install -c bioconda r-saige
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
 RUN conda create --clone base -n user-aou -y
-=======
-RUN chown -R $USER:users /opt/conda
->>>>>>> 4d5c1cf (Updated dockerfiles for changing ownership of conda install, and updated the README files with updateVersion.sc.)
-=======
-RUN conda create --clone base -n user-aou -y
->>>>>>> 1bc0385 (Updates to images. WIP.)
-=======
-RUN conda create --clone base -n user-aou -y
->>>>>>> f674eed999b1f0f4a03935b27c6df4787b811817
 
 ENV PIP_USER=true
 USER $USER

--- a/terra-jupyter-base/CHANGELOG.md
+++ b/terra-jupyter-base/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 1.0.12 - 2022-07-05T14:07:52.764771Z
+
+<<<<<<< HEAD
+<<<<<<< HEAD
+- Change ownership of the Conda install to $USER:users.
+=======
+- Change ownership of the Conda install to NLANDOLTsers.
+>>>>>>> 4d5c1cf (Updated dockerfiles for changing ownership of conda install, and updated the README files with updateVersion.sc.)
+=======
+- Change ownership of the Conda install to $USER:users.
+>>>>>>> c843968 (Fixed NLANDOLT to nlandolt)
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.0.12`
+
 ## 1.0.11 - 2022-06-23T10:58:12.961300Z
 
 - Fix leo_url variable in workspace_cromwell.py script for AoU projects

--- a/terra-jupyter-base/CHANGELOG.md
+++ b/terra-jupyter-base/CHANGELOG.md
@@ -1,18 +1,5 @@
 ## 1.0.12 - 2022-07-05T14:07:52.764771Z
-
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
 - Change ownership of the Conda install to $USER:users.
-=======
-- Change ownership of the Conda install to NLANDOLTsers.
->>>>>>> 4d5c1cf (Updated dockerfiles for changing ownership of conda install, and updated the README files with updateVersion.sc.)
-=======
-- Change ownership of the Conda install to $USER:users.
->>>>>>> c843968 (Fixed NLANDOLT to nlandolt)
-=======
-- Change ownership of the Conda install to $USER:users.
->>>>>>> f674eed999b1f0f4a03935b27c6df4787b811817
 
 Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.0.12`
 

--- a/terra-jupyter-base/Dockerfile
+++ b/terra-jupyter-base/Dockerfile
@@ -148,19 +148,7 @@ RUN chown -R $USER:users $JUPYTER_HOME \
 #  You can get kernel directory by running `jupyter kernelspec list`
  && $JUPYTER_HOME/scripts/kernel/kernelspec.sh $JUPYTER_HOME/scripts/kernel /opt/conda/share/jupyter/kernels
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
 RUN conda create --clone base -n user-base -y
-=======
-RUN chown -R $USER:users /opt/conda
->>>>>>> 4d5c1cf (Updated dockerfiles for changing ownership of conda install, and updated the README files with updateVersion.sc.)
-=======
-RUN conda create --clone base -n user-base -y
->>>>>>> 1bc0385 (Updates to images. WIP.)
-=======
-RUN conda create --clone base -n user-base -y
->>>>>>> f674eed999b1f0f4a03935b27c6df4787b811817
 
 USER $USER
 EXPOSE $JUPYTER_PORT

--- a/terra-jupyter-base/Dockerfile
+++ b/terra-jupyter-base/Dockerfile
@@ -1,6 +1,6 @@
 # adapted from https://hub.docker.com/r/jupyter/base-notebook/ AKA https://github.com/jupyter/docker-stacks/tree/master/base-notebook
 
-FROM gcr.io/deeplearning-platform-release/tf-gpu.2-7
+FROM gcr.io/deeplearning-platform-release/tf-gpu.2-9
 
 USER root
 
@@ -21,7 +21,6 @@ RUN sudo -i \
 # see article: https://developer.nvidia.com/blog/updating-the-cuda-linux-gpg-repository-key/
 # first we remove the bad keys from base image (https://github.com/NVIDIA/nvidia-docker/issues/1631#issuecomment-1112828208)
 RUN rm /etc/apt/sources.list.d/cuda.list \
-    && rm /etc/apt/sources.list.d/nvidia-ml.list \
     && sudo apt-key del 7fa2af80 \
     && curl -L -O https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.0-1_all.deb \
     && sudo dpkg -i cuda-keyring_1.0-1_all.deb
@@ -148,6 +147,16 @@ RUN chown -R $USER:users $JUPYTER_HOME \
  && find $JUPYTER_HOME/scripts -name '*.sh' -type f | xargs chmod +x \
 #  You can get kernel directory by running `jupyter kernelspec list`
  && $JUPYTER_HOME/scripts/kernel/kernelspec.sh $JUPYTER_HOME/scripts/kernel /opt/conda/share/jupyter/kernels
+
+<<<<<<< HEAD
+<<<<<<< HEAD
+RUN conda create --clone base -n user-base -y
+=======
+RUN chown -R $USER:users /opt/conda
+>>>>>>> 4d5c1cf (Updated dockerfiles for changing ownership of conda install, and updated the README files with updateVersion.sc.)
+=======
+RUN conda create --clone base -n user-base -y
+>>>>>>> 1bc0385 (Updates to images. WIP.)
 
 USER $USER
 EXPOSE $JUPYTER_PORT

--- a/terra-jupyter-bioconductor/CHANGELOG.md
+++ b/terra-jupyter-bioconductor/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 2.1.6 - 2022-07-05T14:07:52.807933Z
+
+- Update `terra-jupyter-base` to `1.0.12`
+<<<<<<< HEAD
+<<<<<<< HEAD
+  - Change ownership of the Conda install to $USER:users.
+=======
+  - Change ownership of the Conda install to NLANDOLTsers.
+>>>>>>> 4d5c1cf (Updated dockerfiles for changing ownership of conda install, and updated the README files with updateVersion.sc.)
+=======
+  - Change ownership of the Conda install to $USER:users.
+>>>>>>> c843968 (Fixed NLANDOLT to nlandolt)
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:2.1.6`
+
 ## 2.1.5 - 2022-05-20T18:06:39.449113Z
 
 - Update `terra-jupyter-base` to `1.0.10`

--- a/terra-jupyter-bioconductor/CHANGELOG.md
+++ b/terra-jupyter-bioconductor/CHANGELOG.md
@@ -1,19 +1,7 @@
 ## 2.1.6 - 2022-07-05T14:07:52.807933Z
 
 - Update `terra-jupyter-base` to `1.0.12`
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
   - Change ownership of the Conda install to $USER:users.
-=======
-  - Change ownership of the Conda install to NLANDOLTsers.
->>>>>>> 4d5c1cf (Updated dockerfiles for changing ownership of conda install, and updated the README files with updateVersion.sc.)
-=======
-  - Change ownership of the Conda install to $USER:users.
->>>>>>> c843968 (Fixed NLANDOLT to nlandolt)
-=======
-  - Change ownership of the Conda install to $USER:users.
->>>>>>> f674eed999b1f0f4a03935b27c6df4787b811817
 
 Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:2.1.6`
 

--- a/terra-jupyter-bioconductor/Dockerfile
+++ b/terra-jupyter-bioconductor/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.1.5
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.1.6
 
 USER root
 

--- a/terra-jupyter-gatk-ovtf/CHANGELOG.md
+++ b/terra-jupyter-gatk-ovtf/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 0.2.6 - 2022-07-05T14:07:53.046089Z
+
+- Update `terra-jupyter-base` to `1.0.12`
+<<<<<<< HEAD
+<<<<<<< HEAD
+  - Change ownership of the Conda install to $USER:users.
+=======
+  - Change ownership of the Conda install to NLANDOLTsers.
+>>>>>>> 4d5c1cf (Updated dockerfiles for changing ownership of conda install, and updated the README files with updateVersion.sc.)
+=======
+  - Change ownership of the Conda install to $USER:users.
+>>>>>>> c843968 (Fixed NLANDOLT to nlandolt)
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk-ovtf:0.2.6`
+
 ## 0.2.5 - 2022-06-23T10:58:12.961300Z
 
 - Update `terra-jupyter-base` to `1.0.10`

--- a/terra-jupyter-gatk-ovtf/CHANGELOG.md
+++ b/terra-jupyter-gatk-ovtf/CHANGELOG.md
@@ -1,19 +1,7 @@
 ## 0.2.6 - 2022-07-05T14:07:53.046089Z
 
 - Update `terra-jupyter-base` to `1.0.12`
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
   - Change ownership of the Conda install to $USER:users.
-=======
-  - Change ownership of the Conda install to NLANDOLTsers.
->>>>>>> 4d5c1cf (Updated dockerfiles for changing ownership of conda install, and updated the README files with updateVersion.sc.)
-=======
-  - Change ownership of the Conda install to $USER:users.
->>>>>>> c843968 (Fixed NLANDOLT to nlandolt)
-=======
-  - Change ownership of the Conda install to $USER:users.
->>>>>>> f674eed999b1f0f4a03935b27c6df4787b811817
 
 Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk-ovtf:0.2.6`
 

--- a/terra-jupyter-gatk-ovtf/Dockerfile
+++ b/terra-jupyter-gatk-ovtf/Dockerfile
@@ -1,6 +1,6 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.11 AS python
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.13 AS python
 
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.1.5
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.1.7
 
 # copy everything pip installed from the python image
 COPY --from=python /opt/conda/lib/python3.7/site-packages /opt/conda/lib/python3.7/site-packages

--- a/terra-jupyter-gatk/CHANGELOG.md
+++ b/terra-jupyter-gatk/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 2.2.8 - 2022-07-05T14:07:52.984966Z
+
+- Update `terra-jupyter-base` to `1.0.12`
+<<<<<<< HEAD
+<<<<<<< HEAD
+  - Change ownership of the Conda install to $USER:users.
+=======
+  - Change ownership of the Conda install to NLANDOLTsers.
+>>>>>>> 4d5c1cf (Updated dockerfiles for changing ownership of conda install, and updated the README files with updateVersion.sc.)
+=======
+  - Change ownership of the Conda install to $USER:users.
+>>>>>>> c843968 (Fixed NLANDOLT to nlandolt)
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.2.8`
+
 ## 2.2.7 - 2022-06-23T10:58:12.961300Z
 
 - Update `terra-jupyter-base` to `1.0.10`

--- a/terra-jupyter-gatk/CHANGELOG.md
+++ b/terra-jupyter-gatk/CHANGELOG.md
@@ -1,19 +1,7 @@
 ## 2.2.8 - 2022-07-05T14:07:52.984966Z
 
 - Update `terra-jupyter-base` to `1.0.12`
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
   - Change ownership of the Conda install to $USER:users.
-=======
-  - Change ownership of the Conda install to NLANDOLTsers.
->>>>>>> 4d5c1cf (Updated dockerfiles for changing ownership of conda install, and updated the README files with updateVersion.sc.)
-=======
-  - Change ownership of the Conda install to $USER:users.
->>>>>>> c843968 (Fixed NLANDOLT to nlandolt)
-=======
-  - Change ownership of the Conda install to $USER:users.
->>>>>>> f674eed999b1f0f4a03935b27c6df4787b811817
 
 Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.2.8`
 

--- a/terra-jupyter-gatk/Dockerfile
+++ b/terra-jupyter-gatk/Dockerfile
@@ -63,18 +63,6 @@ RUN patch -u /opt/conda/lib/python3.7/site-packages/vqsr_cnn/vqsr_cnn/models.py 
 ENV PIP_USER=true
 
 ENV USER jupyter
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
 RUN conda create --clone base -n user-gatk -y
-=======
-RUN chown -R $USER:users /opt/conda
->>>>>>> 4d5c1cf (Updated dockerfiles for changing ownership of conda install, and updated the README files with updateVersion.sc.)
-=======
-RUN conda create --clone base -n user-gatk -y
->>>>>>> 1bc0385 (Updates to images. WIP.)
-=======
-RUN conda create --clone base -n user-gatk -y
->>>>>>> f674eed999b1f0f4a03935b27c6df4787b811817
 
 USER $USER

--- a/terra-jupyter-gatk/Dockerfile
+++ b/terra-jupyter-gatk/Dockerfile
@@ -1,6 +1,6 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.13 AS python
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.15 AS python
 
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.1.5
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.1.6
 
 USER root
 
@@ -63,4 +63,14 @@ RUN patch -u /opt/conda/lib/python3.7/site-packages/vqsr_cnn/vqsr_cnn/models.py 
 ENV PIP_USER=true
 
 ENV USER jupyter
+<<<<<<< HEAD
+<<<<<<< HEAD
+RUN conda create --clone base -n user-gatk -y
+=======
+RUN chown -R $USER:users /opt/conda
+>>>>>>> 4d5c1cf (Updated dockerfiles for changing ownership of conda install, and updated the README files with updateVersion.sc.)
+=======
+RUN conda create --clone base -n user-gatk -y
+>>>>>>> 1bc0385 (Updates to images. WIP.)
+
 USER $USER

--- a/terra-jupyter-hail/CHANGELOG.md
+++ b/terra-jupyter-hail/CHANGELOG.md
@@ -1,29 +1,12 @@
-<<<<<<< HEAD
-<<<<<<< HEAD
 ## 1.0.20 - 2022-07-05T14:07:52.844052Z
-=======
-## 1.0.19 - 2022-07-05T14:07:52.844052Z
->>>>>>> f674eed999b1f0f4a03935b27c6df4787b811817
-
 - Update `terra-jupyter-base` to `1.0.12`
   - Change ownership of the Conda install to $USER:users.
 
-<<<<<<< HEAD
 Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-hail:1.0.20`
 
-=======
->>>>>>> f674eed999b1f0f4a03935b27c6df4787b811817
 ## 1.0.19 - 2022-06-30
 - Update `hail` to `0.2.96`
   - See https://hail.is/docs/0.2/change_log.html#version-0-2-96) for details
-=======
-## 1.0.19 - 2022-07-05T14:07:52.844052Z
-
-- Update `terra-jupyter-base` to `1.0.12`
-  - Change ownership of the Conda install to $USER:users.
-
-Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-hail:1.0.19`
->>>>>>> 4d5c1cf (Updated dockerfiles for changing ownership of conda install, and updated the README files with updateVersion.sc.)
 
 ## 1.0.18 - 2022-06-23T10:58:12.961300Z
 

--- a/terra-jupyter-hail/CHANGELOG.md
+++ b/terra-jupyter-hail/CHANGELOG.md
@@ -1,8 +1,22 @@
+<<<<<<< HEAD
+## 1.0.20 - 2022-07-05T14:07:52.844052Z
+
+- Update `terra-jupyter-base` to `1.0.12`
+  - Change ownership of the Conda install to $USER:users.
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-hail:1.0.20`
+
 ## 1.0.19 - 2022-06-30
 - Update `hail` to `0.2.96`
   - See https://hail.is/docs/0.2/change_log.html#version-0-2-96) for details
+=======
+## 1.0.19 - 2022-07-05T14:07:52.844052Z
+
+- Update `terra-jupyter-base` to `1.0.12`
+  - Change ownership of the Conda install to $USER:users.
 
 Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-hail:1.0.19`
+>>>>>>> 4d5c1cf (Updated dockerfiles for changing ownership of conda install, and updated the README files with updateVersion.sc.)
 
 ## 1.0.18 - 2022-06-23T10:58:12.961300Z
 

--- a/terra-jupyter-hail/Dockerfile
+++ b/terra-jupyter-hail/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.11
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.13
 USER root
 
 ENV PIP_USER=false
@@ -34,4 +34,13 @@ RUN find $JUPYTER_HOME/scripts -name '*.sh' -type f | xargs chmod +x \
     && rm -rf /var/lib/apt/lists/*
 
 ENV PIP_USER=true
+
+<<<<<<< HEAD
+<<<<<<< HEAD
+=======
+RUN chown -R $USER:users /opt/conda
+
+>>>>>>> 4d5c1cf (Updated dockerfiles for changing ownership of conda install, and updated the README files with updateVersion.sc.)
+=======
+>>>>>>> 1bc0385 (Updates to images. WIP.)
 USER $USER

--- a/terra-jupyter-hail/Dockerfile
+++ b/terra-jupyter-hail/Dockerfile
@@ -35,15 +35,4 @@ RUN find $JUPYTER_HOME/scripts -name '*.sh' -type f | xargs chmod +x \
 
 ENV PIP_USER=true
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-RUN chown -R $USER:users /opt/conda
-
->>>>>>> 4d5c1cf (Updated dockerfiles for changing ownership of conda install, and updated the README files with updateVersion.sc.)
-=======
->>>>>>> 1bc0385 (Updates to images. WIP.)
-=======
->>>>>>> f674eed999b1f0f4a03935b27c6df4787b811817
 USER $USER

--- a/terra-jupyter-python/CHANGELOG.md
+++ b/terra-jupyter-python/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 1.0.14 - 2022-07-05T14:07:52.897562Z
+
+- Update `terra-jupyter-base` to `1.0.12`
+<<<<<<< HEAD
+<<<<<<< HEAD
+  - Change ownership of the Conda install to $USER:users.
+=======
+  - Change ownership of the Conda install to NLANDOLTsers.
+>>>>>>> 4d5c1cf (Updated dockerfiles for changing ownership of conda install, and updated the README files with updateVersion.sc.)
+=======
+  - Change ownership of the Conda install to $USER:users.
+>>>>>>> c843968 (Fixed NLANDOLT to nlandolt)
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.14`
+
 ## 1.0.13 - 2022-06-23T10:58:12.961300Z
 
 - Update `terra-jupyter-base` to `1.0.10`

--- a/terra-jupyter-python/CHANGELOG.md
+++ b/terra-jupyter-python/CHANGELOG.md
@@ -1,19 +1,7 @@
 ## 1.0.14 - 2022-07-05T14:07:52.897562Z
 
 - Update `terra-jupyter-base` to `1.0.12`
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
   - Change ownership of the Conda install to $USER:users.
-=======
-  - Change ownership of the Conda install to NLANDOLTsers.
->>>>>>> 4d5c1cf (Updated dockerfiles for changing ownership of conda install, and updated the README files with updateVersion.sc.)
-=======
-  - Change ownership of the Conda install to $USER:users.
->>>>>>> c843968 (Fixed NLANDOLT to nlandolt)
-=======
-  - Change ownership of the Conda install to $USER:users.
->>>>>>> f674eed999b1f0f4a03935b27c6df4787b811817
 
 Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.14`
 

--- a/terra-jupyter-python/Dockerfile
+++ b/terra-jupyter-python/Dockerfile
@@ -1,4 +1,18 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.0.11
+<<<<<<< HEAD
+<<<<<<< HEAD
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.0.13
+<<<<<<< HEAD
+
+=======
+>>>>>>> 4d5c1cf (Updated dockerfiles for changing ownership of conda install, and updated the README files with updateVersion.sc.)
+=======
+# FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.0.13
+FROM --platform=linux/amd64 us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:nlandolt-0.0.69
+=======
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.0.13
+>>>>>>> 1610975 (Removed local changes.)
+
+>>>>>>> 1bc0385 (Updates to images. WIP.)
 USER root
 # This makes it so pip runs as root, not the user.
 ENV PIP_USER=false
@@ -51,6 +65,14 @@ RUN pip3 -V \
 RUN pip3 install --upgrade markupsafe==2.0.1
 
 ENV USER jupyter
+<<<<<<< HEAD
+<<<<<<< HEAD
+=======
+RUN chown -R $USER:users /opt/conda
+>>>>>>> 4d5c1cf (Updated dockerfiles for changing ownership of conda install, and updated the README files with updateVersion.sc.)
+=======
+>>>>>>> 1bc0385 (Updates to images. WIP.)
+
 USER $USER
 # We want pip to install into the user's dir when the notebook is running.
 ENV PIP_USER=true

--- a/terra-jupyter-python/Dockerfile
+++ b/terra-jupyter-python/Dockerfile
@@ -1,23 +1,5 @@
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.0.13
-<<<<<<< HEAD
-
-=======
->>>>>>> 4d5c1cf (Updated dockerfiles for changing ownership of conda install, and updated the README files with updateVersion.sc.)
-=======
-# FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.0.13
-FROM --platform=linux/amd64 us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:nlandolt-0.0.69
-=======
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.0.13
->>>>>>> 1610975 (Removed local changes.)
-
->>>>>>> 1bc0385 (Updates to images. WIP.)
-=======
 FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.0.13
 
->>>>>>> f674eed999b1f0f4a03935b27c6df4787b811817
 USER root
 # This makes it so pip runs as root, not the user.
 ENV PIP_USER=false
@@ -70,16 +52,6 @@ RUN pip3 -V \
 RUN pip3 install --upgrade markupsafe==2.0.1
 
 ENV USER jupyter
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-RUN chown -R $USER:users /opt/conda
->>>>>>> 4d5c1cf (Updated dockerfiles for changing ownership of conda install, and updated the README files with updateVersion.sc.)
-=======
->>>>>>> 1bc0385 (Updates to images. WIP.)
-=======
->>>>>>> f674eed999b1f0f4a03935b27c6df4787b811817
 
 USER $USER
 # We want pip to install into the user's dir when the notebook is running.

--- a/terra-jupyter-r/CHANGELOG.md
+++ b/terra-jupyter-r/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.1.6 - 2022-07-05T14:07:52.958166Z
+
+- Update `terra-jupyter-base` to `1.0.12`
+  - Change ownership of the Conda install to $USER:users.
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.1.6`
+
 ## 2.1.5 - 2022-06-23T10:58:12.961300Z
 
 - Update `terra-jupyter-base` to `1.0.10`

--- a/terra-jupyter-r/Dockerfile
+++ b/terra-jupyter-r/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.0.11
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.0.13
 USER root
 
 COPY scripts $JUPYTER_HOME/scripts


### PR DESCRIPTION

Description

User runs conda install and gets permissions error.
The conda installation and associated packages are owned by root:root, so when the "jupyter" user goes to install they will not have permissions to make changes.
Solution

Enable users to have greater control over Conda installs by changing ownership of /opt/conda

Also update to newer version of conda by upgrading the deeplearning base image.
