### PR TITLE
ID-721 Update Terra Notebook Utils to 0.13.0

### DIFF
--- a/.github/workflows/test-terra-jupyter-base.yml
+++ b/.github/workflows/test-terra-jupyter-base.yml
@@ -38,7 +38,7 @@ env:
 jobs:
 
   test_docker_image:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
     - name: Checkout

--- a/.github/workflows/test-terra-jupyter-bioconductor.yml
+++ b/.github/workflows/test-terra-jupyter-bioconductor.yml
@@ -38,7 +38,7 @@ env:
 jobs:
 
   test_docker_image:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
     - name: Checkout

--- a/.github/workflows/test-terra-jupyter-hail.yml
+++ b/.github/workflows/test-terra-jupyter-hail.yml
@@ -38,7 +38,7 @@ env:
 jobs:
 
   test_docker_image:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
     - name: Checkout

--- a/.github/workflows/test-terra-jupyter-python.yml
+++ b/.github/workflows/test-terra-jupyter-python.yml
@@ -40,7 +40,7 @@ env:
 jobs:
 
   test_docker_image:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
     - name: Checkout
@@ -52,7 +52,7 @@ jobs:
         python-version: '3.10'
 
     - name: Free up some disk space
-      run: sudo rm -rf /usr/share/dotnet    
+      run: sudo rm -rf /usr/share/dotnet
 
     - id: auth
       uses: google-github-actions/auth@v1
@@ -113,7 +113,7 @@ jobs:
           --entrypoint="" \
           terra-jupyter-python:smoke-test \
           /bin/sh -c "pip3 install pytest ; pytest"
-          
+
     - name: Test Python code specific to notebooks with nbconvert
       # Simply 'Cell -> Run All` these notebooks and expect no errors in the case of a successful run of the test suite.
       # If the tests throw any exceptions, execution of the notebooks will halt at that point. Look at the workflow

--- a/build.sh
+++ b/build.sh
@@ -42,22 +42,22 @@ docker image build ./$IMAGE_DIR \
   --tag $GCR_IMAGE_REPO/$IMAGE_DIR:$VERSION \
   --tag $GCR_IMAGE_REPO/$IMAGE_DIR:latest
 
-docker push $GCR_IMAGE_REPO/$IMAGE_DIR:$TAG_NAME
-docker push $GCR_IMAGE_REPO/$IMAGE_DIR:$VERSION
-docker push $GCR_IMAGE_REPO/$IMAGE_DIR:latest
-
-docker kill $IMAGE_DIR || true
-docker rm -f $IMAGE_DIR || true
-docker run --rm -itd -u root -e PIP_USER=false --entrypoint='/bin/bash' --name $IMAGE_DIR $GCR_IMAGE_REPO/$IMAGE_DIR:$VERSION
-
-if [[ $IMAGE_DIR != "terra-rstudio-aou" ]]; then
-  gcloud auth list
-  python scripts/generate_package_docs.py "$IMAGE_DIR"
-fi
-
-docker kill $IMAGE_DIR || true
-docker rm -f $IMAGE_DIR || true
-docker image rm -f $GCR_IMAGE_REPO/$IMAGE_DIR:$VERSION
-docker image rm -f $GCR_IMAGE_REPO/$IMAGE_DIR:$TAG_NAME
+#docker push $GCR_IMAGE_REPO/$IMAGE_DIR:$TAG_NAME
+#docker push $GCR_IMAGE_REPO/$IMAGE_DIR:$VERSION
+#docker push $GCR_IMAGE_REPO/$IMAGE_DIR:latest
+#
+#docker kill $IMAGE_DIR || true
+#docker rm -f $IMAGE_DIR || true
+#docker run --rm -itd -u root -e PIP_USER=false --entrypoint='/bin/bash' --name $IMAGE_DIR $GCR_IMAGE_REPO/$IMAGE_DIR:$VERSION
+#
+#if [[ $IMAGE_DIR != "terra-rstudio-aou" ]]; then
+#  gcloud auth list
+#  python scripts/generate_package_docs.py "$IMAGE_DIR"
+#fi
+#
+#docker kill $IMAGE_DIR || true
+#docker rm -f $IMAGE_DIR || true
+#docker image rm -f $GCR_IMAGE_REPO/$IMAGE_DIR:$VERSION
+#docker image rm -f $GCR_IMAGE_REPO/$IMAGE_DIR:$TAG_NAME
 
 echo "Successfully completed build script for $IMAGE_DIR"

