### PR TITLE
[IA-4354] Bump up jupyter-hail version to 1.0.27

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,8 @@ If you are from outside the Broad, don't worry about adding a JIRA issue number 
 
 If you are handling these contributions from the Broad side, please remember to create a corresponding JIRA ticket. This ticket number will be used to track contributions internally.
 
+Standard operating procedures between Bioconductor and Terra teams during release have been detailed in [this document](https://docs.google.com/document/d/1-TVfD9GisifdgB9rjM5Q2ieCri1NPEC8cgHZTy8fWeo/edit#). 
+
 ## Community Images
 
 Community images must be vetted before they will be introduced into Terra.

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Detailed documentation on how to integrate the terra-docker image with Leonardo 
     - Update CHANGELOG.md and VERSION file
     - Ensure that no `From` statements need to be updated based on the image you updated (i.e., if you update the base image, you will need to update several other images)
     - Run updateVersions.sc to bump all images dependent on the base
-- [Merge your terra-docker PR and check if the image(s) is(are) created](https://broadworkbench.atlassian.net/wiki/spaces/IA/pages/2519564289/Integrating+new+Terra+docker+images+with+Leonardo#2.-Merge-your-terra-docker-PR-and-check-images-are-created)
+- [Merge your terra-docker PR and check if the image(s) and version json files are created](https://broadworkbench.atlassian.net/wiki/spaces/IA/pages/2519564289/Integrating+new+Terra+docker+images+with+Leonardo#2.-Merge-your-terra-docker-PR-and-check-images-are-created)
 - [Open a PR in leonardo](https://broadworkbench.atlassian.net/wiki/spaces/IA/pages/2519564289/Integrating+new+Terra+docker+images+with+Leonardo#3.-Create-a-new-leo-PR-that-integrates-the-new-images)
     - Update the relevant `prepare` script within the `jenkins` folder
     - Update the automation `reference.conf` file

--- a/config/conf.json
+++ b/config/conf.json
@@ -47,7 +47,7 @@
                     "hail"
                 ]
             },
-            "version" : "1.0.26",
+            "version" : "1.0.27",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : true,

--- a/terra-jupyter-hail/CHANGELOG.md
+++ b/terra-jupyter-hail/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.0.26 - 2023-06-07
+
+- Force the regeneration of 1.0.26 that was never published
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-hail:1.0.27`
+
 ## 1.0.26 - 2023-03-13T17:26:34.162828Z
 
 - Update `terra-jupyter-base` to `1.0.14`


### PR DESCRIPTION
Previous jenkins job failed because the 1.0.26 terra-jupyter-hail image was never built back in March 2023, so I am trying to bump it up, and get a fresh new package + corresponding documentation files

Also moved the bioconductor SOP document under our contributing guidelines