### PR TITLE
CTM-575 Self-hosted runner diagnostics

### DIFF
--- a/.github/workflows/runner-diagnostics.yml
+++ b/.github/workflows/runner-diagnostics.yml
@@ -1,0 +1,33 @@
+name: Runner diagnostics
+# Manually-triggered probe of the self-hosted runner's hardware, OS, and Docker daemon. Runs in seconds.
+
+on:
+  workflow_dispatch:
+
+jobs:
+
+  probe:
+    runs-on: self-hosted
+
+    steps:
+    - name: Operating system
+      run: |
+        cat /etc/os-release
+
+    - name: CPU and memory
+      run: |
+        cat /proc/cpuinfo
+        echo "--------------------------------------------------------"
+        cat /proc/meminfo
+
+    - name: Docker daemon info
+      run: |
+        docker version
+        echo "--------------------------------------------------------"
+        docker info
+
+    - name: Disk layout
+      run: |
+        df -h
+        echo "--------------------------------------------------------"
+        docker system df || true

--- a/.github/workflows/runner-diagnostics.yml
+++ b/.github/workflows/runner-diagnostics.yml
@@ -30,4 +30,4 @@ jobs:
       run: |
         df -h
         echo "--------------------------------------------------------"
-        docker system df || true
+        docker system df


### PR DESCRIPTION
It should not take 3 hours to build a Docker image, as seen in https://github.com/DataBiosphere/terra-docker/pull/522

I suspect there is something really inefficient going on with the self-hosted runner, such as a misconfigured Docker daemon or insufficient hardware resources.

For security, Github enforces that new Actions must be checked in to the main branch in order to run them. So I do have to merge this PR to perform the diagnosis.