### PR TITLE
[AN-332] Specify Legacy in Legacy Rstudio label

### DIFF
--- a/config/community_images.json
+++ b/config/community_images.json
@@ -20,7 +20,7 @@
 },
 {
     "id": "LegacyRStudio",
-    "label": "RStudio (R 4.4.1, Bioconductor 3.19, Python 3.10.12)",
+    "label": "Legacy RStudio (R 4.4.1, Bioconductor 3.19, Python 3.10.12)",
     "version": "3.19.1",
     "updated": "2024-06-27",
     "packages": "https://raw.githubusercontent.com/anvilproject/anvil-docker/main/anvil-rstudio-bioconductor/info/anvil-rstudio-bioconductor-3.19.1-versions.json",


### PR DESCRIPTION
JIRA ticket: https://broadworkbench.atlassian.net/browse/AN-332

When working on the [Terra UI PR](https://github.com/DataBiosphere/terra-ui/pull/5217), I realized that the labeling of the legacy image was not obvious, and so making it explicit here.