### PR TITLE
Update Jupyter and RStudio for 3.19 release

### DIFF
--- a/config/community_images.json
+++ b/config/community_images.json
@@ -10,21 +10,21 @@
 },
 {
     "id": "RStudio",
-    "label": "RStudio (R 4.3.2, Bioconductor 3.18, Python 3.10.12)",
-    "version": "3.18.0",
-    "updated": "2023-11-07",
-    "packages": "https://raw.githubusercontent.com/anvilproject/anvil-docker/main/anvil-rstudio-bioconductor/info/anvil-rstudio-bioconductor-3.18.0-versions.json",
-    "image": "us.gcr.io/broad-dsp-gcr-public/anvil-rstudio-bioconductor:3.18.0",
+    "label": "RStudio (R 4.4.0, Bioconductor 3.19, Python 3.10.12)",
+    "version": "3.19.0",
+    "updated": "2024-05-13",
+    "packages": "https://raw.githubusercontent.com/anvilproject/anvil-docker/main/anvil-rstudio-bioconductor/info/anvil-rstudio-bioconductor-3.19.0-versions.json",
+    "image": "us.gcr.io/broad-dsp-gcr-public/anvil-rstudio-bioconductor:3.19.0",
     "requiresSpark": false,
     "isRStudio": true
 },
 {
     "id": "LegacyRStudio",
-    "label": "RStudio (R 4.3.1, Bioconductor 3.17, Python 3.10.12)",
-    "version": "3.17.1",
-    "updated": "2023-09-13",
-    "packages": "https://raw.githubusercontent.com/anvilproject/anvil-docker/main/anvil-rstudio-bioconductor/info/anvil-rstudio-bioconductor-3.17.1-versions.json",
-    "image": "us.gcr.io/broad-dsp-gcr-public/anvil-rstudio-bioconductor:3.17.1",
+    "label": "RStudio (R 4.3.3, Bioconductor 3.18, Python 3.10.12)",
+    "version": "3.18.1",
+    "updated": "2024-05-13",
+    "packages": "https://raw.githubusercontent.com/anvilproject/anvil-docker/main/anvil-rstudio-bioconductor/info/anvil-rstudio-bioconductor-3.18.1-versions.json",
+    "image": "us.gcr.io/broad-dsp-gcr-public/anvil-rstudio-bioconductor:3.18.1",
     "requiresSpark": false,
     "isRStudio": true
 }]

--- a/config/conf.json
+++ b/config/conf.json
@@ -26,7 +26,7 @@
                     "tidyverse"
                 ]
             },
