### PR TITLE
Add BiocRStudio 3.18 to dropdown

### DIFF
--- a/config/community_images.json
+++ b/config/community_images.json
@@ -10,21 +10,21 @@
 },
 {
     "id": "RStudio",
-    "label": "RStudio (R 4.3.1, Bioconductor 3.17, Python 3.10.12)",
-    "version": "3.17.1",
-    "updated": "2023-09-13",
-    "packages": "https://raw.githubusercontent.com/anvilproject/anvil-docker/main/anvil-rstudio-bioconductor/info/anvil-rstudio-bioconductor-3.17.1-versions.json",
-    "image": "us.gcr.io/broad-dsp-gcr-public/anvil-rstudio-bioconductor:3.17.1",
+    "label": "RStudio (R 4.3.2, Bioconductor 3.18, Python 3.10.12)",
+    "version": "3.18.0",
+    "updated": "2023-11-07",
+    "packages": "https://raw.githubusercontent.com/anvilproject/anvil-docker/main/anvil-rstudio-bioconductor/info/anvil-rstudio-bioconductor-3.18.0-versions.json",
+    "image": "us.gcr.io/broad-dsp-gcr-public/anvil-rstudio-bioconductor:3.18.0",
     "requiresSpark": false,
     "isRStudio": true
 },
 {
     "id": "LegacyRStudio",
-    "label": "Legacy RStudio (R 4.2.3, Bioconductor 3.16, Python 3.10.6)",
-    "version": "3.16.1",
-    "updated": "2023-05-12",
-    "packages": "https://raw.githubusercontent.com/anvilproject/anvil-docker/main/anvil-rstudio-bioconductor/info/anvil-rstudio-bioconductor-3.16.1-versions.json",
-    "image": "us.gcr.io/broad-dsp-gcr-public/anvil-rstudio-bioconductor:3.16.1",
+    "label": "RStudio (R 4.3.1, Bioconductor 3.17, Python 3.10.12)",
+    "version": "3.17.1",
+    "updated": "2023-09-13",
+    "packages": "https://raw.githubusercontent.com/anvilproject/anvil-docker/main/anvil-rstudio-bioconductor/info/anvil-rstudio-bioconductor-3.17.1-versions.json",
+    "image": "us.gcr.io/broad-dsp-gcr-public/anvil-rstudio-bioconductor:3.17.1",
     "requiresSpark": false,
     "isRStudio": true
 }]


### PR DESCRIPTION
Notable changes:
- R 4.3.2
- Bioc 3.18
- Pinning torch to latest version compatible with current CUDA driver in the container