### PR TITLE
Add 3.20.1 RStudio image

### DIFF
--- a/config/community_images.json
+++ b/config/community_images.json
@@ -11,10 +11,10 @@
 {
     "id": "RStudio",
     "label": "RStudio (R 4.4.2, Bioconductor 3.20, Python 3.12.3)",
-    "version": "3.20.0",
-    "updated": "2024-11-20",
-    "packages": "https://raw.githubusercontent.com/anvilproject/anvil-docker/main/anvil-rstudio-bioconductor/info/anvil-rstudio-bioconductor-3.20.0-versions.json",
-    "image": "us.gcr.io/broad-dsp-gcr-public/anvil-rstudio-bioconductor:3.20.0",
+    "version": "3.20.1",
+    "updated": "2024-12-12",
+    "packages": "https://raw.githubusercontent.com/anvilproject/anvil-docker/main/anvil-rstudio-bioconductor/info/anvil-rstudio-bioconductor-3.20.1-versions.json",
+    "image": "us.gcr.io/broad-dsp-gcr-public/anvil-rstudio-bioconductor:3.20.1",
     "requiresSpark": false,
     "isRStudio": true
 },


### PR DESCRIPTION
Full conversation in Slack.
Summary: `rstudio` user started using new uid, causing problems when re-attaching old disks after a version upgrade in Terra. This forces `rstudio` user to share the same uid. A side effect is that ownership might appear as `ubuntu` instead of `rstudio` within the container, as both users share the uid