### PR TITLE
IA-4362 remove java 8 for the gatk and aou images and update hail to 120

### DIFF
--- a/terra-jupyter-aou/CHANGELOG.md
+++ b/terra-jupyter-aou/CHANGELOG.md
@@ -1,9 +1,9 @@
-## 2.2.1 - 2023-07-06
+## 2.2.1 - 2023-07-28
 
 - Fix bug introduced in https://github.com/DataBiosphere/terra-docker/commit/4a5b4c9212aedcafa2f41fbeb2b161089341c578 
 - Remove outdated cromshell alias
-- Update `hail` to `0.2.119`
-  - See https://hail.is/docs/0.2/change_log.html#version-0-2-119 for details
+- Remove Java 8 and update `hail` to `0.2.120`
+  - See https://hail.is/docs/0.2/change_log.html#version-0-2-120 for details
 
 Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:2.2.1`
 

--- a/terra-jupyter-aou/Dockerfile
+++ b/terra-jupyter-aou/Dockerfile
@@ -47,7 +47,7 @@ ENV PYTHONPATH $PYTHONPATH:/usr/lib/spark/python
 
 ENV PYSPARK_PYTHON=python3
 
-ENV HAIL_VERSION=0.2.119
+ENV HAIL_VERSION=0.2.120
 
 RUN find $JUPYTER_HOME/scripts -name '*.sh' -type f | xargs chmod +x \
     && $JUPYTER_HOME/scripts/kernel/kernelspec.sh $JUPYTER_HOME/scripts/kernel /opt/conda/share/jupyter/kernels \

--- a/terra-jupyter-aou/Dockerfile
+++ b/terra-jupyter-aou/Dockerfile
@@ -58,11 +58,11 @@ RUN find $JUPYTER_HOME/scripts -name '*.sh' -type f | xargs chmod +x \
     && update-alternatives --install /etc/hadoop/conf hadoop-conf /etc/hadoop/conf.empty 100 \
     && update-alternatives --install /etc/hive/conf hive-conf /etc/hive/conf.dist 100 \
     && apt-get update \
-    && apt install -yq --no-install-recommends openjdk-8-jdk \
-        g++ \
-        liblz4-dev \
-    # specify Java 8
-    && update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java \
+    # Note that starting on 2.1.x, dataproc VM also provides java 11, which is incompatible with 8. No need to install it in the container
+    # && apt install -yq --no-install-recommends openjdk-8-jdk \
+    #     g++ \
+    #     liblz4-dev \
+    # && update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java \
     && pip3 install pypandoc gnomad \
     && pip3 install --no-dependencies hail==$HAIL_VERSION \
     && X=$(mktemp -d) \

--- a/terra-jupyter-gatk/CHANGELOG.md
+++ b/terra-jupyter-gatk/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 2.3.1 - 2023-07-06
+## 2.3.1 - 2023-07-28
 
-- Fix bug introduced in https://github.com/DataBiosphere/terra-docker/commit/4a5b4c9212aedcafa2f41fbeb2b161089341c578 
+- Fix bug introduced in https://github.com/DataBiosphere/terra-docker/commit/4a5b4c9212aedcafa2f41fbeb2b161089341c578
+- Remove Java 8 and update to GATK 4.3.0.0
 
 Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.3.1`
 

--- a/terra-jupyter-gatk/Dockerfile
+++ b/terra-jupyter-gatk/Dockerfile
@@ -7,7 +7,6 @@ USER root
 # need to apt-get everything for python since we can only copy pip installed packages
 RUN apt-get update && apt-get install -yq --no-install-recommends \
   python-tk \
-  openjdk-8-jdk \
   tk-dev \
   libssl-dev \
   xz-utils \
@@ -19,8 +18,6 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
   libz-dev \
   samtools \
   git-lfs \
-  # specify Java 8
-  && update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
@@ -34,7 +31,7 @@ COPY --from=python /etc/terra-docker/requirements.txt /etc/terra-docker/base_req
 RUN pip install --upgrade -r /etc/terra-docker/base_requirements.txt
 
 # Install GATK
-ENV GATK_VERSION 4.2.4.0
+ENV GATK_VERSION 4.3.0.0
 ENV GATK_ZIP_PATH /tmp/gatk-${GATK_VERSION}.zip
 
 RUN curl -L -o $GATK_ZIP_PATH https://github.com/broadinstitute/gatk/releases/download/$GATK_VERSION/gatk-$GATK_VERSION.zip \

--- a/terra-jupyter-hail/CHANGELOG.md
+++ b/terra-jupyter-hail/CHANGELOG.md
@@ -1,8 +1,8 @@
-## 1.1.1 - 2023-07-06
+## 1.1.1 - 2023-07-28
 
 - Fix bug introduced in https://github.com/DataBiosphere/terra-docker/commit/4a5b4c9212aedcafa2f41fbeb2b161089341c578 
-- Update `hail` to `0.2.119`
-  - See https://hail.is/docs/0.2/change_log.html#version-0-2-119 for details
+- Remove Java 8 and update `hail` to `0.2.120`
+  - See https://hail.is/docs/0.2/change_log.html#version-0-2-120 for details
 
 Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-hail:1.1.1`
 

--- a/terra-jupyter-hail/Dockerfile
+++ b/terra-jupyter-hail/Dockerfile
@@ -7,7 +7,7 @@ USER root
 ENV PIP_USER=false
 ENV PYTHONPATH $PYTHONPATH:/usr/lib/spark/python
 ENV PYSPARK_PYTHON=python3
-ENV HAIL_VERSION=0.2.119
+ENV HAIL_VERSION=0.2.120
 
 RUN find $JUPYTER_HOME/scripts -name '*.sh' -type f | xargs chmod +x \
     && $JUPYTER_HOME/scripts/kernel/kernelspec.sh $JUPYTER_HOME/scripts/kernel /opt/conda/share/jupyter/kernels \


### PR DESCRIPTION
Forgot to also remove the installation of Java 8 for the AOU image, we are getting Java 11 form the new debian11 dataproc image in leonardo now, and it conflicts with the Java 8 that was previously installed on the image

Instead of bumping up the version, i am just going to override the existing one since we never released it