### PR TITLE
[IA-3730] move bedtools binaries to accessible path

### DIFF
--- a/.github/workflows/test-terra-jupyter-gatk.yml
+++ b/.github/workflows/test-terra-jupyter-gatk.yml
@@ -38,7 +38,7 @@ env:
 jobs:
 
   test_docker_image:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
     - name: Checkout

--- a/config/conf.json
+++ b/config/conf.json
@@ -124,7 +124,7 @@
             "packages" : {
                 
             },
-            "version" : "2.2.13",
+            "version" : "2.2.14",
             "automated_flags" : {
                 "include_in_ui" : true,
                 "generate_docs" : true,

--- a/terra-jupyter-gatk/CHANGELOG.md
+++ b/terra-jupyter-gatk/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.2.14 - 2023-06-09
+
+- Actually install bedtools to accessible path
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.2.14`
+
 ## 2.2.13 - 2023-06-01T17:49:47.668283846Z
 
 - Update `terra-jupyter-r` to `2.1.10`

--- a/terra-jupyter-gatk/Dockerfile
+++ b/terra-jupyter-gatk/Dockerfile
@@ -72,6 +72,7 @@ RUN mkdir -p /tmp/bedtools && \
     tar -zxvf bedtools-2.31.0.tar.gz && \
     cd bedtools2 && \
     make && \
+    make install && \
     cd $HOME && \
     rm -rf /tmp/bedtools
 


### PR DESCRIPTION
Silly mistake on my part, bedtools binaries are generated properly, but were not actually moved to an accessible path 😬 
The commands are now identical to bcftools, which is a working command.