### PR TITLE
[IA-3261] Updated dockerfiles and changelogs for conda install.

### DIFF
--- a/config/conf.json
+++ b/config/conf.json
@@ -26,7 +26,7 @@
                     "tidyverse"
                 ]
             },
-            "version" : "2.1.5",
+            "version" : "2.1.6",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : true,
@@ -47,7 +47,7 @@
                     "hail"
                 ]
             },
-            "version" : "1.0.19",
+            "version" : "1.0.20",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : true,
@@ -68,7 +68,7 @@
                     "scikit-learn"
                 ]
             },
-            "version" : "1.0.13",
+            "version" : "1.0.14",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : true,
@@ -83,8 +83,10 @@
             "tools" : [
                 "python"
             ],
-            "packages" : {},
-            "version" : "1.0.11",
+            "packages" : {
+                
+            },
+            "version" : "1.0.12",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : false,
@@ -99,8 +101,10 @@
             "tools" : [
                 "r"
             ],
-            "packages" : {},
-            "version" : "2.1.5",
+            "packages" : {
+                
+            },
+            "version" : "2.1.6",
             "automated_flags" : {
                 "include_in_ui" : false,
                 "generate_docs" : true,
@@ -117,8 +121,10 @@
                 "python",
                 "r"
             ],
-            "packages" : {},
-            "version" : "2.2.7",
+            "packages" : {
+                
+            },
+            "version" : "2.2.8",
             "automated_flags" : {
                 "include_in_ui" : true,
                 "generate_docs" : true,
@@ -134,8 +140,10 @@
                 "python",
                 "r"
             ],
-            "packages" : {},
-            "version" : "2.1.7",
+            "packages" : {
+                
+            },
+            "version" : "2.1.8",
             "automated_flags" : {
                 "include_in_ui" : false,
                 "generate_docs" : false,
@@ -152,8 +160,10 @@
                 "python",
                 "r"
             ],
