### PR TITLE
[RW-10031] Remove deprecated Google auth API usage

### DIFF
--- a/config/conf.json
+++ b/config/conf.json
@@ -26,7 +26,7 @@
                     "tidyverse"
                 ]
             },
-            "version" : "2.2.1",
+            "version" : "2.2.2",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : true,
@@ -47,7 +47,7 @@
                     "hail"
                 ]
             },
-            "version" : "1.1.1",
+            "version" : "1.1.2",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : true,
@@ -68,7 +68,7 @@
                     "scikit-learn"
                 ]
             },
-            "version" : "1.1.1",
+            "version" : "1.1.2",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : true,
@@ -86,7 +86,7 @@
             "packages" : {
                 
             },
-            "version" : "1.1.1",
+            "version" : "1.1.2",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : false,
@@ -104,7 +104,7 @@
             "packages" : {
                 
             },
-            "version" : "2.2.1",
+            "version" : "2.2.2",
             "automated_flags" : {
                 "include_in_ui" : false,
                 "generate_docs" : true,
@@ -124,7 +124,7 @@
             "packages" : {
                 
             },
-            "version" : "2.3.1",
+            "version" : "2.3.2",
             "automated_flags" : {
                 "include_in_ui" : true,
                 "generate_docs" : true,
@@ -143,7 +143,7 @@
             "packages" : {
                 
             },
-            "version" : "2.2.1",
+            "version" : "2.2.2",
             "automated_flags" : {
                 "include_in_ui" : false,
                 "generate_docs" : false,
@@ -176,7 +176,7 @@
             "tools" : [
             ],
             "packages" : {
-
+                
             },
             "version" : "0.0.1",
             "automated_flags" : {

--- a/terra-jupyter-aou/CHANGELOG.md
+++ b/terra-jupyter-aou/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.2.2 - 2023-07-26T14:05:19.520988Z
+
+- Update `terra-jupyter-base` to `1.1.2`
+  - Removed deprecated google auth usage
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:2.2.2`
+
 ## 2.2.1 - 2023-07-06
 
 - Fix bug introduced in https://github.com/DataBiosphere/terra-docker/commit/4a5b4c9212aedcafa2f41fbeb2b161089341c578 

--- a/terra-jupyter-aou/Dockerfile
+++ b/terra-jupyter-aou/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.3.1
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.3.2
 
 USER root
 

--- a/terra-jupyter-base/CHANGELOG.md
+++ b/terra-jupyter-base/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.1.2 - 2023-07-26T14:05:19.477306Z
+
+- Removed deprecated google auth usage
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.1.2`
+
 ## 1.1.1 - 2023-07-06
 
 - Fix bug introduced in https://github.com/DataBiosphere/terra-docker/commit/4a5b4c9212aedcafa2f41fbeb2b161089341c578 

--- a/terra-jupyter-base/custom/google_sign_in.js
+++ b/terra-jupyter-base/custom/google_sign_in.js
@@ -1,7 +1,13 @@
 /*
- * This library is designed to run as a Jupyter/JupyterLab extension to refresh the user's
- * Google credentials while using a notebook. This flow is described in more detail here:
- * https://github.com/DataBiosphere/leonardo/wiki/Connecting-to-a-Leo-Notebook#token-refresh
+ * This library is a Jupyter/JupyterLab extension that performs periodic jupyter status checks.
+ *
+ * Originally, this extension refreshed the user's Google credentials while using a notebook.
+ * This flow is described in more detail here:
+ * https://github.com/DataBiosphere/leonardo/wiki/Connecting-to-a-Leo-Notebook#token-refresh.
+ * However, the google auth library being used was slated to be sunset:
+ * https://developers.google.com/identity/sign-in/web/deprecation-and-sunset.
+ * As a result, the auth code has been removed. Leonardo's clients now refresh tokens independently.
+ * Further investigation is needed to determine if this library is still needed.
  *
  * Note since this runs inside both Jupyter and JupyterLab, it should not use any
  * libraries/functionality that exists in one but not the other. Examples: node, requireJS.
@@ -104,29 +110,6 @@ function xhttpGet(url, callback) {
 }
 
 function startTimer() {
-  loadGapi('auth2', function() {
-    function doAuth() {
-      if (params.googleClientId) {
-        gapi.auth2.authorize({
-          'client_id': params.googleClientId,
-          'scope': 'openid profile email',
-          'login_hint': params.loginHint,
-          'prompt': 'none'
-        }, function(result) {
-          if (result.error) {
-            console.error('Error occurred authorizing with Google: ' + result.error);
-            return;
-          }
-          setCookie(result.access_token, result.expires_in);
-        });
-      }
-    }
-
-    // refresh token every 3 minutes
-    console.log('Starting token refresh timer');
-    setInterval(doAuth, 180000);
-  });
-
   function statusCheck() {
     const url = `/proxy/${params.googleProject}/${params.clusterName}/jupyter/api/status`;
     // logging the statusCheck can be noisy, and it will tell us in the console if it fails
@@ -134,31 +117,6 @@ function startTimer() {
   }
 
   setInterval(statusCheck, 60000);
-}
-
-// Note: this should match
-// https://github.com/DataBiosphere/leonardo/blob/develop/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/CookieHelper.scala
-function setCookie(token, expiresIn) {
-  document.cookie = 'LeoToken=' + token + '; Max-Age=' + expiresIn + '; Path=/; Secure; SameSite=None';
-}
-
-function loadGapi(googleLib, continuation) {
-  console.log('Loading Google APIs');
-  // Get the gapi script from Google.
-  const gapiScript = document.createElement('script');
-  gapiScript.src = 'https://apis.google.com/js/api.js';
-  gapiScript.type = 'text/javascript';
-  gapiScript.async = true;
-
-  // Load requested API scripts onto the page.
-  gapiScript.onload = function() {
-    console.log('Loading Google library \'' + googleLib + '\'');
-    gapi.load(googleLib, continuation);
-  };
-  gapiScript.onerror = function() {
-    console.error('Unable to load Google APIs');
-  };
-  document.head.appendChild(gapiScript);
 }
 
 function init() {

--- a/terra-jupyter-bioconductor/CHANGELOG.md
+++ b/terra-jupyter-bioconductor/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.2.2 - 2023-07-26T14:05:19.492873Z
+
+- Update `terra-jupyter-base` to `1.1.2`
+  - Removed deprecated google auth usage
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:2.2.2`
+
 ## 2.2.1 - 2023-07-06
 
 - Fix bug introduced in https://github.com/DataBiosphere/terra-docker/commit/4a5b4c9212aedcafa2f41fbeb2b161089341c578 

--- a/terra-jupyter-bioconductor/Dockerfile
+++ b/terra-jupyter-bioconductor/Dockerfile
@@ -1,1 +1,1 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.2.1
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.2.2

--- a/terra-jupyter-gatk/CHANGELOG.md
+++ b/terra-jupyter-gatk/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.3.2 - 2023-07-26T14:05:19.515209Z
+
+- Update `terra-jupyter-base` to `1.1.2`
+  - Removed deprecated google auth usage
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.3.2`
+
 ## 2.3.1 - 2023-07-06
 
 - Fix bug introduced in https://github.com/DataBiosphere/terra-docker/commit/4a5b4c9212aedcafa2f41fbeb2b161089341c578 

--- a/terra-jupyter-gatk/Dockerfile
+++ b/terra-jupyter-gatk/Dockerfile
@@ -1,6 +1,6 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.1.1 AS python
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.1.2 AS python
 
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.2.1
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.2.2
 
 USER root
 

--- a/terra-jupyter-hail/CHANGELOG.md
+++ b/terra-jupyter-hail/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.1.2 - 2023-07-26T14:05:19.498644Z
+
+- Update `terra-jupyter-base` to `1.1.2`
+  - Removed deprecated google auth usage
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-hail:1.1.2`
+
 ## 1.1.1 - 2023-07-06
 
 - Fix bug introduced in https://github.com/DataBiosphere/terra-docker/commit/4a5b4c9212aedcafa2f41fbeb2b161089341c578 

--- a/terra-jupyter-hail/Dockerfile
+++ b/terra-jupyter-hail/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.1.1
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.1.2
 
 USER root
 

--- a/terra-jupyter-python/CHANGELOG.md
+++ b/terra-jupyter-python/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.1.2 - 2023-07-26T14:05:19.505349Z
+
+- Update `terra-jupyter-base` to `1.1.2`
+  - Removed deprecated google auth usage
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.1.2`
+
 ## 1.1.1 - 2023-07-06
 
 - Fix bug introduced in https://github.com/DataBiosphere/terra-docker/commit/4a5b4c9212aedcafa2f41fbeb2b161089341c578 

--- a/terra-jupyter-python/Dockerfile
+++ b/terra-jupyter-python/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.1.1
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.1.2
 
 USER root
 # This makes it so pip runs as root, not the user.

--- a/terra-jupyter-r/CHANGELOG.md
+++ b/terra-jupyter-r/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.2.2 - 2023-07-26T14:05:19.511221Z
+
+- Update `terra-jupyter-base` to `1.1.2`
+  - Removed deprecated google auth usage
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.2.2`
+
 ## 2.2.1 - 2023-07-06
 
 - Fix bug introduced in https://github.com/DataBiosphere/terra-docker/commit/4a5b4c9212aedcafa2f41fbeb2b161089341c578 

--- a/terra-jupyter-r/Dockerfile
+++ b/terra-jupyter-r/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.1.1
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.1.2
 
 USER root
 


### PR DESCRIPTION
This is the minimum changes necessary to prevent any issues when the google library is deprecated and prevent contention between AoU’s periodic refresh code and the extension’s refreshing.

See details in [this thread](https://broadinstitute.slack.com/archives/CA3NP1733/p1683907756108319).

See my manual testing process in the description of the first commit.

This is my first contribution to terra-docker so let me know if there's anything I should do beyond following [this guide](https://broadinstitute.slack.com/archives/CA3NP1733/p1683907756108319).