### PR TITLE
[no ticket] Fix docker version because base image v13 does not exist in GCR

### DIFF
--- a/terra-jupyter-python/Dockerfile
+++ b/terra-jupyter-python/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.0.13
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.0.14
 USER root
 # This makes it so pip runs as root, not the user.
 ENV PIP_USER=false

--- a/terra-jupyter-r/Dockerfile
+++ b/terra-jupyter-r/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.0.13
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.0.14
 USER root
 
 COPY scripts $JUPYTER_HOME/scripts


### PR DESCRIPTION
It might be a typo in https://github.com/DataBiosphere/terra-docker/pull/394, and it makes `python, gatk, r, aou` images fail to build and push. 