### PR TITLE
Bioconductor RStudio 3.17 release

### DIFF
--- a/config/community_images.json
+++ b/config/community_images.json
@@ -10,11 +10,21 @@
 },
 {
     "id": "RStudio",
-    "label": "RStudio (R 4.2.2, Bioconductor 3.16, Python 3.10.6)",
-    "version": "3.16.0",
-    "updated": "2022-11-22",
-    "packages": "https://raw.githubusercontent.com/anvilproject/anvil-docker/master/anvil-rstudio-bioconductor/info/anvil-rstudio-bioconductor-3.16.0-versions.json",
-    "image": "us.gcr.io/broad-dsp-gcr-public/anvil-rstudio-bioconductor:3.16.0",
+    "label": "RStudio (R 4.3.0, Bioconductor 3.17, Python 3.10.6)",
+    "version": "3.17.0",
+    "updated": "2023-05-12",
+    "packages": "https://raw.githubusercontent.com/anvilproject/anvil-docker/master/anvil-rstudio-bioconductor/info/anvil-rstudio-bioconductor-3.17.0-versions.json",
+    "image": "us.gcr.io/broad-dsp-gcr-public/anvil-rstudio-bioconductor:3.17.0",
+    "requiresSpark": false,
+    "isRStudio": true
+},
+{
+    "id": "LegacyRStudio",
+    "label": "Legacy RStudio (R 4.2.3, Bioconductor 3.16, Python 3.10.6)",
+    "version": "3.16.1",
+    "updated": "2023-05-12",
+    "packages": "https://raw.githubusercontent.com/anvilproject/anvil-docker/master/anvil-rstudio-bioconductor/info/anvil-rstudio-bioconductor-3.16.1-versions.json",
+    "image": "us.gcr.io/broad-dsp-gcr-public/anvil-rstudio-bioconductor:3.16.1",
     "requiresSpark": false,
     "isRStudio": true
 },


### PR DESCRIPTION
- Adds Bioconductor 3.17 image with R 4.3.0
- Adds Bioconductor 3.16.1 image as legacy with R 4.2.3
- Both images are now GPU-ready, and images going forward will remain so, and therefore the GPU box can be allowed for all Bioconductor RStudio images not just Custom Environments going forward
- Images have increased in size from 1.8GB to 6.5GB as a result of the new `cuda` base image

Jupyter 3.17 PR will be done separately as per previous requests