### PR TITLE
[IA-4586] Regenerate images with known versions of jupyter notebook and server

### DIFF
--- a/config/conf.json
+++ b/config/conf.json
@@ -26,7 +26,7 @@
                     "tidyverse"
                 ]
             },
-            "version" : "2.2.2",
+            "version" : "2.2.3",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : true,
@@ -47,7 +47,7 @@
                     "hail"
                 ]
             },
-            "version" : "1.1.2",
+            "version" : "1.1.3",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : true,
@@ -68,7 +68,7 @@
                     "scikit-learn"
                 ]
             },
-            "version" : "1.1.2",
+            "version" : "1.1.3",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : true,
@@ -86,7 +86,7 @@
             "packages" : {
 
             },
-            "version" : "1.1.2",
+            "version" : "1.1.3",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : false,
@@ -104,7 +104,7 @@
             "packages" : {
 
             },
-            "version" : "2.2.2",
+            "version" : "2.2.3",
             "automated_flags" : {
                 "include_in_ui" : false,
                 "generate_docs" : true,
@@ -124,7 +124,7 @@
             "packages" : {
 
             },
-            "version" : "2.3.2",
+            "version" : "2.3.3",
             "automated_flags" : {
                 "include_in_ui" : true,
                 "generate_docs" : true,
@@ -143,7 +143,7 @@
             "packages" : {
 
             },
-            "version" : "2.2.2",
+            "version" : "2.2.3",
             "automated_flags" : {
                 "include_in_ui" : false,
                 "generate_docs" : false,

--- a/terra-jupyter-aou/CHANGELOG.md
+++ b/terra-jupyter-aou/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2.2.3 - 2023-10-03
+- Update `terra-jupyter-gatk` to `2.3.3`
+  - Update `terra-jupyter-python` to `1.1.3`
+    - Update `terra-jupyter-base` to `1.1.3`
+      - Downgrade notebook to `6.5.4` and jupyterlab-server to `2.23.0`
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:2.2.3`
+
 ## 2.2.2 - 2023-07-31
 - Update `terra-jupyter-gatk` to `2.3.2`
   - Update `terra-jupyter-python` to `1.1.2`

--- a/terra-jupyter-aou/Dockerfile
+++ b/terra-jupyter-aou/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.3.2
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.3.3
 
 USER root
 

--- a/terra-jupyter-base/CHANGELOG.md
+++ b/terra-jupyter-base/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.1.3 - 2023-10-03
+- Downgrade notebook to `6.5.4` and jupyterlab-server to `2.23.0`
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.1.3`
+
 ## 1.1.2 - 2023-07-31
 - Upgrade Terra Notebook Utils to `0.13.0`
 

--- a/terra-jupyter-base/Dockerfile
+++ b/terra-jupyter-base/Dockerfile
@@ -106,6 +106,9 @@ RUN pip3 -V \
     # Avoid notebook extension issues
     && pip3 install "nbclassic<0.5" \
     # for jupyter_delocalize.py and jupyter_notebook_config.py
+    # DO NOT CHANGE OR UNPIN NOTEBOOK OR JUPYTERLAB-SERVER! When trying with 6.5.5 and 2.24.0 notebook commands could not find the notebook config file
+    && pip3 install notebook==6.5.4 \
+    && pip3 install jupyterlab-server==2.23.0 \
     && pip3 install requests \
     && pip3 install firecloud \
     && pip3 install terra-notebook-utils==0.13.0 \

--- a/terra-jupyter-bioconductor/CHANGELOG.md
+++ b/terra-jupyter-bioconductor/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.2.3 - 2023-10-03
+- Update `terra-jupyter-r` to `2.2.3`
+    - Update `terra-jupyter-base` to `1.1.3`
+      - Downgrade notebook to `6.5.4` and jupyterlab-server to `2.23.0`
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:2.2.3`
+
 ## 2.2.2 - 2023-07-31
 - Update `terra-jupyter-r` to `2.2.2`
   - Update `terra-jupyter-base` to `1.1.2`

--- a/terra-jupyter-bioconductor/Dockerfile
+++ b/terra-jupyter-bioconductor/Dockerfile
@@ -1,1 +1,1 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.2.2
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.2.3

--- a/terra-jupyter-gatk/CHANGELOG.md
+++ b/terra-jupyter-gatk/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2.3.3 - 2023-10-03
+- Update `terra-jupyter-r` to `2.2.3`
+- Update `terra-jupyter-python` to `1.1.3`
+  - Update `terra-jupyter-base` to `1.1.3`
+    - Downgrade notebook to `6.5.4` and jupyterlab-server to `2.23.0`
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.3.3`
+
 ## 2.3.2 - 2023-07-31
 - Update `terra-jupyter-python` to `1.1.2`
   - Update `terra-jupyter-base` tp `1.1.2`

--- a/terra-jupyter-gatk/Dockerfile
+++ b/terra-jupyter-gatk/Dockerfile
@@ -1,6 +1,6 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.1.2 AS python
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.1.3 AS python
 
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.2.2
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.2.3
 
 USER root
 

--- a/terra-jupyter-hail/CHANGELOG.md
+++ b/terra-jupyter-hail/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.1.3 - 2023-10-03
+- Update `terra-jupyter-python` to `1.1.3`
+  - Update `terra-jupyter-base` to `1.1.3`
+    - Downgrade notebook to `6.5.4` and jupyterlab-server to `2.23.0`
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-hail:1.1.3`
+
 ## 1.1.2 - 2023-07-31
 - Update `terra-jupyter-python` to `1.1.2`
   - Update `terra-jupyter-base` to `1.1.2`

--- a/terra-jupyter-hail/Dockerfile
+++ b/terra-jupyter-hail/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.1.2
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.1.3
 
 USER root
 

--- a/terra-jupyter-python/CHANGELOG.md
+++ b/terra-jupyter-python/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.1.3 - 2023-10-03
+- Update `terra-jupyter-base` to `1.1.3`
+   - Downgrade notebook to `6.5.4` and jupyterlab-server to `2.23.0`
+    
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.1.3`
+
 ## 1.1.2 - 2023-07-31
 - Update `terra-jupyter-base` to `1.1.2`
   - Upgrade Terra Notebook Utils to `0.13.0`

--- a/terra-jupyter-python/Dockerfile
+++ b/terra-jupyter-python/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.1.2
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.1.3
 
 USER root
 # This makes it so pip runs as root, not the user.

--- a/terra-jupyter-r/CHANGELOG.md
+++ b/terra-jupyter-r/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.1.3 - 2023-10-03
+- Update `terra-jupyter-base` to `1.1.3`
+   - Downgrade notebook to `6.5.4` and jupyterlab-server to `2.23.0`
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.2.3`
+
 ## 2.2.2 - 2023-07-31
 - Update `terra-jupyter-base` to `1.1.2`
   - Upgrade Terra Notebook Utils to `0.13.0`

--- a/terra-jupyter-r/Dockerfile
+++ b/terra-jupyter-r/Dockerfile
@@ -1,11 +1,11 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.1.2
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.1.3
 
 USER root
 
 COPY scripts $JUPYTER_HOME/scripts
 
 # Add env vars to identify binary package installation
-ENV TERRA_R_PLATFORM="terra-jupyter-r-1.1.2"
+ENV TERRA_R_PLATFORM="terra-jupyter-r-1.1.3"
 ENV TERRA_R_PLATFORM_BINARY_VERSION=3.17
 
 # Install protobuf 3.20.3. Note this version comes from base deep learning image. Use `conda list` to see what's installed


### PR DESCRIPTION
The previous set of images had a version of jupyter notebook and server that seemed to be incompatible (it was boud to happen without pinning dependencies), this should hopefully fix the issue 🤞 

Leo PR: https://github.com/DataBiosphere/leonardo/pull/3797

Note:
- The test failure for the bioconductor image is expected (the thing is too big and times out)
- I have tested all images on my BEE and things are working well