### PR TITLE
[IA-4070] fix hail

### DIFF
--- a/terra-jupyter-hail/Dockerfile
+++ b/terra-jupyter-hail/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.12
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.14
 USER root
 
 ENV PIP_USER=false


### PR DESCRIPTION
The version referenced in hail dockerfile is not valid

See changelog for terra-jupyter-python version in question

```
## 1.0.12 - 2022-06-23T10:58:12.961300Z

- reverted, do not use
```

Should not require a changelog bump for terra-jupyter-hail since this version was never generated due to error.