### PR TITLE
Update Bolt LMM to 2.4.1 because 2.4 doesn't exist. 

### DIFF
--- a/terra-jupyter-aou/Dockerfile
+++ b/terra-jupyter-aou/Dockerfile
@@ -111,7 +111,7 @@ RUN mkdir -p /tmp/prsice && \
   ln -s "/opt/prsice/PRsice_linux" /bin/prsice
 
 # BOLT-LMM install
-ENV BOLT_LMM_VERSION v2.4
+ENV BOLT_LMM_VERSION v2.4.1
 RUN mkdir -p /tmp/bolt-lmm && \
   cd /tmp/bolt-lmm && \
   curl -L -o bolt-lmm.tar.gz "https://storage.googleapis.com/broad-alkesgroup-public/BOLT-LMM/downloads/BOLT-LMM_${BOLT_LMM_VERSION}.tar.gz" && \


### PR DESCRIPTION
Per Feedback from Sam Bryant at the broad, Bolt LMM 2.4 doesn't exist.