### PR TITLE
Update to Jupyter for Bioconductor 3.17 release

### DIFF
--- a/config/conf.json
+++ b/config/conf.json
@@ -26,7 +26,7 @@
                     "tidyverse"
                 ]
             },
-            "version" : "2.1.10",
+            "version" : "2.1.11",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : true,
@@ -104,7 +104,7 @@
             "packages" : {
                 
             },
-            "version" : "2.1.9",
+            "version" : "2.1.10",
             "automated_flags" : {
                 "include_in_ui" : false,
                 "generate_docs" : true,
@@ -124,7 +124,7 @@
             "packages" : {
                 
             },
-            "version" : "2.2.12",
+            "version" : "2.2.13",
             "automated_flags" : {
                 "include_in_ui" : true,
                 "generate_docs" : true,
@@ -143,7 +143,7 @@
             "packages" : {
                 
             },
-            "version" : "2.1.21",
+            "version" : "2.1.22",
             "automated_flags" : {
                 "include_in_ui" : false,
                 "generate_docs" : false,
@@ -181,7 +181,7 @@
             "packages" : {
                 
             },
-            "version" : "0.2.9",
+            "version" : "0.2.10",
             "automated_flags" : {
                 "include_in_ui" : false,
                 "generate_docs" : true,

--- a/config/legacy_static_images.json
+++ b/config/legacy_static_images.json
@@ -1,11 +1,11 @@
 [
   {
-    "updated": "2022-11-15",
-    "image": "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:2.1.7",
-    "label": "Legacy R / Bioconductor (R 4.1.2, Bioconductor 3.15, Python 3.7.12)",
-    "version": "2.1.7",
+    "updated": "2023-02-09",
+    "image": "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:2.1.9",
+    "label": "Legacy R / Bioconductor (R 4.2.2, Bioconductor 3.16, Python 3.7.12)",
+    "version": "2.1.9",
     "requiresSpark": false,
-    "packages": "https://storage.googleapis.com/terra-docker-image-documentation/terra-jupyter-bioconductor-2.1.7-versions.json",
+    "packages": "https://storage.googleapis.com/terra-docker-image-documentation/terra-jupyter-bioconductor-2.1.9-versions.json",
     "id": "terra-jupyter-bioconductor_legacy"
   }
 ]

--- a/terra-jupyter-aou/CHANGELOG.md
+++ b/terra-jupyter-aou/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.1.22 - 2023-06-01T17:49:47.721962740Z
+
+- Update `terra-jupyter-r` to `2.1.10`
+  - Bioconductor 3.17 release with R 4.3
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:2.1.22`
+
 ## 2.1.21 - 2023-05-24
 - Rollback `hail` to `0.2.107`
 - Fix `cromshell` alias typo

--- a/terra-jupyter-aou/Dockerfile
+++ b/terra-jupyter-aou/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.2.11
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.2.12
 
 USER root
 

--- a/terra-jupyter-bioconductor/CHANGELOG.md
+++ b/terra-jupyter-bioconductor/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.1.11 - 2023-06-01T17:49:47.622531112Z
+
+- Update `terra-jupyter-r` to `2.1.10`
+  - Bioconductor 3.17 release with R 4.3
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:2.1.11`
+
 ## 2.1.10 - 2023-03-13T17:26:34.148443Z
 
 - Update `terra-jupyter-base` to `1.0.14`

--- a/terra-jupyter-bioconductor/Dockerfile
+++ b/terra-jupyter-bioconductor/Dockerfile
@@ -1,1 +1,1 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.1.9
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.1.10

--- a/terra-jupyter-gatk-ovtf/CHANGELOG.md
+++ b/terra-jupyter-gatk-ovtf/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.2.10 - 2023-06-01T17:49:47.736670188Z
+
+- Update `terra-jupyter-r` to `2.1.10`
+  - Bioconductor 3.17 release with R 4.3
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk-ovtf:0.2.10`
+
 ## 0.2.9 - 2023-03-13T17:26:34.258214Z
 
 - Update `terra-jupyter-base` to `1.0.14`

--- a/terra-jupyter-gatk-ovtf/Dockerfile
+++ b/terra-jupyter-gatk-ovtf/Dockerfile
@@ -1,6 +1,6 @@
 FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.13 AS python
 
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.1.9
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.1.10
 
 # copy everything pip installed from the python image
 COPY --from=python /opt/conda/lib/python3.7/site-packages /opt/conda/lib/python3.7/site-packages

--- a/terra-jupyter-gatk/CHANGELOG.md
+++ b/terra-jupyter-gatk/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.2.13 - 2023-06-01T17:49:47.668283846Z
+
+- Update `terra-jupyter-r` to `2.1.10`
+  - Bioconductor 3.17 release with R 4.3
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.2.13`
+
 ## 2.2.12 - 2023-05-31T13:55:05
 
 - Add bcftools

--- a/terra-jupyter-gatk/Dockerfile
+++ b/terra-jupyter-gatk/Dockerfile
@@ -1,6 +1,6 @@
 FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.15 AS python
 
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.1.9
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.1.10
 
 USER root
 

--- a/terra-jupyter-r/CHANGELOG.md
+++ b/terra-jupyter-r/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.1.10 - 2023-06-01T17:49:47.585402026Z
+
+- Bioconductor 3.17 release with R 4.3
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.1.10`
+
 ## 2.1.9 - 2023-03-13T17:26:34.207471Z
 
 - Update `terra-jupyter-base` to `1.0.14`

--- a/terra-jupyter-r/Dockerfile
+++ b/terra-jupyter-r/Dockerfile
@@ -5,7 +5,7 @@ COPY scripts $JUPYTER_HOME/scripts
 
 # Add env vars to identify binary package installation
 ENV TERRA_R_PLATFORM="terra-jupyter-r"
-ENV TERRA_R_PLATFORM_BINARY_VERSION=3.16.0
+ENV TERRA_R_PLATFORM_BINARY_VERSION=3.17
 
 # Install protobuf 3.19.1. Note this version comes from base deep learning image. Use `conda list` to see what's installed
 RUN cd /tmp \
@@ -96,6 +96,12 @@ RUN apt-get update \
 	libzmq3-dev \
 	libsbml5-dev \
 	biber \
+        ## for gpuMagic package
+        ocl-icd-opencl-dev \
+        ## for ChemmineOB package
+        libeigen3-dev \
+        ## for rawrr package
+        mono-runtime \
     && ln -s /usr/lib/gcc/x86_64-linux-gnu/7/libgfortran.so /usr/lib/x86_64-linux-gnu/libgfortran.so \
     && ln -s /usr/lib/gcc/x86_64-linux-gnu/7/libstdc++.so /usr/lib/x86_64-linux-gnu/libstdc++.so \
     && apt-get clean \
@@ -121,7 +127,7 @@ RUN pip3 -V \
 
 RUN R -e 'install.packages("BiocManager")' \
     ## check version
-    && R -e 'BiocManager::install(version="3.16", ask=FALSE)' \
+    && R -e 'BiocManager::install(version="3.17", ask=FALSE)' \
     && R -e 'BiocManager::install(c( \
     "boot", \
     "class", \


### PR DESCRIPTION
Complements https://github.com/DataBiosphere/terra-docker/pull/420 .

Making Jupyter PR before propagation is done for RStudio as discussed with Susan on Slack.