### PR TITLE
RW-9307 wondershaper docker image

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,7 @@ on:
           - terra-jupyter-python
           - terra-jupyter-r
           - terra-rstudio-aou
+          - wondershaper
         default: terra-rstudio-rstudio
       branch:
         description: 'Branch to run the workflow on'

--- a/config/conf.json
+++ b/config/conf.json
@@ -189,6 +189,23 @@
                 "include_in_custom_dataproc" : false,
                 "include_in_custom_gce" : false
             }
+        },
+        {
+            "name" : "wondershaper",
+            "base_label" : "wondershaper",
+            "tools" : [
+            ],
+            "packages" : {
+
+            },
+            "version" : "0.0.1",
+            "automated_flags" : {
+                "include_in_ui" : false,
+                "generate_docs" : false,
+                "build" : false,
+                "include_in_custom_dataproc" : false,
+                "include_in_custom_gce" : false
+            }
         }
     ]
 }

--- a/wondershaper/Dockerfile
+++ b/wondershaper/Dockerfile
@@ -1,0 +1,22 @@
+FROM ubuntu:latest
+
+# Install dependencies
+RUN apt-get update && apt-get install -y \
+    iproute2 \
+    ethtool \
+    wget \
+    unzip \
+    build-essential
+
+# Install Wondershaper
+RUN apt-get install -y wget \
+    && wget https://github.com/magnific0/wondershaper/archive/master.zip \
+    && unzip master.zip \
+    && rm master.zip \
+    && cd wondershaper-master \
+    && make install
+
+# Set up entrypoint
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/wondershaper/README.md
+++ b/wondershaper/README.md
@@ -1,0 +1,44 @@
+# Dockerfile and Entrypoint for Wondershaper
+This Dockerfile and associated entrypoint script provide a way to set up and run Wondershaper, a network traffic shaping tool, within a Docker container. The Docker image is already published and available at us.gcr.io/wondershaper/wondershaper:latest. It is not necessary to republish the image unless modifications are required.
+
+## Dockerfile
+The Dockerfile sets up an Ubuntu-based environment, installs the required dependencies, and installs Wondershaper from the official GitHub repository. It also includes an entrypoint script that configures the network interface and applies bandwidth limits using Wondershaper.
+
+To build the Docker image locally, use the following command:
+
+```
+docker build -t wondershaper-image .
+```
+
+To run the local image, use:
+```
+docker run  --privileged --network=host  wondershaper-local-image
+```
+
+## Entrypoint Script (entrypoint.sh)
+The entrypoint script (entrypoint.sh) is copied into the Docker image. It performs the following tasks:
+
+Sets the network interface (eth0) and the desired upload bandwidth limit (in kilobits per second).
+Applies the bandwidth limits to the network interface using Wondershaper.
+Keeps the container running by executing the tail -f /dev/null command.
+
+## Running the Docker Image
+To run the Wondershaper container using the published image (us.gcr.io/wondershaper/wondershaper:latest), execute the following command:
+
+```
+docker run --name wondershaper-container us.gcr.io/wondershaper/wondershaper:latest
+```
+
+Please note that the image is already published, so you don't need to perform any additional steps unless you want to modify the Dockerfile or the entrypoint script.
+
+If needed, the build and the publish commands are:
+```
+docker build -t us.gcr.io/broad-dsp-gcr-public/wondershaper:latest .
+docker push us.gcr.io/broad-dsp-gcr-public/wondershaper:latest
+```
+
+
+Remember to replace wondershaper-container with your preferred container name.
+
+
+

--- a/wondershaper/README.md
+++ b/wondershaper/README.md
@@ -7,7 +7,7 @@ The Dockerfile sets up an Ubuntu-based environment, installs the required depend
 To build the Docker image locally, use the following command:
 
 ```
-docker build -t wondershaper-image .
+docker build -t wondershaper-local-image .
 ```
 
 To run the local image, use:
@@ -26,7 +26,7 @@ Keeps the container running by executing the tail -f /dev/null command.
 To run the Wondershaper container using the published image (us.gcr.io/wondershaper/wondershaper:latest), execute the following command:
 
 ```
-docker run --name wondershaper-container us.gcr.io/wondershaper/wondershaper:latest
+docker run --name wondershaper-container us.gcr.io/broad-dsp-gcr-public/wondershaper:latest
 ```
 
 Please note that the image is already published, so you don't need to perform any additional steps unless you want to modify the Dockerfile or the entrypoint script.

--- a/wondershaper/README.md
+++ b/wondershaper/README.md
@@ -31,12 +31,6 @@ docker run --name wondershaper-container us.gcr.io/wondershaper/wondershaper:lat
 
 Please note that the image is already published, so you don't need to perform any additional steps unless you want to modify the Dockerfile or the entrypoint script.
 
-If needed, the build and the publish commands are:
-```
-docker build -t us.gcr.io/broad-dsp-gcr-public/wondershaper:latest .
-docker push us.gcr.io/broad-dsp-gcr-public/wondershaper:latest
-```
-
 
 Remember to replace wondershaper-container with your preferred container name.
 

--- a/wondershaper/entrypoint.sh
+++ b/wondershaper/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Network interface and bandwidth values
+INTERFACE="eth0"
+UPLOAD_BANDWIDTH="16384"    # kilobits; 16Mib/s (2MiB/s)
+
+# Apply bandwidth limits using Wondershaper
+wondershaper -a $INTERFACE -u $UPLOAD_BANDWIDTH
+
+# Keep the container running
+tail -f /dev/null
+
+#!/bin/bash


### PR DESCRIPTION
I’ve created a wondershaper image and published it to this path https://pantheon.corp.google.com/gcr/images/broad-dsp-gcr-public/us/wondershaper?project=broad-dsp-gcr-public

I think we can still have this PR merged and keep the wondershaper image to use it in the future if needed, despite that we may be using GCE apps instead of GKE in the near future