### PR TITLE
Add some missing sysdeps for Bioc/R packages

### DIFF
--- a/.github/workflows/test-terra-jupyter-bioconductor.yml
+++ b/.github/workflows/test-terra-jupyter-bioconductor.yml
@@ -50,7 +50,7 @@ jobs:
         python-version: '3.10'
 
     - name: Free up some disk space
-      run: sudo rm -rf /usr/share/dotnet
+      run: sudo rm -rf /usr/share/dotnet && sudo rm -rf /usr/local/lib/android && sudo rm -rf /usr/lib/firefox
 
     - id: auth
       uses: google-github-actions/auth@v1

--- a/.github/workflows/test-terra-jupyter-bioconductor.yml
+++ b/.github/workflows/test-terra-jupyter-bioconductor.yml
@@ -42,10 +42,10 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: '3.10'
 

--- a/config/conf.json
+++ b/config/conf.json
@@ -26,7 +26,7 @@
                     "tidyverse"
                 ]
             },
-            "version" : "2.2.1",
+            "version" : "2.2.2",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : true,
@@ -104,7 +104,7 @@
             "packages" : {
                 
             },
-            "version" : "2.2.1",
+            "version" : "2.2.2",
             "automated_flags" : {
                 "include_in_ui" : false,
                 "generate_docs" : true,
@@ -124,7 +124,7 @@
             "packages" : {
                 
             },
-            "version" : "2.3.1",
+            "version" : "2.3.2",
             "automated_flags" : {
                 "include_in_ui" : true,
                 "generate_docs" : true,
@@ -143,7 +143,7 @@
             "packages" : {
                 
             },
-            "version" : "2.2.1",
+            "version" : "2.2.2",
             "automated_flags" : {
                 "include_in_ui" : false,
                 "generate_docs" : false,
@@ -176,7 +176,7 @@
             "tools" : [
             ],
             "packages" : {
-
+                
             },
             "version" : "0.0.1",
             "automated_flags" : {

--- a/terra-jupyter-aou/CHANGELOG.md
+++ b/terra-jupyter-aou/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.2.2 - 2023-08-18T18:31:49.659779743Z
+
+- Update `terra-jupyter-r` to `2.2.2`
+  - Add missing sysdeps for Bioc/R packages
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:2.2.2`
+
 ## 2.2.1 - 2023-07-28
 
 - Fix bug introduced in https://github.com/DataBiosphere/terra-docker/commit/4a5b4c9212aedcafa2f41fbeb2b161089341c578 

--- a/terra-jupyter-aou/Dockerfile
+++ b/terra-jupyter-aou/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.3.1
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.3.2
 
 USER root
 

--- a/terra-jupyter-bioconductor/CHANGELOG.md
+++ b/terra-jupyter-bioconductor/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.2.2 - 2023-08-18T18:31:49.558490764Z
+
+- Update `terra-jupyter-r` to `2.2.2`
+  - Add missing sysdeps for Bioc/R packages
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:2.2.2`
+
 ## 2.2.1 - 2023-07-06
 
 - Fix bug introduced in https://github.com/DataBiosphere/terra-docker/commit/4a5b4c9212aedcafa2f41fbeb2b161089341c578 

--- a/terra-jupyter-bioconductor/Dockerfile
+++ b/terra-jupyter-bioconductor/Dockerfile
@@ -1,1 +1,1 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.2.1
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.2.2

--- a/terra-jupyter-gatk/CHANGELOG.md
+++ b/terra-jupyter-gatk/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.3.2 - 2023-08-18T18:31:49.586852208Z
+
+- Update `terra-jupyter-r` to `2.2.2`
+  - Add missing sysdeps for Bioc/R packages
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.3.2`
+
 ## 2.3.1 - 2023-07-28
 
 - Fix bug introduced in https://github.com/DataBiosphere/terra-docker/commit/4a5b4c9212aedcafa2f41fbeb2b161089341c578

--- a/terra-jupyter-gatk/Dockerfile
+++ b/terra-jupyter-gatk/Dockerfile
@@ -1,6 +1,6 @@
 FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.1.1 AS python
 
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.2.1
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.2.2
 
 USER root
 

--- a/terra-jupyter-r/CHANGELOG.md
+++ b/terra-jupyter-r/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.2.2 - 2023-08-18T18:31:49.471831821Z
+
+- Add missing sysdeps for Bioc/R packages
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.2.2`
+
 ## 2.2.1 - 2023-07-06
 
 - Fix bug introduced in https://github.com/DataBiosphere/terra-docker/commit/4a5b4c9212aedcafa2f41fbeb2b161089341c578 

--- a/terra-jupyter-r/Dockerfile
+++ b/terra-jupyter-r/Dockerfile
@@ -103,6 +103,10 @@ RUN apt-get update \
         libeigen3-dev \
         ## for rawrr package
         mono-runtime \
+	## for nloptr package
+	cmake \
+ 	## for archive package
+ 	libarchive-dev \
     && ln -s /usr/lib/gcc/x86_64-linux-gnu/7/libgfortran.so /usr/lib/x86_64-linux-gnu/libgfortran.so \
     && ln -s /usr/lib/gcc/x86_64-linux-gnu/7/libstdc++.so /usr/lib/x86_64-linux-gnu/libstdc++.so \
     && apt-get clean \


### PR DESCRIPTION
Some missing sysdeps surfaced in the new base container after it was changed for the python upgrade