### PR TITLE
[RW-10031] Fix cromshell 2.0 installation

### DIFF
--- a/config/conf.json
+++ b/config/conf.json
@@ -143,7 +143,7 @@
             "packages" : {
                 
             },
-            "version" : "2.2.0",
+            "version" : "2.2.1",
             "automated_flags" : {
                 "include_in_ui" : false,
                 "generate_docs" : false,

--- a/terra-jupyter-aou/CHANGELOG.md
+++ b/terra-jupyter-aou/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.2.1 - 2023-07-10T15:49:55.974075Z
+
+- Remove outdated cromshell alias
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:2.2.1`
+
 ## 2.2.0 - 2023-06-23
 
 - Update python from 3.7 to 3.10

--- a/terra-jupyter-aou/Dockerfile
+++ b/terra-jupyter-aou/Dockerfile
@@ -259,8 +259,6 @@ RUN curl -L http://www.repeatmasker.org/RepeatMasker/RepeatMasker-4.1.4.tar.gz \
 
 # Remove workspace_cromwell script as it may allow user bypass AoU to create Cromwell via Leo directly
 RUN rm -f /usr/local/bin/workspace_cromwell.py
-# alias cromshell_beta to cromshell
-RUN echo "alias cromshell='cromshell-beta'" >> ~/.bash_aliases
 
 # Downgrade Jinja2 as the newer version breaks the notebook
 # See https://jinja.palletsprojects.com/en/3.1.x/changes/#version-3-1-0

--- a/updateVersions.sc
+++ b/updateVersions.sc
@@ -97,6 +97,9 @@ def main(updatedImage: String, updatedImageReleaseNote: String, bumpMajorVersion
     case "terra-jupyter-gatk" => List(
       "terra-jupyter-gatk"
     )
+    case "terra-jupyter-aou" => List(
+      "terra-jupyter-aou"
+    )
     case updatedImage =>
       throw new Exception(s"${updatedImage} is not supported yet. Please update the script to support the image")
   }


### PR DESCRIPTION
The `cromshell_2.0` branch was renamed to `main`. This broke the terra-jupyter-base image's cromshell installation step because it relied on that branch existing. This PR installs cromshell using pip instead of manually installing. Additionally, this change locks the package version to prevent future versioning drift.

This replaces the "cromshell-beta" command with "cromshell" now that 2.0 is out of beta.

See [this slack thread](https://broadinstitute.slack.com/archives/CA3NP1733/p1684781063373129) for additional information.

Tested by building the image locally and running `cromshell` and `cromshell-beta` in the container's terminal.
 - Before this change, the image did not build. After this change, the image builds.
 - In the latest published image, `cromshell-beta` is a valid command and `cromshell` is not. After this change, `cromshell` is available, and `cromshell-beta` is not.