### PR TITLE
Add "--enable-gcs" to samtools and bcftools tool builds

### DIFF
--- a/terra-jupyter-gatk/Dockerfile
+++ b/terra-jupyter-gatk/Dockerfile
@@ -55,6 +55,7 @@ RUN mkdir -p /tmp/samtools && \
     bzip2 -d samtools.tar.bz2 && \
     tar xvf samtools.tar && \
     cd samtools-1.18 && \
+    ./configure --enable-gcs && \
     make && \
     make install && \
     cd $HOME && \
@@ -67,6 +68,7 @@ RUN mkdir -p /tmp/bcftools && \
     bzip2 -d bcftools.tar.bz2 && \
     tar xvf bcftools.tar && \
     cd bcftools-1.18 && \
+    ./configure --enable-gcs && \
     make && \
     make install && \
     cd $HOME && \


### PR DESCRIPTION
This change enables network access to Google Cloud Storage buckets for the samtools and bcftools command line tools.  The upstream image (terra-jupyter-python) already has this flag enabled for htslib (which these tools use, though during install, they use their own htslib by default).