### PR TITLE
[IA-4148] updated the LargeFileManager import in jupyter_delocalize.py

### DIFF
--- a/terra-jupyter-base/custom/jupyter_delocalize.py
+++ b/terra-jupyter-base/custom/jupyter_delocalize.py
@@ -3,7 +3,7 @@ import json
 import os
 import requests
 import tornado
-from notebook.services.contents.largefilemanager import LargeFileManager
+from jupyter_server.services.contents.largefilemanager import LargeFileManager
 
 METADATA_TTL = timedelta(minutes=5)
 


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-4148

This PR updates the import from notebook to Jupyter Server. 

It seems the package naming changed with the new DSVM image.