### PR TITLE
Revert AoU image Java 11 upgrade attempt

### DIFF
--- a/config/conf.json
+++ b/config/conf.json
@@ -135,7 +135,7 @@
                 "r"
             ],
             "packages" : {},
-            "version" : "2.1.7",
+            "version" : "2.1.8",
             "automated_flags" : {
                 "include_in_ui" : false,
                 "generate_docs" : false,

--- a/terra-jupyter-aou/CHANGELOG.md
+++ b/terra-jupyter-aou/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.1.8 - 2022-07-12
+
+- Revert attempted Java11 upgrade back to Java8
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:2.1.8`
+
 ## 2.1.7 - 2022-06-30
 - Update `hail` to `0.2.96`
   - See https://hail.is/docs/0.2/change_log.html#version-0-2-96) for details

--- a/terra-jupyter-aou/Dockerfile
+++ b/terra-jupyter-aou/Dockerfile
@@ -61,6 +61,8 @@ RUN find $JUPYTER_HOME/scripts -name '*.sh' -type f | xargs chmod +x \
     && apt install -yq --no-install-recommends \
         g++ \
         liblz4-dev \
+    # specify Java 8
+    && update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java \
     && pip3 install pypandoc gnomad \
     && pip3 install --no-dependencies hail==$HAIL_VERSION \
     && X=$(mktemp -d) \


### PR DESCRIPTION
Ideally we would upgrade the notebook image to Java 11 fully. My previous attempt only half switched from Java 8 to Java 11, causing some complications in the image. Just revert the change for now.