### PR TITLE
[CTM-142] Fix generate version docs to allow new images

### DIFF
--- a/scripts/generate_package_docs.py
+++ b/scripts/generate_package_docs.py
@@ -102,7 +102,7 @@ class ParamProcessor():
 
   def __init__(self, params):
     if not len(params) == 2:
-      raise ValueError("Usage: python generate_package_docs.py [STRING: image_dir], given: " + params)
+      raise ValueError(f"Usage: python generate_package_docs.py [STRING: image_dir], given: {params}")
 
     self.image_dir = argv[1]
 

--- a/scripts/generate_version_docs.py
+++ b/scripts/generate_version_docs.py
@@ -35,9 +35,8 @@ def generate_docs():
   for image_config in image_configs:
       # Here we check first if the remote documentation exists, then if the local version is the same as the remote.
       # If the remote documentation exists and the version matches the local, we re-use the old documentation
-
-      remote_doc = list(filter(lambda image_doc: image_doc["id"] == image_config["name"], remote_docs))[0]
       if image_config["name"] in remote_versions and image_config["version"] == remote_versions[image_config["name"]]:
+        remote_doc = list(filter(lambda image_doc: image_doc["id"] == image_config["name"], remote_docs))[0]
         print("using remote doc: {}".format(remote_doc))
         doc = remote_doc
       else:

--- a/updateVersions.sc
+++ b/updateVersions.sc
@@ -99,6 +99,9 @@ def main(updatedImage: String, updatedImageReleaseNote: String, bumpMajorVersion
     case "terra-jupyter-aou" => List(
       "terra-jupyter-aou"
     )
+    case "terra-base" => List(
+      "terra-base"
+    )
     case updatedImage =>
       throw new Exception(s"${updatedImage} is not supported yet. Please update the script to support the image")
   }


### PR DESCRIPTION
When adding a new docker image the generate docs process fails because no version file exists yet, moved some things around and added terra-base to the generate docs list