### PR TITLE
Change legacy BiocJupyter to last 3.16 container

### DIFF
--- a/config/legacy_static_images.json
+++ b/config/legacy_static_images.json
@@ -1,11 +1,11 @@
 [
   {
     "updated": "2023-06-23",
-    "image": "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:2.1.11",
+    "image": "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:2.1.10",
     "label": "Legacy R / Bioconductor (R 4.2.2, Bioconductor 3.16, Python 3.7.12)",
-    "version": "2.1.11",
+    "version": "2.1.10",
     "requiresSpark": false,
-    "packages": "https://storage.googleapis.com/terra-docker-image-documentation/terra-jupyter-bioconductor-2.1.11-versions.json",
+    "packages": "https://storage.googleapis.com/terra-docker-image-documentation/terra-jupyter-bioconductor-2.1.10-versions.json",
     "id": "terra-jupyter-bioconductor_legacy"
   },
   {


### PR DESCRIPTION
`2.1.10` is the last version with R 4.2.2 and Bioc 3.16.
Since the latest container is Bioc 3.17 and R 4.3.0, it makes sense to leave the legacy at Bioc 3.16, rather than Bioc 3.17 with older python as is `2.1.11`.