-            "version" : "2.2.4",
+            "version" : "2.2.5",
             "automated_flags" : {
                 "generate_docs" : true,
                 "include_in_ui" : true,
@@ -83,7 +83,9 @@
             "tools" : [
                 "python"
             ],
-            "packages" : {},
+            "packages" : {
+                
+            },
             "version" : "1.1.3",
             "automated_flags" : {
                 "generate_docs" : true,
@@ -99,8 +101,10 @@
             "tools" : [
                 "r"
             ],
-            "packages" : {},
-            "version" : "2.2.4",
+            "packages" : {
+                
+            },
+            "version" : "2.2.5",
             "automated_flags" : {
                 "include_in_ui" : false,
                 "generate_docs" : true,
@@ -117,8 +121,10 @@
                 "python",
                 "r"
             ],
-            "packages" : {},
-            "version" : "2.3.6",
+            "packages" : {
+                
+            },
+            "version" : "2.3.7",
             "automated_flags" : {
                 "include_in_ui" : true,
                 "generate_docs" : true,
@@ -134,8 +140,10 @@
                 "python",
                 "r"
             ],
-            "packages" : {},
-            "version" : "2.2.11",
+            "packages" : {
+                
+            },
+            "version" : "2.2.12",
             "automated_flags" : {
                 "include_in_ui" : false,
                 "generate_docs" : false,
@@ -150,7 +158,9 @@
             "tools" : [
                 "r"
             ],
-            "packages" : {},
+            "packages" : {
+                
+            },
             "version" : "0.1.1",
             "automated_flags" : {
                 "include_in_ui" : false,
@@ -163,8 +173,11 @@
         {
             "name" : "wondershaper",
             "base_label" : "wondershaper",
-            "tools" : [],
-            "packages" : {},
+            "tools" : [
+            ],
+            "packages" : {
+                
+            },
             "version" : "0.0.1",
             "automated_flags" : {
                 "include_in_ui" : false,

--- a/terra-jupyter-aou/CHANGELOG.md
+++ b/terra-jupyter-aou/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.2.12 - 2024-05-15T15:36:28.616710060Z
+
+- Update `terra-jupyter-r` to `2.2.5`
+  - Update for R 4.4.0 and Bioc 3.19
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:2.2.12`
+
 ## 2.2.11 - 2024-04-10
 - Update `hail` to `0.2.130`
   - See https://hail.is/docs/0.2/change_log.html#version-0-2-130) for details

--- a/terra-jupyter-aou/Dockerfile
+++ b/terra-jupyter-aou/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.3.6
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.3.7
 
 USER root
 

--- a/terra-jupyter-bioconductor/CHANGELOG.md
+++ b/terra-jupyter-bioconductor/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.2.5 - 2024-05-15T15:36:28.576892790Z
+
+- Update `terra-jupyter-r` to `2.2.5`
+  - Update for R 4.4.0 and Bioc 3.19
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:2.2.5`
+
 ## 2.2.4 - 2023-11-14T15:56:44.470211534Z
 
 - Update `terra-jupyter-r` to `2.2.4`

--- a/terra-jupyter-bioconductor/Dockerfile
+++ b/terra-jupyter-bioconductor/Dockerfile
@@ -1,1 +1,1 @@
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.2.4
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.2.5

--- a/terra-jupyter-gatk/CHANGELOG.md
+++ b/terra-jupyter-gatk/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.3.7 - 2024-05-15T15:36:28.602743427Z
+
+- Update `terra-jupyter-r` to `2.2.5`
+  - Update for R 4.4.0 and Bioc 3.19
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.3.7`
+
 ## 2.3.6 - 2023-11-27
 
 - Update Samtools to `1.18`

--- a/terra-jupyter-gatk/Dockerfile
+++ b/terra-jupyter-gatk/Dockerfile
@@ -1,6 +1,6 @@
 FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.1.5 AS python
 
-FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.2.4
+FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.2.5
 
 USER root
 

--- a/terra-jupyter-gatk/Dockerfile
+++ b/terra-jupyter-gatk/Dockerfile
@@ -91,8 +91,8 @@ COPY cnn-models.patch /etc/gatk-$GATK_VERSION/cnn-models.patch
 RUN patch -u /opt/conda/lib/python3.10/site-packages/vqsr_cnn/vqsr_cnn/models.py -i /etc/gatk-$GATK_VERSION/cnn-models.patch
 
 # Older version of nbconvert fail to convert notebooks to html
-RUN pip3 install "nbconvert>=7.7.3" \
-    && pip3 install --force-reinstall "python-dateutil"
+RUN pip3 install --force-reinstall "python-dateutil" \
+    && pip3 install "nbconvert>=7.7.3"
 
 
 ENV PIP_USER=true

--- a/terra-jupyter-gatk/Dockerfile
+++ b/terra-jupyter-gatk/Dockerfile
@@ -91,7 +91,7 @@ COPY cnn-models.patch /etc/gatk-$GATK_VERSION/cnn-models.patch
 RUN patch -u /opt/conda/lib/python3.10/site-packages/vqsr_cnn/vqsr_cnn/models.py -i /etc/gatk-$GATK_VERSION/cnn-models.patch
 
 # Older version of nbconvert fail to convert notebooks to html
-RUN pip3 install --force-reinstall --no-deps python-dateutil==2.8.2 \
+RUN pip3 install --ignore-installed python-dateutil==2.8.2 \
     && pip3 install "nbconvert>=7.7.3"
 
 
@@ -100,5 +100,3 @@ ENV PIP_USER=true
 ENV USER jupyter
 
 USER $USER
-
-

--- a/terra-jupyter-gatk/Dockerfile
+++ b/terra-jupyter-gatk/Dockerfile
@@ -90,6 +90,11 @@ COPY cnn-models.patch /etc/gatk-$GATK_VERSION/cnn-models.patch
 
 RUN patch -u /opt/conda/lib/python3.10/site-packages/vqsr_cnn/vqsr_cnn/models.py -i /etc/gatk-$GATK_VERSION/cnn-models.patch
 
+# Older version of nbconvert fail to convert notebooks to html
+RUN pip3 install "nbconvert>=7.7.3" \
+    && pip3 install --force-reinstall "python-dateutil"
+
+
 ENV PIP_USER=true
 
 ENV USER jupyter

--- a/terra-jupyter-gatk/Dockerfile
+++ b/terra-jupyter-gatk/Dockerfile
@@ -91,7 +91,7 @@ COPY cnn-models.patch /etc/gatk-$GATK_VERSION/cnn-models.patch
 RUN patch -u /opt/conda/lib/python3.10/site-packages/vqsr_cnn/vqsr_cnn/models.py -i /etc/gatk-$GATK_VERSION/cnn-models.patch
 
 # Older version of nbconvert fail to convert notebooks to html
-RUN pip3 install --force-reinstall "python-dateutil" \
+RUN pip3 install --force-reinstall --no-deps python-dateutil==2.8.2 \
     && pip3 install "nbconvert>=7.7.3"
 
 

--- a/terra-jupyter-gatk/Dockerfile
+++ b/terra-jupyter-gatk/Dockerfile
@@ -90,10 +90,6 @@ COPY cnn-models.patch /etc/gatk-$GATK_VERSION/cnn-models.patch
 
 RUN patch -u /opt/conda/lib/python3.10/site-packages/vqsr_cnn/vqsr_cnn/models.py -i /etc/gatk-$GATK_VERSION/cnn-models.patch
 
-# Older version of nbconvert fail to convert notebooks to html
-RUN pip3 install "nbconvert>=7.7.3"
-
-
 ENV PIP_USER=true
 
 ENV USER jupyter

--- a/terra-jupyter-gatk/Dockerfile
+++ b/terra-jupyter-gatk/Dockerfile
@@ -90,9 +90,9 @@ COPY cnn-models.patch /etc/gatk-$GATK_VERSION/cnn-models.patch
 
 RUN patch -u /opt/conda/lib/python3.10/site-packages/vqsr_cnn/vqsr_cnn/models.py -i /etc/gatk-$GATK_VERSION/cnn-models.patch
 
-# Older version of nbconvert fail to convert notebooks to html
+# Newer version of nbconvert fail to convert notebooks to html
 RUN pip3 install --ignore-installed python-dateutil==2.8.2 \
-    && pip3 install "nbconvert>=7.7.3"
+    && pip3 install "nbconvert==7.11.0"
 
 
 ENV PIP_USER=true

--- a/terra-jupyter-r/CHANGELOG.md
+++ b/terra-jupyter-r/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.2.5 - 2024-05-15T15:36:28.555690376Z
+
+- Update for R 4.4.0 and Bioc 3.19
+
+Image URL: `us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.2.5`
+
 ## 2.2.4 - 2023-11-14T15:56:44.443656567Z
 
 - Bioconductor 3.18 release

--- a/terra-jupyter-r/Dockerfile
+++ b/terra-jupyter-r/Dockerfile
@@ -6,7 +6,7 @@ COPY scripts $JUPYTER_HOME/scripts
 
 # Add env vars to identify binary package installation
 ENV TERRA_R_PLATFORM="terra-jupyter-r-2.2.4"
-ENV TERRA_R_PLATFORM_BINARY_VERSION=3.18
+ENV TERRA_R_PLATFORM_BINARY_VERSION=3.19
 
 # Install protobuf 3.20.3. Note this version comes from base deep learning image. Use `conda list` to see what's installed
 RUN cd /tmp \
@@ -132,7 +132,7 @@ RUN pip3 -V \
 
 RUN R -e 'install.packages("BiocManager")' \
     ## check version
-    && R -e 'BiocManager::install(version="3.18", ask=FALSE)' \
+    && R -e 'BiocManager::install(version="3.19", ask=FALSE)' \
     && R -e 'BiocManager::install(c( \
     "boot", \
     "class", \

--- a/terra-jupyter-r/Dockerfile
+++ b/terra-jupyter-r/Dockerfile
@@ -5,7 +5,7 @@ USER root
 COPY scripts $JUPYTER_HOME/scripts
 
 # Add env vars to identify binary package installation
-ENV TERRA_R_PLATFORM="terra-jupyter-r-2.2.4"
+ENV TERRA_R_PLATFORM="terra-jupyter-r-2.2.5"
 ENV TERRA_R_PLATFORM_BINARY_VERSION=3.19
 
 # Install protobuf 3.20.3. Note this version comes from base deep learning image. Use `conda list` to see what's installed


### PR DESCRIPTION
- Added Bioc 3.19 with R 4.4.0 for latest release.
- Added Bioc 3.18 and R 4.3.3 for RStudio legacy.
- Updated versions for Jupyter Dockerfile and used provided ammonite script to make version bumps.