-            "packages" : {},
-            "version" : "0.2.5",
+            "packages" : {
+                
+            },
+            "version" : "0.2.6",
             "automated_flags" : {
                 "include_in_ui" : false,
                 "generate_docs" : true,

--- a/terra-jupyter-aou/CHANGELOG.md
+++ b/terra-jupyter-aou/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2.1.8 - 2022-07-08T13:38:50.191114Z
+
+- Update `terra-jupyter-base` to `1.0.12`
+  - Add conda environment so the user has an environment with permissions to run conda install.
+- Add conda environment so the user has an environment with permissions to run conda install.
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:2.1.8`
+
 ## 2.1.7 - 2022-06-30
 - Update `hail` to `0.2.96`
   - See https://hail.is/docs/0.2/change_log.html#version-0-2-96) for details

--- a/terra-jupyter-aou/Dockerfile
+++ b/terra-jupyter-aou/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.2.7
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.2.8
 
 USER root
 
@@ -193,3 +193,5 @@ RUN conda install -c bioconda r-saige
 
 ENV PIP_USER=true
 USER $USER
+
+RUN conda create --clone base -p $HOME/.jupyter/env/base -y

--- a/terra-jupyter-aou/Dockerfile
+++ b/terra-jupyter-aou/Dockerfile
@@ -194,4 +194,4 @@ RUN conda install -c bioconda r-saige
 ENV PIP_USER=true
 USER $USER
 
-RUN conda create --clone base -p $HOME/.jupyter/env/base -y
+RUN conda create --clone base -p $HOME/.jupyter/env/user-aou -y

--- a/terra-jupyter-base/CHANGELOG.md
+++ b/terra-jupyter-base/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.0.12 - 2022-07-08T13:38:49.941847Z
+
+- Add conda environment so the user has an environment with permissions to run conda install.
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.0.12`
+
 ## 1.0.11 - 2022-06-23T10:58:12.961300Z
 
 - Fix leo_url variable in workspace_cromwell.py script for AoU projects

--- a/terra-jupyter-base/Dockerfile
+++ b/terra-jupyter-base/Dockerfile
@@ -153,6 +153,8 @@ USER $USER
 EXPOSE $JUPYTER_PORT
 WORKDIR $HOME
 
+RUN conda create --clone base -p $HOME/.jupyter/env/base -y
+
 # Note: this entrypoint is provided for running Jupyter independently of Leonardo.
 # When Leonardo deploys this image onto a cluster, the entrypoint is overwritten to enable
 # additional setup inside the container before execution.  Jupyter execution occurs when the

--- a/terra-jupyter-base/Dockerfile
+++ b/terra-jupyter-base/Dockerfile
@@ -153,7 +153,7 @@ USER $USER
 EXPOSE $JUPYTER_PORT
 WORKDIR $HOME
 
-RUN conda create --clone base -p $HOME/.jupyter/env/base -y
+RUN conda create --clone base -p $HOME/.jupyter/env/user-base -y
 
 # Note: this entrypoint is provided for running Jupyter independently of Leonardo.
 # When Leonardo deploys this image onto a cluster, the entrypoint is overwritten to enable

--- a/terra-jupyter-bioconductor/CHANGELOG.md
+++ b/terra-jupyter-bioconductor/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.1.6 - 2022-07-08T13:38:49.983597Z
+
+- Update `terra-jupyter-base` to `1.0.12`
+  - Add conda environment so the user has an environment with permissions to run conda install.
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:2.1.6`
+
 ## 2.1.5 - 2022-05-20T18:06:39.449113Z
 
 - Update `terra-jupyter-base` to `1.0.10`

--- a/terra-jupyter-bioconductor/Dockerfile
+++ b/terra-jupyter-bioconductor/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.1.5
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.1.6
 
 USER root
 

--- a/terra-jupyter-gatk-ovtf/CHANGELOG.md
+++ b/terra-jupyter-gatk-ovtf/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.2.6 - 2022-07-08T13:38:50.211053Z
+
+- Update `terra-jupyter-base` to `1.0.12`
+  - Add conda environment so the user has an environment with permissions to run conda install.
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk-ovtf:0.2.6`
+
 ## 0.2.5 - 2022-06-23T10:58:12.961300Z
 
 - Update `terra-jupyter-base` to `1.0.10`

--- a/terra-jupyter-gatk-ovtf/Dockerfile
+++ b/terra-jupyter-gatk-ovtf/Dockerfile
@@ -1,6 +1,6 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.11 AS python
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.12 AS python
 
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.1.5
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.1.6
 
 # copy everything pip installed from the python image
 COPY --from=python /opt/conda/lib/python3.7/site-packages /opt/conda/lib/python3.7/site-packages

--- a/terra-jupyter-gatk/CHANGELOG.md
+++ b/terra-jupyter-gatk/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.2.8 - 2022-07-08T13:38:50.143329Z
+
+- Update `terra-jupyter-base` to `1.0.12`
+  - Add conda environment so the user has an environment with permissions to run conda install.
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.2.8`
+
 ## 2.2.7 - 2022-06-23T10:58:12.961300Z
 
 - Update `terra-jupyter-base` to `1.0.10`

--- a/terra-jupyter-gatk/Dockerfile
+++ b/terra-jupyter-gatk/Dockerfile
@@ -1,6 +1,6 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.13 AS python
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.14 AS python
 
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.1.5
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.1.6
 
 USER root
 

--- a/terra-jupyter-hail/CHANGELOG.md
+++ b/terra-jupyter-hail/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.0.20 - 2022-07-08T13:38:50.031615Z
+
+- Update `terra-jupyter-base` to `1.0.12`
+  - Add conda environment so the user has an environment with permissions to run conda install.
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-hail:1.0.20`
+
 ## 1.0.19 - 2022-06-30
 - Update `hail` to `0.2.96`
   - See https://hail.is/docs/0.2/change_log.html#version-0-2-96) for details

--- a/terra-jupyter-hail/Dockerfile
+++ b/terra-jupyter-hail/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.11
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.12
 USER root
 
 ENV PIP_USER=false

--- a/terra-jupyter-python/CHANGELOG.md
+++ b/terra-jupyter-python/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.0.14 - 2022-07-08T13:38:50.061654Z
+
+- Update `terra-jupyter-base` to `1.0.12`
+  - Add conda environment so the user has an environment with permissions to run conda install.
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.14`
+
 ## 1.0.13 - 2022-06-23T10:58:12.961300Z
 
 - Update `terra-jupyter-base` to `1.0.10`

--- a/terra-jupyter-python/Dockerfile
+++ b/terra-jupyter-python/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.0.11
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.0.12
 USER root
 # This makes it so pip runs as root, not the user.
 ENV PIP_USER=false

--- a/terra-jupyter-r/CHANGELOG.md
+++ b/terra-jupyter-r/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.1.6 - 2022-07-08T13:38:50.115637Z
+
+- Update `terra-jupyter-base` to `1.0.12`
+  - Add conda environment so the user has an environment with permissions to run conda install.
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.1.6`
+
 ## 2.1.5 - 2022-06-23T10:58:12.961300Z
 
 - Update `terra-jupyter-base` to `1.0.10`

--- a/terra-jupyter-r/Dockerfile
+++ b/terra-jupyter-r/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.0.11
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.0.12
 USER root
 
 COPY scripts $JUPYTER_HOME/scripts


### PR DESCRIPTION
## Description

Users need to be able to run Conda install in their environment in AoU.

## Solution

From within the dockerfile, we create an environment where the user has write access. 

If the user wants to install conda packages, they must select the appropriate environment kernel. (The base image env is user-base, the aou image env is user-aou).