--- a/build.sh
+++ b/build.sh
@@ -42,22 +42,22 @@ docker image build ./$IMAGE_DIR \
   --tag $GCR_IMAGE_REPO/$IMAGE_DIR:$VERSION \
   --tag $GCR_IMAGE_REPO/$IMAGE_DIR:latest
 
-#docker push $GCR_IMAGE_REPO/$IMAGE_DIR:$TAG_NAME
-#docker push $GCR_IMAGE_REPO/$IMAGE_DIR:$VERSION
-#docker push $GCR_IMAGE_REPO/$IMAGE_DIR:latest
-#
-#docker kill $IMAGE_DIR || true
-#docker rm -f $IMAGE_DIR || true
-#docker run --rm -itd -u root -e PIP_USER=false --entrypoint='/bin/bash' --name $IMAGE_DIR $GCR_IMAGE_REPO/$IMAGE_DIR:$VERSION
-#
-#if [[ $IMAGE_DIR != "terra-rstudio-aou" ]]; then
-#  gcloud auth list
-#  python scripts/generate_package_docs.py "$IMAGE_DIR"
-#fi
-#
-#docker kill $IMAGE_DIR || true
-#docker rm -f $IMAGE_DIR || true
-#docker image rm -f $GCR_IMAGE_REPO/$IMAGE_DIR:$VERSION
-#docker image rm -f $GCR_IMAGE_REPO/$IMAGE_DIR:$TAG_NAME
+docker push $GCR_IMAGE_REPO/$IMAGE_DIR:$TAG_NAME
+docker push $GCR_IMAGE_REPO/$IMAGE_DIR:$VERSION
+docker push $GCR_IMAGE_REPO/$IMAGE_DIR:latest
+
+docker kill $IMAGE_DIR || true
+docker rm -f $IMAGE_DIR || true
+docker run --rm -itd -u root -e PIP_USER=false --entrypoint='/bin/bash' --name $IMAGE_DIR $GCR_IMAGE_REPO/$IMAGE_DIR:$VERSION
+
+if [[ $IMAGE_DIR != "terra-rstudio-aou" ]]; then
+  gcloud auth list
+  python scripts/generate_package_docs.py "$IMAGE_DIR"
+fi
+
+docker kill $IMAGE_DIR || true
+docker rm -f $IMAGE_DIR || true
+docker image rm -f $GCR_IMAGE_REPO/$IMAGE_DIR:$VERSION
+docker image rm -f $GCR_IMAGE_REPO/$IMAGE_DIR:$TAG_NAME
 
 echo "Successfully completed build script for $IMAGE_DIR"

--- a/config/conf.json
+++ b/config/conf.json
@@ -26,7 +26,7 @@
                     "tidyverse"
                 ]
             },
-            "version" : "2.2.1",
+            "version" : "2.2.2",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : true,
@@ -47,7 +47,7 @@
                     "hail"
                 ]
             },
-            "version" : "1.1.1",
+            "version" : "1.1.2",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : true,
@@ -68,7 +68,7 @@
                     "scikit-learn"
                 ]
             },
-            "version" : "1.1.1",
+            "version" : "1.1.2",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : true,
@@ -84,9 +84,9 @@
                 "python"
             ],
             "packages" : {
-                
+
             },
-            "version" : "1.1.1",
+            "version" : "1.1.2",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : false,
@@ -102,9 +102,9 @@
                 "r"
             ],
             "packages" : {
-                
+
             },
-            "version" : "2.2.1",
+            "version" : "2.2.2",
             "automated_flags" : {
                 "include_in_ui" : false,
                 "generate_docs" : true,
@@ -122,9 +122,9 @@
                 "r"
             ],
             "packages" : {
-                
+
             },
-            "version" : "2.3.1",
+            "version" : "2.3.2",
             "automated_flags" : {
                 "include_in_ui" : true,
                 "generate_docs" : true,
@@ -141,9 +141,9 @@
                 "r"
             ],
             "packages" : {
-                
+
             },
