### PR TITLE
feature: add RStudio Server installation and configuration

### DIFF
--- a/terra-jupyter-bioconductor/Dockerfile
+++ b/terra-jupyter-bioconductor/Dockerfile
@@ -1,1 +1,59 @@
 FROM us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.2.7
+
+USER root
+SHELL ["/usr/bin/bash", "-o", "pipefail", "-c"]
+ENV DEBIAN_FRONTEND=noninteractive
+
+ENV RSTUDIO_PORT=8001
+ENV RSTUDIO_HOME=/etc/rstudio
+ENV RSTUDIO_USERSETTING=/home/rstudio/.config/rstudio/rstudio-prefs.json
+
+ARG RSTUDIO_VERSION=""
+## 1) Install dependencies
+RUN apt-get update && apt-get install -yq --no-install-recommends \
+    file git \
+    libapparmor1 \
+    libcurl4-openssl-dev \
+    libedit2 \
+    libssl-dev \
+    lsb-release \
+    psmisc \
+    procps \
+    sudo \
+    wget \
+    libclang-dev \
+    libpq5 \
+    && \
+    ## 2) Install RStudio Server for Ubuntu 22.04 (Jammy)
+    if [[ -z "${RSTUDIO_VERSION}" ]]; then \
+      RSTUDIO_URL="https://rstudio.org/download/latest/stable/server/jammy/rstudio-server-latest-amd64.deb"; \
+    else \
+      RSTUDIO_URL="https://download2.rstudio.org/server/jammy/amd64/rstudio-server-${RSTUDIO_VERSION}-amd64.deb"; \
+    fi; \
+    wget -qO /tmp/rstudio.deb "${RSTUDIO_URL}" && \
+    ## use apt-get install to handle deps
+    apt-get install -yq /tmp/rstudio.deb && \
+    ## 3) Terra-friendly rstudio user
+    if ! id -u rstudio >/dev/null 2>&1; then \
+      useradd -m -s /bin/bash -N --non-unique -u 1002 rstudio; \
+    fi && \
+    usermod -g users rstudio && \
+    mkdir -p /home/rstudio/.config/rstudio ${RSTUDIO_HOME} /etc/rstudio && \
+    echo 'lock-type=advisory' >> /etc/rstudio/file-locks && \
+    ## Grant passwordless sudo
+    echo "jupyter ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/90-jupyter-user && \
+    echo "rstudio ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/90-rstudio-user && \
+    ## CLEANUP: Remove everything no longer needed
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+## 4) Copy config files
+COPY rserver.conf ${RSTUDIO_HOME}/rserver.conf
+COPY rstudio-prefs.json ${RSTUDIO_USERSETTING}
+
+RUN chown -R rstudio:users /home/rstudio && \
+    chown rstudio:users ${RSTUDIO_USERSETTING}
+
+EXPOSE 8001
+USER jupyter
+

--- a/terra-jupyter-bioconductor/rserver.conf
+++ b/terra-jupyter-bioconductor/rserver.conf
@@ -1,0 +1,7 @@
+# Server Configuration File
+# See https://support.rstudio.com/hc/en-us/articles/200552316-Configuring-the-Server
+
+rsession-which-r=/usr/bin/R
+auth-none=1
+www-port=8001
+www-address=0.0.0.0

--- a/terra-jupyter-bioconductor/rstudio-prefs.json
+++ b/terra-jupyter-bioconductor/rstudio-prefs.json
@@ -1,0 +1,6 @@
+{
+    "save_workspace": "always",
+    "always_save_history": true,
+    "reuse_sessions_for_project_links": true,
+    "posix_terminal_shell": "bash"
+}

--- a/terra-jupyter-bioconductor/scripts/run-rstudio.sh
+++ b/terra-jupyter-bioconductor/scripts/run-rstudio.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PORT="${RSTUDIO_PORT:-8001}"
+
+exec /usr/lib/rstudio-server/bin/rserver \
+  --server-daemonize=0 \
+  --www-port="${PORT}" \
+  --auth-none=1 \
+  --server-app-armor-enabled=0
+


### PR DESCRIPTION
- Install RStudio Server (Jammy) and required dependencies (psmisc, libclang-dev, etc.).
- Configure `rserver.conf` to allow non-authenticated access on port 8001.
- Set up a Terra-friendly `rstudio` user and establish default IDE preferences via `rstudio-prefs.json`.
- Grant passwordless sudo privileges to both `jupyter` and `rstudio` users.
- Add `scripts/run-rstudio.sh` to handle server startup within the container.
- Optimize Docker image size by consolidating installation and cleanup into a single layer.
