### PR TITLE
[RW-10154][RW-10159] Fix Cromshell alias and revert Hail upgrade

### DIFF
--- a/config/conf.json
+++ b/config/conf.json
@@ -143,7 +143,7 @@
             "packages" : {
                 
             },
-            "version" : "2.1.20",
+            "version" : "2.1.21",
             "automated_flags" : {
                 "include_in_ui" : false,
                 "generate_docs" : false,

--- a/terra-jupyter-aou/CHANGELOG.md
+++ b/terra-jupyter-aou/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.1.21 - 2023-05-24
+- Rollback `hail` to `0.2.107`
+- Fix `cromshell` alias typo
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:2.1.21`
+- 
+
 ## 2.1.20 - 2023-04-11
 - Update `hail` to `0.2.113`
   - See https://hail.is/docs/0.2/change_log.html#version-0-2-113) for details

--- a/terra-jupyter-aou/Dockerfile
+++ b/terra-jupyter-aou/Dockerfile
@@ -48,7 +48,7 @@ ENV PYTHONPATH $PYTHONPATH:/usr/lib/spark/python
 
 ENV PYSPARK_PYTHON=python3
 
-ENV HAIL_VERSION=0.2.113
+ENV HAIL_VERSION=0.2.107
 
 RUN find $JUPYTER_HOME/scripts -name '*.sh' -type f | xargs chmod +x \
     && $JUPYTER_HOME/scripts/kernel/kernelspec.sh $JUPYTER_HOME/scripts/kernel /opt/conda/share/jupyter/kernels \
@@ -263,7 +263,7 @@ RUN curl -L http://www.repeatmasker.org/RepeatMasker/RepeatMasker-4.1.4.tar.gz \
 # Remove workspace_cromwell script as it may allow user bypass AoU to create Cromwell via Leo directly
 RUN rm -f /usr/local/bin/workspace_cromwell.py
 # alias cromshell_beta to cromshell
-RUN echo "alias cromshell='cromshell_beta'" >> ~/.bash_aliases
+RUN echo "alias cromshell='cromshell-beta'" >> ~/.bash_aliases
 # Downgrade jupyter_contrib_nbextensions as the newer version breaks snippet_menu extension
 RUN pip install --force-reinstall -v "jupyter_contrib_nbextensions==0.5.1"
 


### PR DESCRIPTION
1: The newer Hail version requires higher version of Spark. Spark is intalled via Leonardo. Rollback Hail for now until Leo upgrade Dataproc version. 
2: Fix a typo of Cromshell alias. 