-            "version" : "2.2.1",
+            "version" : "2.2.2",
             "automated_flags" : {
                 "include_in_ui" : false,
                 "generate_docs" : false,
@@ -159,7 +159,7 @@
                 "r"
             ],
             "packages" : {
-                
+
             },
             "version" : "0.1.1",
             "automated_flags" : {

--- a/mind.puml
+++ b/mind.puml
@@ -1,10 +1,10 @@
 @startmindmap
-* terra-jupyter-base Y
-** terra-jupyter-python Y
-*** terra-jupyter-gatk Y
+* terra-jupyter-base
+** terra-jupyter-python
+*** terra-jupyter-gatk
 **** terra-jupyter-aou
 *** terra-jupyter-hail
-** terra-jupyter-r Y
-*** terra-jupyter-gatk Y
-*** terra-jupyter-bioconductor Y
+** terra-jupyter-r
+*** terra-jupyter-gatk
+*** terra-jupyter-bioconductor
 @endmindmap

--- a/mind.puml
+++ b/mind.puml
@@ -2,6 +2,7 @@
 * terra-jupyter-base
 ** terra-jupyter-python
 *** terra-jupyter-gatk
+**** terra-jupyter-aou
 *** terra-jupyter-hail
 ** terra-jupyter-r
 *** terra-jupyter-gatk

--- a/mind.puml
+++ b/mind.puml
@@ -1,10 +1,10 @@
 @startmindmap
-* terra-jupyter-base
-** terra-jupyter-python
-*** terra-jupyter-gatk
+* terra-jupyter-base Y
+** terra-jupyter-python Y
+*** terra-jupyter-gatk Y
 **** terra-jupyter-aou
 *** terra-jupyter-hail
-** terra-jupyter-r
-*** terra-jupyter-gatk
-*** terra-jupyter-bioconductor
+** terra-jupyter-r Y
+*** terra-jupyter-gatk Y
+*** terra-jupyter-bioconductor Y
 @endmindmap

--- a/terra-jupyter-aou/CHANGELOG.md
+++ b/terra-jupyter-aou/CHANGELOG.md
@@ -3,6 +3,9 @@
   - Update `terra-jupyter-python` to `1.1.2`
     - Update `terra-jupyter-base` tp `1.1.2`
       - Upgrade Terra Notebook Utils to `0.13.0`
+- Update PanGenie to 3.0.1 and pinning version
+- Update RMBlast to 2.14.0
+- Update RepeatMasker to 4.1.5
 
 Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:2.2.2`
 

--- a/terra-jupyter-aou/CHANGELOG.md
+++ b/terra-jupyter-aou/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2.2.2 - 2023-07-31
+- Update `terra-jupyter-gatk` to `2.3.2`
+  - Update `terra-jupyter-python` to `1.1.2`
+    - Update `terra-jupyter-base` tp `1.1.2`
+      - Upgrade Terra Notebook Utils to `0.13.0`
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:2.2.2`
+
 ## 2.2.1 - 2023-07-06
 
 - Fix bug introduced in https://github.com/DataBiosphere/terra-docker/commit/4a5b4c9212aedcafa2f41fbeb2b161089341c578 

--- a/terra-jupyter-aou/Dockerfile
+++ b/terra-jupyter-aou/Dockerfile
@@ -212,16 +212,27 @@ RUN mkdir -p /tmp/jellyfish && \
     cd $HOME && \
     rm -rf /tmp/jellyfish
 
+# Install Cereal headers (dependency of pangenie)
+RUN mkdir -p /tmp/cereal && \
+    cd /tmp/cereal && \
+    curl -fsSL -o cereal.tar.gz https://github.com/USCiLab/cereal/archive/refs/tags/v1.3.2.tar.gz && \
+    tar xvf cereal.tar.gz && \
+    cd cereal-1.3.2/include && \
+    mv cereal/ /usr/local/include/ && \
+    cd $HOME && \
+    rm -rf /tmp/cereal
+
 # Install pangenie
 RUN mkdir -p /tmp/pangenie && \
-  cd /tmp/pangenie && \
-  git clone https://github.com/eblerjana/pangenie.git && \
-  cd pangenie && \
-  mkdir build; cd build; cmake .. ; make && cd src && \
-  mv *.so /lib && \
-  mv * /bin/ && \
-  cd $HOME && \
-  rm -rf /tmp/pangenie
+    cd /tmp/pangenie && \
+    curl -fsSL -o pangenie.tar.gz https://github.com/eblerjana/pangenie/archive/refs/tags/v3.0.1.tar.gz && \
+    tar xvf pangenie.tar.gz && \
+    cd pangenie-3.0.1 && \
+    mkdir build; cd build; cmake .. ; make && cd src && \
+    mv *.so /lib && \
+    mv * /bin/ && \
+    cd $HOME && \
+    rm -rf /tmp/pangenie
 
 # Install minimap2
 RUN curl -fsSL https://github.com/lh3/minimap2/releases/download/v2.24/minimap2-2.24_x64-linux.tar.bz2 | tar -jxvf - && cd minimap2-2.24_x64-linux/ && cp minimap2 /bin/minimap2 && cd $HOME
@@ -247,16 +258,16 @@ RUN mkdir -p /tmp/hmmer && cd /tmp/hmmer && \
 
 # rmblast (200M)
 RUN mkdir -p /tmp/rmblast && cd /tmp/rmblast && \
-  curl -fsSL -o rmblast-2.11.0+-x64-linux.tar.gz http://www.repeatmasker.org/rmblast-2.11.0+-x64-linux.tar.gz && \
-  tar -zxvf rmblast-2.11.0+-x64-linux.tar.gz && \
-  cp rmblast-2.11.0/bin/* /usr/local/bin && \
+  curl -fsSL -o rmblast-2.14.0+-x64-linux.tar.gz https://www.repeatmasker.org/rmblast/rmblast-2.14.0+-x64-linux.tar.gz && \
+  tar -zxvf rmblast-2.14.0+-x64-linux.tar.gz && \
+  cp rmblast-2.14.0/bin/* /usr/local/bin && \
   cd $HOME && \
   rm -rf /tmp/rmblast
 
 RUN PERL_MM_USE_DEFAULT=1 cpan Text::Soundex
 
 # Install RepeatMasker (900M)
-RUN curl -fsSL http://www.repeatmasker.org/RepeatMasker/RepeatMasker-4.1.4.tar.gz \
+RUN curl -fsSL http://www.repeatmasker.org/RepeatMasker/RepeatMasker-4.1.5.tar.gz \
   | (cd /usr/local; tar -xz)
 
 # Remove workspace_cromwell script as it may allow user bypass AoU to create Cromwell via Leo directly

--- a/terra-jupyter-aou/Dockerfile
+++ b/terra-jupyter-aou/Dockerfile
@@ -34,7 +34,8 @@ RUN pip3 install \
       nbstripout \
       papermill \
       dsub \
-      "git+https://github.com/all-of-us/workbench-snippets.git#egg=terra_widgets&subdirectory=py"
+      "git+https://github.com/all-of-us/workbench-snippets.git#egg=terra_widgets&subdirectory=py" \
+      'PyYAML==6.0.1'
 
 
 # 2.0.0 has breaking changes and we're not ready for them yet.

--- a/terra-jupyter-aou/Dockerfile
+++ b/terra-jupyter-aou/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.3.1
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.3.2
 
 USER root
 

--- a/terra-jupyter-base/CHANGELOG.md
+++ b/terra-jupyter-base/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.1.2 - 2023-07-31
+- Upgrade Terra Notebook Utils to `0.13.0`
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.1.2`
+
 ## 1.1.1 - 2023-07-06
 
 - Fix bug introduced in https://github.com/DataBiosphere/terra-docker/commit/4a5b4c9212aedcafa2f41fbeb2b161089341c578 

--- a/terra-jupyter-base/Dockerfile
+++ b/terra-jupyter-base/Dockerfile
@@ -69,7 +69,7 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
     # Generate locale
     && locale-gen \
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* 
+    && rm -rf /var/lib/apt/lists/*
 
 ENV LC_ALL en_US.UTF-8
 
@@ -108,9 +108,9 @@ RUN pip3 -V \
     # for jupyter_delocalize.py and jupyter_notebook_config.py
     && pip3 install requests \
     && pip3 install firecloud \
-    && pip3 install terra-notebook-utils \
+    && pip3 install terra-notebook-utils==0.13.0 \
     && pip3 install crcmod \
-    # For gcloud alpha storage support.   
+    # For gcloud alpha storage support.
     && pip3 install google-crc32c --target /usr/lib/google-cloud-sdk/lib/third_party \
     && pip3 install cromshell==2.0.0
 

--- a/terra-jupyter-base/Dockerfile
+++ b/terra-jupyter-base/Dockerfile
@@ -102,7 +102,7 @@ RUN pip3 -V \
     && pip3 install jupyter_nbextensions_configurator \
     && pip3 install markupsafe==2.1.2 \
     # Avoid broken lower versions: https://github.com/jupyter/nbconvert/pull/1624, pinning to latest known working version on terra
-    && pip3 install "nbconvert==7.2.9" \
+    && pip3 install "nbconvert>=7.7.3" \
     # Avoid notebook extension issues
     && pip3 install "nbclassic<0.5" \
     # for jupyter_delocalize.py and jupyter_notebook_config.py

--- a/terra-jupyter-bioconductor/CHANGELOG.md
+++ b/terra-jupyter-bioconductor/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.2.2 - 2023-07-31
+- Update `terra-jupyter-r` to `2.2.2`
+  - Update `terra-jupyter-base` to `1.1.2`
+    - Upgrade Terra Notebook Utils to `0.13.0`
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:2.2.2`
+
 ## 2.2.1 - 2023-07-06
 
 - Fix bug introduced in https://github.com/DataBiosphere/terra-docker/commit/4a5b4c9212aedcafa2f41fbeb2b161089341c578 

--- a/terra-jupyter-bioconductor/Dockerfile
+++ b/terra-jupyter-bioconductor/Dockerfile
@@ -1,1 +1,1 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.2.1
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.2.2

--- a/terra-jupyter-gatk/CHANGELOG.md
+++ b/terra-jupyter-gatk/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.3.2 - 2023-07-31
+- Update `terra-jupyter-python` to `1.1.2`
+  - Update `terra-jupyter-base` tp `1.1.2`
+    - Upgrade Terra Notebook Utils to `0.13.0`
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.3.2`
+
 ## 2.3.1 - 2023-07-06
 
 - Fix bug introduced in https://github.com/DataBiosphere/terra-docker/commit/4a5b4c9212aedcafa2f41fbeb2b161089341c578 

--- a/terra-jupyter-gatk/Dockerfile
+++ b/terra-jupyter-gatk/Dockerfile
@@ -81,10 +81,12 @@ RUN patch -u /opt/conda/lib/python3.10/site-packages/vqsr_cnn/vqsr_cnn/models.py
 
 # Older version of nbconvert fail to convert notebooks to html
 RUN pip3 install "nbconvert>=7.7.3"
-# pytz seems to have a metadata error when installing. Force-reinstalling fixes this.
-RUN pip3 install --force-reinstall pytz
 
 ENV PIP_USER=true
 
 ENV USER jupyter
+
 USER $USER
+
+# pytz seems to have a metadata error when installing. Force-reinstalling fixes this.
+RUN pip3 install --force-reinstall pytz

--- a/terra-jupyter-gatk/Dockerfile
+++ b/terra-jupyter-gatk/Dockerfile
@@ -81,6 +81,8 @@ RUN patch -u /opt/conda/lib/python3.10/site-packages/vqsr_cnn/vqsr_cnn/models.py
 
 # Older version of nbconvert fail to convert notebooks to html
 RUN pip3 install "nbconvert>=7.7.3"
+# pytz seems to have a metadata error when installing. Force-reinstalling fixes this.
+RUN pip3 install --force-reinstall pytz
 
 ENV PIP_USER=true
 

--- a/terra-jupyter-gatk/Dockerfile
+++ b/terra-jupyter-gatk/Dockerfile
@@ -79,6 +79,9 @@ COPY cnn-models.patch /etc/gatk-$GATK_VERSION/cnn-models.patch
 
 RUN patch -u /opt/conda/lib/python3.10/site-packages/vqsr_cnn/vqsr_cnn/models.py -i /etc/gatk-$GATK_VERSION/cnn-models.patch
 
+# Older version of nbconvert fail to convert notebooks to html
+RUN pip3 install "nbconvert>=7.7.3"
+
 ENV PIP_USER=true
 
 ENV USER jupyter

--- a/terra-jupyter-gatk/Dockerfile
+++ b/terra-jupyter-gatk/Dockerfile
@@ -1,6 +1,6 @@
 FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.1.2 AS python
 
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.2.1
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.2.2
 
 USER root
 

--- a/terra-jupyter-gatk/Dockerfile
+++ b/terra-jupyter-gatk/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.1.1 AS python
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.1.2 AS python
 
 FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.2.1
 

--- a/terra-jupyter-hail/CHANGELOG.md
+++ b/terra-jupyter-hail/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.1.2 - 2023-07-31
+- Update `terra-jupyter-python` to `1.1.2`
+  - Update `terra-jupyter-base` to `1.1.2`
+    - Upgrade Terra Notebook Utils to `0.13.0`
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-hail:1.1.2`
+
 ## 1.1.1 - 2023-07-06
 
 - Fix bug introduced in https://github.com/DataBiosphere/terra-docker/commit/4a5b4c9212aedcafa2f41fbeb2b161089341c578 

--- a/terra-jupyter-hail/Dockerfile
+++ b/terra-jupyter-hail/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.1.1
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.1.2
 
 USER root
 

--- a/terra-jupyter-python/CHANGELOG.md
+++ b/terra-jupyter-python/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.1.2 - 2023-07-31
+- Update `terra-jupyter-base` to `1.1.2`
+  - Upgrade Terra Notebook Utils to `0.13.0`
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.1.2`
+
 ## 1.1.1 - 2023-07-06
 
 - Fix bug introduced in https://github.com/DataBiosphere/terra-docker/commit/4a5b4c9212aedcafa2f41fbeb2b161089341c578 

--- a/terra-jupyter-python/Dockerfile
+++ b/terra-jupyter-python/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.1.1
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.1.2
 
 USER root
 # This makes it so pip runs as root, not the user.

--- a/terra-jupyter-python/Dockerfile
+++ b/terra-jupyter-python/Dockerfile
@@ -34,20 +34,11 @@ COPY requirements.txt /etc/terra-docker/
 RUN pip3 -V \
   && pip3 install --upgrade pip \
   && pip3 install --upgrade -r /etc/terra-docker/requirements.txt \
-
-  # Remove this after https://broadworkbench.atlassian.net/browse/CA-1179
-  # As of release [google-cloud-bigquery 1.26.0 (2020-07-20)](https://github.com/googleapis/python-bigquery/blob/master/CHANGELOG.md#1260-2020-07-20)
-  # the BigQuery Python client uses the BigQuery Storage client by default.
-  # This currently causes an error on Terra Cloud Runtimes `the user does not have 'bigquery.readsessions.create' permission
-  # for '<Terra billing project id>'`. To work-around this uninstall the dependency so that flag `--use_rest_api` can be used
-  # with `%%bigquery` to use the older, slower mechanism for data transfer.
-  && pip3 uninstall -y google-cloud-bigquery-storage \
   && sed -i 's/pandas.lib/pandas/g' /opt/conda/lib/python3.10/site-packages/ggplot/stats/smoothers.py \
   # the next few `sed` lines are workaround for a ggplot bug. See https://github.com/yhat/ggpy/issues/662
   && sed -i 's/pandas.tslib.Timestamp/pandas.Timestamp/g' /opt/conda/lib/python3.10/site-packages/ggplot/stats/smoothers.py \
   && sed -i 's/pd.tslib.Timestamp/pd.Timestamp/g' /opt/conda/lib/python3.10/site-packages/ggplot/stats/smoothers.py \
   && sed -i 's/pd.tslib.Timestamp/pd.Timestamp/g' /opt/conda/lib/python3.10/site-packages/ggplot/utils.py
-
 
 RUN pip3 install --upgrade markupsafe==2.1.2
 
@@ -57,6 +48,9 @@ USER $USER
 ENV PIP_USER=true
 # Enable Intel oneDNN optimizatoin by default
 ENV TF_ENABLE_ONEDNN_OPTS=1
+
+# pytz seems to have a metadata error when installing. Force-reinstalling fixes this.
+RUN pip3 install --force-reinstall pytz
 
 # Note: this entrypoint is provided for running Jupyter independently of Leonardo.
 # When Leonardo deploys this image onto a cluster, the entrypoint is overwritten to enable

--- a/terra-jupyter-python/requirements.txt
+++ b/terra-jupyter-python/requirements.txt
@@ -36,7 +36,8 @@ certifi
 intel-openmp
 mkl
 wheel
-plotnine
+plotnine==0.10.1
+mizani==0.9.2
 google-resumable-media
 #adding intel optimized xgboost and intel extension for scikit-learn
 scikit-learn-intelex

--- a/terra-jupyter-python/tests/smoke_test.ipynb
+++ b/terra-jupyter-python/tests/smoke_test.ipynb
@@ -33,7 +33,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Test cases requiring the context of a notebook "
+    "# Test cases requiring the context of a notebook"
    ]
   },
   {
@@ -377,7 +377,7 @@
    "source": [
     "%%bash\n",
     "\n",
-    "gcloud version "
+    "gcloud version"
    ]
   },
   {
@@ -464,7 +464,7 @@
     "%%bash\n",
     "\n",
     "# test composite object, requires python crcmod to be installed\n",
-    "gsutil cp gs://terra-docker-image-documentation/test-composite.cram . "
+    "gsutil cp gs://terra-docker-image-documentation/test-composite.cram ."
    ]
   },
   {
@@ -593,7 +593,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Define a loss function for training "
+    "Define a loss function for training"
    ]
   },
   {
@@ -653,7 +653,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Validate usage of oneDNN optimization \n",
+    "### Validate usage of oneDNN optimization\n",
     ">Please redirect standard outputs and errors to stdout.txt and stderr.txt files by starting jupyter notebook with below command.\n",
     "```\n",
     "jupyter notebook --ip=0.0.0.0 > stdout.txt 2>stderr.txt\n",
@@ -819,11 +819,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Starting with [XGBoost](https://xgboost.readthedocs.io/en/latest/index.html) 0.81 version onward, Intel has been directly upstreaming many training optimizations to provide superior performance on Intel® CPUs. \n",
+    "Starting with [XGBoost](https://xgboost.readthedocs.io/en/latest/index.html) 0.81 version onward, Intel has been directly upstreaming many training optimizations to provide superior performance on Intel® CPUs.\n",
     "\n",
-    "Starting with XGBoost 1.3 version onward, Intel has been upstreaming inference optimizations to provide even more performance on Intel® CPUs. \n",
+    "Starting with XGBoost 1.3 version onward, Intel has been upstreaming inference optimizations to provide even more performance on Intel® CPUs.\n",
     "\n",
-    "This well-known, machine-learning package for gradient-boosted decision trees now includes seamless, drop-in acceleration for Intel® architectures to significantly speed up model training and improve accuracy for better predictions. \n",
+    "This well-known, machine-learning package for gradient-boosted decision trees now includes seamless, drop-in acceleration for Intel® architectures to significantly speed up model training and improve accuracy for better predictions.\n",
     "\n",
     "We will use the following cell to validate the XGBoost version to determine if these optimizations are enabled."
    ]

--- a/terra-jupyter-r/CHANGELOG.md
+++ b/terra-jupyter-r/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.2.2 - 2023-07-31
+- Update `terra-jupyter-base` to `1.1.2`
+  - Upgrade Terra Notebook Utils to `0.13.0`
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.2.2`
+
 ## 2.2.1 - 2023-07-06
 
 - Fix bug introduced in https://github.com/DataBiosphere/terra-docker/commit/4a5b4c9212aedcafa2f41fbeb2b161089341c578 

--- a/terra-jupyter-r/Dockerfile
+++ b/terra-jupyter-r/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.1.1
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.1.2
 
 USER root
 
@@ -160,14 +160,14 @@ RUN R -e 'install.packages("BiocManager")' \
     "pbdZMQ", \
     "uuid"))' \
     && R -e 'BiocManager::install("DataBiosphere/Ronaldo")'
-    
+
 # Install Bioconductor packages found at:
 # https://raw.githubusercontent.com/anvilproject/anvil-docker/master/anvil-rstudio-bioconductor/install.R
 RUN R -e 'BiocManager::install(c( \
     "AnVIL", \
-    "SingleCellExperiment", \ 
+    "SingleCellExperiment", \
     "GenomicFeatures", \
-    "GenomicAlignments", \ 
+    "GenomicAlignments", \
     "ShortRead", \
     "DESeq2", \
     "AnnotationHub", \

--- a/terra-jupyter-r/Dockerfile
+++ b/terra-jupyter-r/Dockerfile
@@ -5,7 +5,7 @@ USER root
 COPY scripts $JUPYTER_HOME/scripts
 
 # Add env vars to identify binary package installation
-ENV TERRA_R_PLATFORM="terra-jupyter-r-1.1.1"
+ENV TERRA_R_PLATFORM="terra-jupyter-r-1.1.2"
 ENV TERRA_R_PLATFORM_BINARY_VERSION=3.17
 
 # Install protobuf 3.20.3. Note this version comes from base deep learning image. Use `conda list` to see what's installed


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/ID-721

Updating TNU to `0.13.0` so that the DRSHub can be used instead of Martha. If TNU sees a `DRS_RESOLVER_ENDPOINT` environment variable, it will talk to DRSHub at the specified endpoint for DRS resolutions. If the env var is not provided, TNU will default back to Martha.

Looks like I had to update all the images!