### PR TITLE
[AN-304] Do not rename images id as Terra UI depends on it

### DIFF
--- a/config/community_images.json
+++ b/config/community_images.json
@@ -9,7 +9,7 @@
     "isCommunity": true
 },
 {
-    "id": "Rstudio",
+    "id": "RStudio",
     "label": "RStudio (R 4.4.2, Bioconductor 3.20, Python 3.12.3)",
     "version": "3.20.0",
     "updated": "2024-11-20",


### PR DESCRIPTION
All of our UI integration tests failed after we merged in the new bioconductor image because `RStudio` was changed to `Rstudio`, I definitely missed this during review. This is a very brittle process that we should refactor, but for now, reverting this little change (dev, staging, and prod have been manually fixed).