### PR TITLE
Update for Bioconductor release 3.16

### DIFF
--- a/config/community_images.json
+++ b/config/community_images.json
@@ -10,11 +10,11 @@
 },
 {
     "id": "RStudio",
-    "label": "RStudio (R 4.2.1, Bioconductor 3.15, Python 3.8.10)",
-    "version": "3.15.3",
-    "updated": "2022-09-13",
+    "label": "RStudio (R 4.2.2, Bioconductor 3.16, Python 3.10.6)",
+    "version": "3.16.0",
+    "updated": "2022-11-22",
     "packages": "https://storage.googleapis.com/terra-docker-image-documentation/placeholder.json",
-    "image": "us.gcr.io/broad-dsp-gcr-public/anvil-rstudio-bioconductor:3.15.3",
+    "image": "us.gcr.io/broad-dsp-gcr-public/anvil-rstudio-bioconductor:3.16.0",
     "requiresSpark": false,
     "isRStudio": true
 },


### PR DESCRIPTION
<img width="840" alt="image" src="https://user-images.githubusercontent.com/14061824/203408372-5925f23a-d9b0-4bab-9e24-f3c97c3a6438.png">
Image slightly smaller.
Fwiw, base also changed from ubuntu focal to ubuntu jammy